### PR TITLE
[2731] Test setup

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,3 +13,7 @@ AllCops:
 
 Rails/HasManyOrHasOneDependent:
   Enabled: false
+
+Style/ClassVars:
+  Exclude:
+    - 'spec/support/test_setup.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,3 @@ AllCops:
 Rails/HasManyOrHasOneDependent:
   Enabled: false
 
-Style/ClassVars:
-  Exclude:
-    - 'spec/support/test_setup.rb'

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -40,7 +40,7 @@ FactoryBot.define do
     qualification { :pgce_with_qts }
     with_apprenticeship
 
-    provider
+    provider { find_or_create(:provider) }
 
     study_mode { :full_time }
     maths { :must_have_qualification_at_application_time }
@@ -125,11 +125,6 @@ FactoryBot.define do
       # We've just created a course with this provider's code, so ensure it's
       # up-to-date and has this course loaded.
       course.provider.reload
-
-      # Make sure this Course and and Sites are associated with the same Provider
-      if course.site_statuses.any?
-        course.site_statuses.first.site.provider = course.provider
-      end
     end
 
     trait :infer_level do
@@ -217,14 +212,17 @@ FactoryBot.define do
 
     trait :unpublished_with_primary_maths do
       transient do
-        identifier { "unpublished_with_primary_mathematics" }
+        identifier { "unpublished_with_primary_maths" }
       end
 
-      name { "#{identifier} course" }
+      name { "#{identifier} course name" }
 
       provider { find_or_create :provider, :published_scitt }
-      site_statuses { [build(:site_status, :new)] }
-      enrichments { [build(:course_enrichment, :initial_draft)] }
+      sites { build_list(:site, 1, provider: provider) }
+    end
+
+    trait :draft_enrichment do
+      enrichments { [build(:course_enrichment, :initial_draft, course: nil)] }
     end
   end
 end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -125,6 +125,11 @@ FactoryBot.define do
       # We've just created a course with this provider's code, so ensure it's
       # up-to-date and has this course loaded.
       course.provider.reload
+
+      # Make sure this Course and and Sites are associated with the same Provider
+      if course.site_statuses.any?
+        course.site_statuses.first.site.provider = course.provider
+      end
     end
 
     trait :infer_level do
@@ -208,6 +213,18 @@ FactoryBot.define do
 
     trait :skip_validate do
       to_create { |instance| instance.save(validate: false) }
+    end
+
+    trait :unpublished_with_primary_maths do
+      transient do
+        identifier { "unpublished_with_primary_mathematics" }
+      end
+
+      name { "#{identifier} course" }
+
+      provider { find_or_create :provider, :published_scitt }
+      site_statuses { [build(:site_status, :new)] }
+      enrichments { [build(:course_enrichment, :initial_draft)] }
     end
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
     sequence(:org_id)
 
     trait :with_user do
-      users { [find_or_create(:user)] }
+      users { [create(:user)] }
     end
   end
 end

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
   factory :organisation do
     name { "LONDON SCITT" + rand(1000000).to_s }
     sequence(:org_id)
+
+    trait :with_user do
+      users { [find_or_create(:user)] }
+    end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -53,7 +53,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     accrediting_provider { "N" }
     region_code { "london" }
-    organisations { build_list :organisation, 1 }
+    organisations { [find_or_create(:organisation, :with_user)] }
     association :recruitment_cycle, strategy: :find_or_create
 
     train_with_us { Faker::Lorem.sentence.to_s }
@@ -89,6 +89,14 @@ FactoryBot.define do
 
     trait :previous_recruitment_cycle do
       recruitment_cycle { find_or_create :recruitment_cycle, :previous }
+    end
+
+    trait :published_scitt do
+      transient do
+        identifier { "published_scitt" }
+      end
+
+      provider_name { "#{identifier} provider" }
     end
   end
 end

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -96,7 +96,7 @@ FactoryBot.define do
         identifier { "published_scitt" }
       end
 
-      provider_name { "#{identifier} provider" }
+      provider_name { "#{identifier} provider name" }
     end
   end
 end

--- a/spec/factory_specs/course_spec.rb
+++ b/spec/factory_specs/course_spec.rb
@@ -30,4 +30,20 @@ describe "Course factory" do
       expect(CourseEnrichment.where("created_at < ?", 4.days.ago).count).to eq(1)
     end
   end
+
+  context "unpublished_with_primary_maths" do
+    subject { create(:course, :unpublished_with_primary_maths) }
+
+    its(:name) { should eq("unpublished_with_primary_maths course name") }
+
+    it "has the correct number of associations" do
+      expect { subject }.to change { Site.count }.by(1).and change { Provider.count }.by(1)
+    end
+
+    it "has the correct association" do
+      provider_id = subject.provider.id
+
+      expect(subject.sites.first.provider_id == provider_id)
+    end
+  end
 end

--- a/spec/factory_specs/providers_spec.rb
+++ b/spec/factory_specs/providers_spec.rb
@@ -1,10 +1,13 @@
 require "rails_helper"
 
 describe "Provider Factory" do
