### PR TITLE
mcb - Don't prompt for environment confirmation on qa/staging

### DIFF
--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -88,7 +88,7 @@ module MCB
                                          rgroup: rgroup,
                                          subscription: subscription)
 
-      unless %w(qa staging).include?(app_config["RAILS_ENV"])
+      unless require_confirmation
         print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
         expected_environment = $stdin.readline.chomp
 
@@ -104,5 +104,9 @@ module MCB
 
       app_config["RAILS_ENV"]
     end
+  end
+
+  def require_confirmation
+    %w(qa staging).include?(app_config["RAILS_ENV"])
   end
 end

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -89,7 +89,6 @@ module MCB
                                          subscription: subscription)
 
       unless %w(qa staging).include?(app_config["RAILS_ENV"])
-        # TODO: only require confirmation on commands that write to the db
         print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
         expected_environment = $stdin.readline.chomp
 

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -88,13 +88,15 @@ module MCB
                                          rgroup: rgroup,
                                          subscription: subscription)
 
-      # TODO: only require confirmation on commands that write to the db
-      print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
-      expected_environment = $stdin.readline.chomp
+      unless %w(qa staging).include?(app_config["RAILS_ENV"])
+        # TODO: only require confirmation on commands that write to the db
+        print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
+        expected_environment = $stdin.readline.chomp
 
-      if app_config["RAILS_ENV"] != expected_environment
-        raise "RAILS_ENV for #{webapp} does not match: " \
-              "#{app_config['RAILS_ENV']} != #{expected_environment}"
+        if app_config["RAILS_ENV"] != expected_environment
+          raise "RAILS_ENV for #{webapp} does not match: " \
+                "#{app_config['RAILS_ENV']} != #{expected_environment}"
+        end
       end
 
       MCB::Azure.configure_database(app_config)

--- a/lib/mcb/azure.rb
+++ b/lib/mcb/azure.rb
@@ -88,7 +88,7 @@ module MCB
                                          rgroup: rgroup,
                                          subscription: subscription)
 
-      unless require_confirmation
+      unless require_confirmation(app_config["RAILS_ENV"])
         print "As a safety measure, please enter the expected RAILS_ENV for #{webapp}: "
         expected_environment = $stdin.readline.chomp
 
@@ -104,9 +104,13 @@ module MCB
 
       app_config["RAILS_ENV"]
     end
-  end
 
-  def require_confirmation
-    %w(qa staging).include?(app_config["RAILS_ENV"])
+    class << self
+    private
+
+      def require_confirmation(rails_env)
+        %w(qa staging).include?(rails_env)
+      end
+    end
   end
 end


### PR DESCRIPTION
This has two benefits:

* Easier workflow for throw-away qa/staging data
* Makes it stand out much more when you do actually want production


### Context

Doing a lot of qa/staging stuff while building a new query before
running on prod.

### Changes proposed in this pull request

* Don't prompt for environment confirmation on qa/staging

### Guidance to review

Ignore whitespace to see a more meaningful diff

:ship:

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally