### PR TITLE
[2766] Add new course serializer for v3

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -14,7 +14,7 @@ module API
 
         if @course.is_published?
           # https://github.com/jsonapi-rb/jsonapi-rails/issues/113
-          render jsonapi: @course, fields: fields_param, include: params[:include], class: CourseSerializersService.new.execute
+          render jsonapi: @course, fields: fields_param, include: params[:include], class: CourseSerializersServiceV3.new.execute
         else
           raise ActiveRecord::RecordNotFound
         end

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -1,0 +1,66 @@
+module API
+  module V3
+    class SerializableCourse < JSONAPI::Serializable::Resource
+      class << self
+        def enrichment_attribute(name, enrichment_name = name)
+          attribute name do
+            @object.enrichments.select(&:published?).last&.__send__(enrichment_name)
+          end
+        end
+      end
+
+      type "courses"
+
+      attributes :findable?, :open_for_applications?, :has_vacancies?,
+                 :course_code, :name, :study_mode, :qualification, :description,
+                 :content_status, :ucas_status, :funding_type,
+                 :level, :is_send?, :english, :maths, :science, :gcse_subjects_required,
+                 :age_range_in_years, :accrediting_provider,
+                 :accrediting_provider_code, :level
+
+      attribute :start_date do
+        @object.start_date.strftime("%B %Y") if @object.start_date
+      end
+
+      attribute :applications_open_from do
+        @object.applications_open_from&.iso8601
+      end
+
+      attribute :last_published_at do
+        @object.last_published_at&.iso8601
+      end
+
+      attribute :about_accrediting_body do
+        @object.accrediting_provider_description
+      end
+
+      attribute :provider_code do
+        @object.provider.provider_code
+      end
+
+      attribute :recruitment_cycle_year do
+        @object.recruitment_cycle.year
+      end
+
+      belongs_to :provider
+      belongs_to :accrediting_provider
+
+      has_many :site_statuses
+      has_many :sites
+      has_many :subjects
+
+      enrichment_attribute :about_course
+      enrichment_attribute :course_length
+      enrichment_attribute :fee_details
+      enrichment_attribute :fee_international
+      enrichment_attribute :fee_uk_eu
+      enrichment_attribute :financial_support
+      enrichment_attribute :how_school_placements_work
+      enrichment_attribute :interview_process
+      enrichment_attribute :other_requirements
+      enrichment_attribute :personal_qualities
+      enrichment_attribute :required_qualifications
+      enrichment_attribute :salary_details
+    end
+  end
+end

--- a/app/services/course_serializers_service_v3.rb
+++ b/app/services/course_serializers_service_v3.rb
@@ -1,0 +1,43 @@
+class CourseSerializersServiceV3
+  def initialize(
+    course_serializer: API::V3::SerializableCourse,
+    subject_serializer: API::V2::SerializableSubject,
+    primary_subject_serializer: API::V2::SerializableSubject,
+    secondary_subject_serializer: API::V2::SerializableSubject,
+    modern_languages_subject_serializer: API::V2::SerializableSubject,
+    further_education_subject_serializer: API::V2::SerializableSubject,
+    site_status_serializer: API::V2::SerializableSiteStatus,
+    site_serializer: API::V2::SerializableSite,
+    provider_serializer: API::V2::SerializableProvider,
+    provider_enrichment_serializer: API::V2::SerializableProviderEnrichment,
+    recruitment_cycle_serializer: API::V2::SerializableRecruitmentCycle
+  )
+    @course_serializer = course_serializer
+    @subject_serializer = subject_serializer
+    @primary_subject_serializer = primary_subject_serializer
+    @secondary_subject_serializer = secondary_subject_serializer
+    @modern_languages_subject_serializer = modern_languages_subject_serializer
+    @further_education_subject_serializer = further_education_subject_serializer
+    @site_serializer = site_serializer
+    @site_status_serializer = site_status_serializer
+    @provider_serializer = provider_serializer
+    @provider_enrichment_serializer = provider_enrichment_serializer
+    @recruitment_cycle_serializer = recruitment_cycle_serializer
+  end
+
+  def execute
+    {
+      Course: @course_serializer,
+      Subject: @subject_serializer,
+      PrimarySubject: @primary_subject_serializer,
+      SecondarySubject: @secondary_subject_serializer,
+      ModernLanguagesSubject: @modern_languages_subject_serializer,
+      FurtherEducationSubject: @further_education_subject_serializer,
+      SiteStatus: @site_status_serializer,
+      Site: @site_serializer,
+      Provider: @provider_serializer,
+      ProviderEnrichment: @provider_enrichment_serializer,
+      RecruitmentCycle: @recruitment_cycle_serializer,
+    }
+  end
+end

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -19,7 +19,7 @@ describe "GET v3/providers/:provider_code/courses/:course_code" do
       JSONAPI::Serializable::Renderer.new.render(
         course,
         class: {
-          Course: API::V2::SerializableCourse,
+          Course: API::V3::SerializableCourse,
         },
       ).to_json,
     )