-  let(:provider) { create(:provider) }
+  subject { create(:provider) }
 
-  it "created provider" do
-    expect(provider).to be_instance_of(Provider)
-    expect(provider).to be_valid
+  it { should be_instance_of(Provider) }
+  it { should be_valid }
+
+  it "creates the correct number of associations" do
+    expect { subject }.to change { Organisation.count }.by(1).
+        and change { User.count }.by(1)
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -268,14 +268,10 @@ describe Provider, type: :model do
   end
 
   describe "courses" do
-    let(:provider) { create(:provider, courses: [course]) }
-    let(:course) { build(:course) }
+    let(:course) { TestSetup.unpub_pri_math }
+    let!(:provider) { course.provider }
 
     describe "#courses_count" do
-      before do
-        provider
-      end
-
       it "returns course count using courses.size" do
         allow(provider.courses).to receive(:size).and_return(1)
 
@@ -298,10 +294,8 @@ describe Provider, type: :model do
     end
 
     describe ".include_courses_counts" do
+      let(:courses) { [course] }
       let(:first_provider) { Provider.include_courses_counts.first }
-      before do
-        provider
-      end
 
       it "includes course counts" do
         expect(first_provider.courses_count).to eq(1)

--- a/spec/models/recruitment_cycle_spec.rb
+++ b/spec/models/recruitment_cycle_spec.rb
@@ -13,9 +13,12 @@
 require "rails_helper"
 
 describe RecruitmentCycle, type: :model do
-  subject { find_or_create :recruitment_cycle, year: "2019" }
+  let(:current_cycle) { TestSetup.current_cycle }
+  let(:next_cycle) { TestSetup.next_cycle }
 
-  its(:to_s) { should eq("2019/20") }
+  subject { current_cycle }
+
+  its(:to_s) { should eq("2020/21") }
 
   it "is valid with valid attributes" do
     expect(subject).to be_valid
@@ -44,23 +47,18 @@ describe RecruitmentCycle, type: :model do
   end
 
   describe "current?" do
-    let(:current_cycle) { find_or_create :recruitment_cycle }
-    let(:second_cycle) { find_or_create :recruitment_cycle, :next }
-
     it "should return true when it's the current cycle" do
       expect(current_cycle.current?).to be(true)
     end
 
     it "should return true false it's not the current cycle" do
-      expect(second_cycle.current?).to be(false)
+      expect(next_cycle.current?).to be(false)
     end
   end
 
   context "when there are multiple cycles" do
-    let(:current_cycle) { find_or_create :recruitment_cycle }
-    let!(:second_cycle) { find_or_create :recruitment_cycle, :next }
     let!(:third_cycle) do
-      find_or_create :recruitment_cycle, year: second_cycle.year.to_i + 1
+      find_or_create :recruitment_cycle, year: next_cycle.year.to_i + 1
     end
 
     describe ".current_recruitment_cycle" do
@@ -71,7 +69,7 @@ describe RecruitmentCycle, type: :model do
 
     describe ".next_recruitment_cycle" do
       it "returns the next cycle after the current one" do
-        expect(RecruitmentCycle.next_recruitment_cycle).to eq(second_cycle)
+        expect(RecruitmentCycle.next_recruitment_cycle).to eq(next_cycle)
       end
     end
 
@@ -111,7 +109,7 @@ describe RecruitmentCycle, type: :model do
       context "next_recruitment_cycle" do
         let(:provider) do
           build(:provider, sites: [site],
-                recruitment_cycle: second_cycle)
+                recruitment_cycle: next_cycle)
         end
 
         it "returns the empty" do
@@ -122,21 +120,18 @@ describe RecruitmentCycle, type: :model do
 
     describe "#next" do
       subject { current_cycle }
-      its(:next) { should eq(second_cycle) }
+      its(:next) { should eq(next_cycle) }
 
       it "is nil for the newest cycle" do
         expect(third_cycle.next).to be_nil
       end
 
       it "returns the next cycle along when there is one" do
-        expect(second_cycle.next).to eq(third_cycle)
+        expect(next_cycle.next).to eq(third_cycle)
       end
     end
 
     describe "next?" do
-      let(:current_cycle) { find_or_create :recruitment_cycle }
-      let(:next_cycle) { find_or_create :recruitment_cycle, :next }
-
       it "should return true when it's the next cycle" do
         expect(next_cycle.next?).to be(true)
       end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 describe Providers::CopyToRecruitmentCycleService do
   describe "#execute" do
     let(:site)   { build :site }
-    let(:course) { build :course }
+    let(:course) { create :course, provider: provider }
     let(:ucas_preferences) { build(:ucas_preferences, type_of_gt12: :coming_or_not) }
     let(:contacts) {
       [
@@ -16,7 +16,6 @@ describe Providers::CopyToRecruitmentCycleService do
     }
     let(:provider) {
       create :provider,
-             courses: [course],
              sites: [site],
              ucas_preferences: ucas_preferences,
              contacts: contacts
@@ -35,6 +34,10 @@ describe Providers::CopyToRecruitmentCycleService do
         copy_course_to_provider_service: mocked_copy_course_service,
         copy_site_to_provider_service: mocked_copy_site_service,
       )
+    end
+
+    before do
+      course
     end
 
     it "makes a copy of the provider in the new recruitment cycle" do

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -26,6 +26,11 @@ RSpec.configure do |config|
     SubjectCreatorService.new.execute
     SubjectFinancialIncentiveCreatorService.new.execute
     SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+
+    # Creating or finding course test data
+    if Settings.test_setup
+      TestSetup.new
+    end
   end
 
   config.before(:each, without_subjects: true) do

--- a/spec/support/test_setup.rb
+++ b/spec/support/test_setup.rb
@@ -1,0 +1,90 @@
+class TestSetup
+  # Class that instantiates standard set of test data for specs.
+
+  @@recruitment_cycles = {
+    current_cycle: -> { FactoryBot.find_or_create :recruitment_cycle },
+    next_cycle: -> { FactoryBot.find_or_create :recruitment_cycle, :next },
+  }
+
+  @@courses = {
+    unpublished_course_with_primary_maths: ->(attributes = {}) do
+      FactoryBot.find_or_create(:course, :unpublished_with_primary_maths, attributes)
+    end,
+    unpublished_course_with_no_location_or_enrichment: ->(attributes = {}) do
+      FactoryBot.find_or_create(:course, :unpublished_with_primary_maths, {
+        site_statuses: [],
+        enrichments: [],
+      }.merge(attributes))
+    end,
+    unpublished_course_with_draft_enrichment: ->(attributes = {}) do
+      FactoryBot.find_or_create(:course, :unpublished_with_primary_maths, attributes)
+    end,
+    unpublished_fee_type_based_course_with_invalid_enrichment: ->(attributes = {}) do
+      FactoryBot.find_or_create(:course, :fee_type_based, :unpublished_with_primary_maths, {
+        enrichments: [FactoryBot.build(:course_enrichment, :without_content)],
+      }.merge(attributes))
+    end,
+  }
+
+  # Used when not instantiating a TestSetup object in a before block.
+  # This will create a new fixture, using 'find_or_create' for teams and
+  # users and 'create' for cases. This is used to have a standardised set of
+  # recruitment cycles to work with, but without requiring
+  # pre-instantiation.
+
+  def self.method_missing(method_name, *args)
+    if @@recruitment_cycles&.key?(method_name)
+      @@recruitment_cycles[method_name].call
+    elsif @@courses&.key?(method_name)
+      @@courses[method_name].call
+    else
+      super
+    end
+  end
+
+  def self.respond_to_missing?(method_name, include_private = false)
+    @@recruitment_cycles&.key?(method_name) ||
+      @@courses&.key?(method_name) ||
+      super
+  end
+
+  attr_reader :courses, :recruitment_cycles
+
+  def initialize(with_courses: nil)
+    @recruitment_cycles = @@recruitment_cycles.transform_values(&:call)
+    @courses = @@courses.transform_values(&:call)
+
+    if with_courses.respond_to? :keys
+      @courses = @@courses.slice(*with_courses.keys)
+      with_courses.each do |name, attrs|
+        # instantiate course by calling the blocks in @@courses and passing in any
+        # attributes defined in only_courses for this course.
+        @courses[name] = @courses[name].call(attrs)
+      end
+    else
+      course_types = with_courses || @@courses.keys
+      @courses = Hash[
+        @@courses.slice(*course_types).map do |name, kourse|
+          # instantiate course by calling the blocks in @@courses
+          [name, kourse.call]
+        end
+      ]
+    end
+  end
+
+  def method_missing(method_name, *args)
+    if @recruitment_cycles&.key?(method_name)
+      @recruitment_cycles[method_name]
+    elsif @courses&.key?(method_name)
+      @courses[method_name]
+    else
+      super
+    end
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    @recruitment_cycles&.key?(method_name) ||
+      @courses&.key?(method_name) ||
+      super
+  end
+end


### PR DESCRIPTION
### Context

We recently undertook a spike on our test suite to identify opportunities for improve, particularly around decreasing the time it takes to run the tests.

This PR acts on one the recommendations and aims to create a standard test setup process. What this means is that each test will have access to standardised set of test data (with the ability to customise where required). This will remove a lot of the duplicated factories that are instantiated across all the tests and increase overall speed. 

This work is based on similar work undertaken for [Ministry Of Justice Correspondance Tool](https://github.com/ministryofjustice/correspondence_tool_staff/blob/master/spec/support/standard_setup.rb)

### Guidance to review

NB: This PR should be considered a 'first iteration'. Functionality has been added to create a limited set of test data. The TestSetup class has been wired up to two specs. Moving forwards we would need to decide how to migrate all specs over to the TestSetup process (possibly we could add a new PR checklist requirement and migrate as we go?)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