@@ -139,121 +139,6 @@ describe "GET v3/providers/:provider_code/courses/:course_code" do
             "site_statuses" => { "meta" => { "included" => false } },
             "subjects" => { "meta" => { "included" => false } },
           },
-          "meta" => {
-            "edit_options" => {
-              "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-              "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
-              "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
-              "start_dates" => [
-                "October #{previous_year}",
-                "November #{previous_year}",
-                "December #{previous_year}",
-                "January #{current_year}",
-                "February #{current_year}",
-                "March #{current_year}",
-                "April #{current_year}",
-                "May #{current_year}",
-                "June #{current_year}",
-                "July #{current_year}",
-                "August #{current_year}",
-                "September #{current_year}",
-                "October #{current_year}",
-                "November #{current_year}",
-                "December #{current_year}",
-                "January #{next_year}",
-                "February #{next_year}",
-                "March #{next_year}",
-                "April #{next_year}",
-                "May #{next_year}",
-                "June #{next_year}",
-                "July #{next_year}",
-              ],
-              "study_modes" => %w[full_time part_time full_time_or_part_time],
-              "show_is_send" => false,
-              "show_start_date" => false,
-              "show_applications_open" => false,
-              "subjects" => [
-                 {
-                   "id" => "1",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary",
-                     "subject_code" => "00",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "2",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with English",
-                     "subject_code" => "01",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "3",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with geography and history",
-                     "subject_code" => "02",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "4",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with mathematics",
-                     "subject_code" => "03",
-                     "bursary_amount" => "6000",
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "5",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with modern languages",
-                     "subject_code" => "04",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "6",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with physical education",
-                     "subject_code" => "06",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-                 {
-                   "id" => "7",
-                   "type" => "subjects",
-                   "attributes" => {
-                     "subject_name" => "Primary with science",
-                     "subject_code" => "07",
-                     "bursary_amount" => nil,
-                     "early_career_payments" => nil,
-                     "scholarship" => nil,
-                   },
-                 },
-              ],
-              "modern_languages" => nil,
-            },
-          },
         },
         "included" => [
           {
@@ -285,7 +170,7 @@ describe "GET v3/providers/:provider_code/courses/:course_code" do
     JSONAPI::Serializable::Renderer.new.render(
       course,
       class: {
-        Course: API::V2::SerializableCourse,
+        Course: API::V3::SerializableCourse,
       },
     )
   end

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -1,0 +1,217 @@
+require "rails_helper"
+
+describe API::V3::SerializableCourse do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+  let(:draft_enrichment) { build :course_enrichment }
+  let(:published_enrichment) { build :course_enrichment, :published }
+  let(:date_today) { Time.zone.today }
+  let(:time_now) { Time.now.utc }
+  let(:course) do
+    create(:course, enrichments: [draft_enrichment, published_enrichment], start_date: time_now, applications_open_from: date_today, level: :primary)
+  end
+  let(:course_json) do
+    jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V3::SerializableCourse,
+      },
+    ).to_json
+  end
+  let(:parsed_json) { JSON.parse(course_json) }
+
+  subject { parsed_json["data"] }
+
+  it { is_expected.to have_type("courses") }
+  it { is_expected.to have_attribute(:start_date).with_value(time_now.strftime("%B %Y")) }
+  it { is_expected.to have_attribute :content_status }
+  it { is_expected.to have_attribute :ucas_status }
+  it { is_expected.to have_attribute :funding_type }
+  it { is_expected.to have_attribute(:applications_open_from).with_value(date_today.to_s) }
+  it { is_expected.to have_attribute :is_send? }
+  it { is_expected.to have_attribute(:level).with_value("primary") }
+  it { is_expected.to have_attribute :english }
+  it { is_expected.to have_attribute :maths }
+  it { is_expected.to have_attribute :science }
+  it { is_expected.to have_attribute :gcse_subjects_required }
+  it { is_expected.to have_attribute :provider_code }
+  it { is_expected.to have_attribute :age_range_in_years }
+  it { is_expected.to have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
+
+  context "with a provider" do
+    let(:provider) { course.provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V3::SerializableCourse,
+          Provider: API::V2::SerializableProvider,
+        },
+        include: [
+          :provider,
+        ],
+      ).to_json
+    end
+
+    it { is_expected.to have_relationship(:provider) }
+
+    it "includes the provider" do
+      expect(parsed_json["included"])
+        .to(include(have_type("providers")
+          .and(have_id(provider.id.to_s))))
+    end
+  end
+
+  context "with a subject" do
+    let(:course) { create(:course, subjects: [find_or_create(:primary_subject, :primary_with_mathematics)]) }
+    let(:accrediting_provider) { course.accrediting_provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course: API::V3::SerializableCourse,
+          Subject: API::V2::SerializableSubject,
+          PrimarySubject: API::V2::SerializableSubject,
+        },
+        include: [
+          :subjects,
+        ],
+      ).to_json
+    end
+
+    it { is_expected.to have_relationship(:accrediting_provider) }
+  end
+
+  context "with an accrediting_provider" do
+    let(:course) { create(:course, :with_accrediting_provider) }
+    let(:accrediting_provider) { course.accrediting_provider }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V3::SerializableCourse,
+          Provider: API::V2::SerializableProvider,
+        },
+        include: [
+          :accrediting_provider,
+        ],
+      ).to_json
+    end
+
+    it { is_expected.to have_relationship(:accrediting_provider) }
+  end
+
+  context "with a site_status" do
+    let(:course) { create(:course, site_statuses: [site_status]) }
+    let(:site_status) { create(:site_status) }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V3::SerializableCourse,
+          Provider: API::V2::SerializableProvider,
+        },
+        include: [
+          :site_status,
+        ],
+      ).to_json
+    end
+
+    it { is_expected.to have_relationship(:site_statuses) }
+  end
+
+  context "with a site" do
+    let(:course) { create(:course, sites: [site]) }
+    let(:site) { create(:site) }
+    let(:course_json) do
+      jsonapi_renderer.render(
+        course,
+        class: {
+          Course:   API::V3::SerializableCourse,
+          Provider: API::V2::SerializableProvider,
+        },
+        include: [
+          :site,
+        ],
+      ).to_json
+    end
+
+    it { is_expected.to have_relationship(:sites) }
+  end
+
+  context "funding_type" do
+    context "fee-paying" do
+      let(:course) { create(:course, :fee_type_based) }
+
+      it { expect(subject["attributes"]).to include("funding_type" => "fee") }
+    end
+
+    context "apprenticeship" do
+      let(:course) { create(:course, :with_apprenticeship) }
+
+      it { expect(subject["attributes"]).to include("funding_type" => "apprenticeship") }
+    end
+
+    context "salaried" do
+      let(:course) { create(:course, :with_salary) }
+
+      it { expect(subject["attributes"]).to include("funding_type" => "salary") }
+    end
+  end
+
+  describe "#is_send?" do
+    let(:course) { create(:course) }
+    it { expect(subject["attributes"]).to include("is_send?" => false) }
+
+    context "with a SEND subject" do
+      let(:course) { create(:course, is_send: true) }
+      it { expect(subject["attributes"]).to include("is_send?" => true) }
+    end
+  end
+
+  # TODO: level now drives the valid subjects that can be assigned to a
+  #       given course
+  # TODO: bursary and scholarship info should now live in the database
+  # TODO: chase up FINANCIAL_SUPPORT
+  xcontext "subjects & level" do
+    let(:course) { create(:course, subjects: subjects) }
+
+    describe "are taken from the course" do
+      let(:subjects) { [find_or_create(:primary_subject, :primary)] }
+      it { expect(subject["attributes"]).to include("level" => "primary") }
+      it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
+    end
+
+    describe "determine bursary and scholarship info" do
+      let(:subjects) { [find_or_create(:ucas_subject, :secondary), find_or_create(:ucas_subject, subject_name: "Russian")] }
+      it { expect(subject["attributes"]).to include("has_bursary?" => true) }
+      it { expect(subject["attributes"]).to include("has_scholarship_and_bursary?" => false) }
+    end
+  end
+
+  describe "attributes retrieved from enrichments" do
+    subject { parsed_json["data"]["attributes"] }
+
+    it { expect(subject["about_course"]).to               eq(published_enrichment.about_course) }
+    it { expect(subject["about_course"]).to               eq published_enrichment.about_course }
+    it { expect(subject["course_length"]).to              eq published_enrichment.course_length }
+    it { expect(subject["fee_details"]).to                eq published_enrichment.fee_details }
+    it { expect(subject["fee_international"]).to          eq published_enrichment.fee_international }
+    it { expect(subject["fee_uk_eu"]).to                  eq published_enrichment.fee_uk_eu }
+    it { expect(subject["financial_support"]).to          eq published_enrichment.financial_support }
+    it { expect(subject["how_school_placements_work"]).to eq published_enrichment.how_school_placements_work }
+    it { expect(subject["interview_process"]).to          eq published_enrichment.interview_process }
+    it { expect(subject["other_requirements"]).to         eq published_enrichment.other_requirements }
+    it { expect(subject["personal_qualities"]).to         eq published_enrichment.personal_qualities }
+    it { expect(subject["required_qualifications"]).to    eq published_enrichment.required_qualifications }
+    it { expect(subject["salary_details"]).to             eq published_enrichment.salary_details }
+  end
+
+  context "a new course" do
+    let(:provider) { create :provider }
+    let(:course) { Course.new(provider: provider) }
+
+    subject { parsed_json["data"] }
+
+    it { is_expected.to have_attribute(:start_date).with_value(nil) }
+  end
+end


### PR DESCRIPTION
### Context
Courses V2 serializer exposing the last enrichment for the frontend

### Changes proposed in this pull request
- Create a new serializer for V3 that exposes the last "published" enrichment
- Remove metadata as they aren't needed in V3.

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
