### PR TITLE
[2801] /subject-areas endpoint

### DIFF
--- a/app/controllers/api/v2/accredited_body_training_provider_courses_controller.rb
+++ b/app/controllers/api/v2/accredited_body_training_provider_courses_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class AccreditedBodyTrainingProviderCoursesController < ApplicationController
+    class AccreditedBodyTrainingProviderCoursesController < API::V2::ApplicationController
       before_action :build_recruitment_cycle, :build_accredited_body, :build_training_provider
 
       def index

--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class AccreditedProviderTrainingProvidersController < ApplicationController
+    class AccreditedProviderTrainingProvidersController < API::V2::ApplicationController
       before_action :build_recruitment_cycle
       before_action :build_provider
 

--- a/app/controllers/api/v2/recruitment_cycles_controller.rb
+++ b/app/controllers/api/v2/recruitment_cycles_controller.rb
@@ -1,6 +1,6 @@
 module API
   module V2
-    class RecruitmentCyclesController < ApplicationController
+    class RecruitmentCyclesController < API::V2::ApplicationController
       before_action :build_recruitment_cycle
 
       def index

--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -14,6 +14,13 @@ module API
           year: params[:recruitment_cycle_year],
         ) || RecruitmentCycle.current_recruitment_cycle
       end
+
+      def fields_param
+        params.fetch(:fields, {})
+          .permit(:subject_areas, :courses, :providers)
+          .to_h
+          .map { |k, v| [k, v.split(",").map(&:to_sym)] }
+      end
     end
   end
 end

--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -20,13 +20,6 @@ module API
         end
       end
 
-      def fields_param
-        params.fetch(:fields, {})
-          .permit(:courses, :providers)
-          .to_h
-          .map { |k, v| [k, v.split(",").map(&:to_sym)] }
-      end
-
     private
 
       def build_courses

--- a/app/controllers/api/v3/subject_areas_controller.rb
+++ b/app/controllers/api/v3/subject_areas_controller.rb
@@ -1,0 +1,9 @@
+module API
+  module V3
+    class SubjectAreasController < API::V3::ApplicationController
+      def index
+        render jsonapi: SubjectArea.active, fields: fields_param, include: params[:include], class: CourseSerializersService.new.execute[:v3]
+      end
+    end
+  end
+end

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -2,21 +2,24 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class Subject < ApplicationRecord
   has_many :course_subjects
   has_many :courses, through: :course_subjects
+  belongs_to :subject_area, foreign_key: :type, inverse_of: :subjects
   has_one :financial_incentive
 
   def to_sym

--- a/app/models/subject_area.rb
+++ b/app/models/subject_area.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: subject_area
+#
+#  created_at :datetime         not null
+#  name       :text
+#  typename   :text             not null, primary key
+#  updated_at :datetime         not null
+#
+
+class SubjectArea < ApplicationRecord
+  has_many :subjects, foreign_key: :type, inverse_of: :subject_area
+  self.primary_key = :typename
+  scope :active, -> { where.not(typename: "DiscontinuedSubject") }
+end

--- a/app/models/subjects/discontinued_subject.rb
+++ b/app/models/subjects/discontinued_subject.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class DiscontinuedSubject < Subject

--- a/app/models/subjects/further_education_subject.rb
+++ b/app/models/subjects/further_education_subject.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class FurtherEducationSubject < Subject

--- a/app/models/subjects/modern_languages_subject.rb
+++ b/app/models/subjects/modern_languages_subject.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class ModernLanguagesSubject < Subject

--- a/app/models/subjects/primary_subject.rb
+++ b/app/models/subjects/primary_subject.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class PrimarySubject < Subject

--- a/app/models/subjects/secondary_subject.rb
+++ b/app/models/subjects/secondary_subject.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class SecondarySubject < Subject

--- a/app/serializers/api/v3/serializable_subject_area.rb
+++ b/app/serializers/api/v3/serializable_subject_area.rb
@@ -1,0 +1,11 @@
+module API
+  module V3
+    class SerializableSubjectArea < JSONAPI::Serializable::Resource
+      type "subject_areas"
+      has_many :subjects
+
+      attributes :name
+      attributes :typename
+    end
+  end
+end

--- a/app/serializers/subject_serializer.rb
+++ b/app/serializers/subject_serializer.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 class SubjectSerializer < ActiveModel::Serializer

--- a/app/services/course_serializers_service.rb
+++ b/app/services/course_serializers_service.rb
@@ -10,7 +10,8 @@ class CourseSerializersService
     site_serializer: API::V2::SerializableSite,
     provider_serializer: API::V2::SerializableProvider,
     provider_enrichment_serializer: API::V2::SerializableProviderEnrichment,
-    recruitment_cycle_serializer: API::V2::SerializableRecruitmentCycle
+    recruitment_cycle_serializer: API::V2::SerializableRecruitmentCycle,
+    v3_subject_area_serializer: API::V3::SerializableSubjectArea
   )
     @course_serializer = course_serializer
     @subject_serializer = subject_serializer
@@ -23,6 +24,8 @@ class CourseSerializersService
     @provider_serializer = provider_serializer
     @provider_enrichment_serializer = provider_enrichment_serializer
     @recruitment_cycle_serializer = recruitment_cycle_serializer
+
+    @v3_subject_area_serializer = v3_subject_area_serializer
   end
 
   def execute
@@ -38,6 +41,15 @@ class CourseSerializersService
       Provider: @provider_serializer,
       ProviderEnrichment: @provider_enrichment_serializer,
       RecruitmentCycle: @recruitment_cycle_serializer,
+      v3: {
+        SubjectArea: @v3_subject_area_serializer,
+        #this is ok until the serializers for subjects need to diverge from V2
+        Subject: @subject_serializer,
+        PrimarySubject: @primary_subject_serializer,
+        SecondarySubject: @secondary_subject_serializer,
+        ModernLanguagesSubject: @modern_languages_subject_serializer,
+        FurtherEducationSubject: @further_education_subject_serializer,
+      },
     }
   end
 end

--- a/app/services/subject_creator_service.rb
+++ b/app/services/subject_creator_service.rb
@@ -1,0 +1,98 @@
+class SubjectCreatorService
+  def initialize(primary_subject: PrimarySubject,
+      secondary_subject: SecondarySubject,
+      further_education_subject: FurtherEducationSubject,
+      modern_languages_subject: ModernLanguagesSubject,
+      discontinued_subject: DiscontinuedSubject)
+    @primary_subject = primary_subject
+    @secondary_subject = secondary_subject
+    @further_education_subject = further_education_subject
+    @modern_languages_subject = modern_languages_subject
+    @discontinued_subject = discontinued_subject
+  end
+
+  def execute
+    primary = [
+      { subject_name: "Primary", subject_code: "00" },
+      { subject_name: "Primary with English", subject_code: "01" },
+      { subject_name: "Primary with geography and history", subject_code: "02" },
+      { subject_name: "Primary with mathematics", subject_code: "03" },
+      { subject_name: "Primary with modern languages", subject_code: "04" },
+      { subject_name: "Primary with physical education", subject_code: "06" },
+      { subject_name: "Primary with science", subject_code: "07" },
+    ]
+
+    secondary = [
+      { subject_name: "Art and design", subject_code: "W1" },
+      { subject_name: "Science", subject_code:  "F0" },
+      { subject_name: "Biology", subject_code:  "C1" },
+      { subject_name: "Business studies", subject_code: "08" },
+      { subject_name: "Chemistry", subject_code: "F1" },
+      { subject_name: "Citizenship", subject_code:  "09" },
+      { subject_name: "Classics", subject_code: "Q8" },
+      { subject_name: "Communication and media studies", subject_code: "P3" },
+      { subject_name: "Computing", subject_code: "11" },
+      { subject_name: "Dance", subject_code: "12" },
+      { subject_name: "Design and technology", subject_code: "DT" },
+      { subject_name: "Drama", subject_code: "13" },
+      { subject_name: "Economics", subject_code: "L1" },
+      { subject_name: "English", subject_code: "Q3" },
+      { subject_name: "Geography", subject_code: "F8" },
+      { subject_name: "Health and social care", subject_code: "L5" },
+      { subject_name: "History", subject_code:  "V1" },
+      { subject_name: "Mathematics", subject_code: "G1" },
+      { subject_name: "Music", subject_code: "W3" },
+      { subject_name: "Philosophy", subject_code: "P1" },
+      { subject_name: "Physical education", subject_code: "C6" },
+      { subject_name: "Physics", subject_code: "F3" },
+      { subject_name: "Psychology", subject_code: "C8" },
+      { subject_name: "Religious education", subject_code: "V6" },
+      { subject_name: "Social sciences", subject_code: "14" },
+      # NOTE: no subject_code for 'Modern Languages' because this is just a stub used to trigger
+      # selection of actual entries from `modern_languages` list
+      { subject_name: "Modern Languages", subject_code: nil },
+    ]
+
+    modern_languages = [
+      { subject_name: "French", subject_code: "15" },
+      { subject_name: "English as a second or other language", subject_code: "16" },
+      { subject_name: "German", subject_code: "17" },
+      { subject_name: "Italian", subject_code: "18" },
+      { subject_name: "Japanese", subject_code:  "19" },
+      { subject_name: "Mandarin", subject_code:  "20" },
+      { subject_name: "Russian", subject_code:  "21" },
+      { subject_name: "Spanish", subject_code:  "22" },
+      { subject_name: "Modern languages (other)", subject_code: "24" },
+    ]
+
+    further_education = [
+      { subject_name: "Further education", subject_code: "41" },
+    ]
+
+    # old 2019 DfE subjects
+    discontinued = [
+      { subject_name: "Humanities" },
+      { subject_name: "Balanced Science" },
+    ]
+
+    primary.each do |subject|
+      @primary_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    secondary.each do |subject|
+      @secondary_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    modern_languages.each do |subject|
+      @modern_languages_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    further_education.each do |subject|
+      @further_education_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+    end
+
+    discontinued.each do |subject|
+      @discontinued_subject.find_or_create_by!(subject_name: subject[:subject_name])
+    end
+  end
+end

--- a/app/services/subjects/creator_service.rb
+++ b/app/services/subjects/creator_service.rb
@@ -77,23 +77,23 @@ module Subjects
       ]
 
       primary.each do |subject|
-        @primary_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+        @primary_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
       end
 
       secondary.each do |subject|
-        @secondary_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+        @secondary_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
       end
 
       modern_languages.each do |subject|
-        @modern_languages_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+        @modern_languages_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
       end
 
       further_education.each do |subject|
-        @further_education_subject.find_or_create_by(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
+        @further_education_subject.find_or_create_by!(subject_name: subject[:subject_name], subject_code: subject[:subject_code])
       end
 
       discontinued.each do |subject|
-        @discontinued_subject.find_or_create_by(subject_name: subject[:subject_name])
+        @discontinued_subject.find_or_create_by!(subject_name: subject[:subject_name])
       end
     end
   end

--- a/app/services/subjects/subject_area_creator_service.rb
+++ b/app/services/subjects/subject_area_creator_service.rb
@@ -1,0 +1,15 @@
+module Subjects
+  class SubjectAreaCreatorService
+    def initialize(subject_area: SubjectArea)
+      @subject_area = subject_area
+    end
+
+    def execute
+      @subject_area.find_or_create_by!(typename: "PrimarySubject", name: "Primary")
+      @subject_area.find_or_create_by!(typename: "SecondarySubject", name: "Secondary")
+      @subject_area.find_or_create_by!(typename: "ModernLanguagesSubject", name: "Secondary: Modern Languages")
+      @subject_area.find_or_create_by!(typename: "FurtherEducationSubject", name: "Further Education")
+      @subject_area.find_or_create_by!(typename: "DiscontinuedSubject", name: "Discontinued")
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,7 @@
 #                                     api_v3_recruitment_cycle_providers GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers(.:format)                                                                   api/v3/providers#index
 #                                      api_v3_recruitment_cycle_provider GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                             api/v3/providers#show
 #                                               api_v3_recruitment_cycle GET    /api/v3/recruitment_cycles/:year(.:format)                                                                                               api/v3/recruitment_cycles#show
+#                                                   api_v3_subject_areas GET    /api/v3/subject_areas(.:format)                                                                                                          api/v3/subject_areas#index
 #                                                        api_system_sync POST   /api/system/sync(.:format)                                                                                                               api/system/force_sync#sync
 #                                                              error_500 GET    /error_500(.:format)                                                                                                                     error#error_500
 #                                                             error_nodb GET    /error_nodb(.:format)                                                                                                                    error#error_nodb
@@ -186,6 +187,8 @@ Rails.application.routes.draw do
           end
         end
       end
+
+      resources :subject_areas, only: :index
     end
 
     namespace :system do

--- a/db/migrate/20200114132313_create_subject_area.rb
+++ b/db/migrate/20200114132313_create_subject_area.rb
@@ -1,0 +1,17 @@
+class CreateSubjectArea < ActiveRecord::Migration[6.0]
+  def change
+    create_table :subject_area, primary_key: :typename, id: false do |t|
+      t.text :typename, null: false # This ID will be tied to subject types
+      t.text :name
+      t.timestamps
+    end
+
+    change_table :subject do |t|
+      t.references :subject_area
+    end
+
+    say_with_time "populating subject areas" do
+      Subjects::SubjectAreaCreatorService.new.execute
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -273,7 +273,16 @@ ActiveRecord::Schema.define(version: 2020_01_15_141035) do
     t.text "subject_name"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.bigint "subject_area_id"
+    t.index ["subject_area_id"], name: "index_subject_on_subject_area_id"
     t.index ["subject_name"], name: "index_subject_on_subject_name"
+  end
+
+  create_table "subject_area", id: false, force: :cascade do |t|
+    t.text "typename", null: false
+    t.text "name"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "user", id: :serial, force: :cascade do |t|

--- a/spec/factories/subject_areas.rb
+++ b/spec/factories/subject_areas.rb
@@ -1,0 +1,38 @@
+# == Schema Information
+#
+# Table name: subject_area
+#
+#  created_at :datetime         not null
+#  name       :text
+#  typename   :text             not null, primary key
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :subject_area do
+    trait :primary do
+      typename { "PrimarySubject" }
+      name { "Primary" }
+    end
+
+    trait :secondary do
+      typename { "SecondarySubject" }
+      name { "Secondary" }
+    end
+
+    trait :modern_languages do
+      typename { "ModernLanguagesSubject" }
+      name { "Modern Language" }
+    end
+
+    trait :further_education do
+      typename { "FurtherEducationSubject" }
+      name { "Further Education" }
+    end
+
+    trait :discontinued do
+      typename { "DiscontinuedSubject" }
+      name { "Discontinued" }
+    end
+  end
+end

--- a/spec/factories/subjects/secondary_subjects.rb
+++ b/spec/factories/subjects/secondary_subjects.rb
@@ -37,6 +37,10 @@ FactoryBot.define do
     subject_name { sample_subject.first }
     subject_code { sample_subject.second }
 
+    after(:build) do |subject, _level|
+      find_or_create(:financial_incentive, subject: subject)
+    end
+
     trait :art_and_design do
       subject_name { "Art and design" }
       subject_code { subjects["Art and design"] }

--- a/spec/models/secondary_subject_spec.rb
+++ b/spec/models/secondary_subject_spec.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 require "rails_helper"

--- a/spec/models/subject_area_spec.rb
+++ b/spec/models/subject_area_spec.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: subject_area
+#
+#  created_at :datetime         not null
+#  name       :text
+#  typename   :text             not null, primary key
+#  updated_at :datetime         not null
+#
+
+describe SubjectArea do
+  it "excludes the discontinued subject area" do
+    expect(described_class.active.find_by(typename: "DiscontinuedSubject")).to be_nil
+  end
+end

--- a/spec/models/subject_spec.rb
+++ b/spec/models/subject_spec.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 require "rails_helper"

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -37,7 +37,6 @@ describe "Courses API", type: :request do
           site = create(:site, code: "-", location_name: "Main Site", provider: provider)
           subject1 = find_or_create(:secondary_subject, :modern_languages)
           subject2 = find_or_create(:modern_languages_subject, :german)
-
           course = create(:course,
                           level: "secondary",
                           course_code: "2HPF",

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "GET v3/providers/:provider_code/courses" do
+describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_code/courses" do
   let(:course_subject_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
 
   let(:current_cycle) { find_or_create :recruitment_cycle }

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "GET v3/providers/:provider_code/courses/:course_code" do
+describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_code/courses/:course_code" do
   let(:current_cycle) { find_or_create :recruitment_cycle }
   let(:next_cycle)    { find_or_create :recruitment_cycle, :next }
   let(:current_year)  { current_cycle.year.to_i }

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "GET v3/providers" do
+describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
   let(:organisation) { create(:organisation) }
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
 

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "GET v3/providers/:provider_code" do
+describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_code" do
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:request_path) { "/api/v3/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}" }
   let(:request_params) { {} }

--- a/spec/requests/api/v3/subject_areas/index_spec.rb
+++ b/spec/requests/api/v3/subject_areas/index_spec.rb
@@ -1,0 +1,167 @@
+require "rails_helper"
+
+describe "GET v3 /subject-areas" do
+  let(:request_path) { "/api/v3/subject_areas" }
+  let(:json_response) { JSON.parse(response.body) }
+
+  before do
+    get request_path
+  end
+
+  it "returns the correct data" do
+    expect(json_response).to eq("data" => [
+      {
+        "id" => "PrimarySubject",
+        "type" => "subject_areas",
+        "attributes" => {
+          "name" => "Primary",
+          "typename" => "PrimarySubject",
+        },
+        "relationships" => {
+          "subjects" => {
+            "meta" => {
+              "included" => false,
+            },
+          },
+        },
+      },
+      {
+        "id" => "SecondarySubject",
+        "type" => "subject_areas",
+        "attributes" => {
+          "name" => "Secondary",
+          "typename" => "SecondarySubject",
+        },
+        "relationships" => {
+          "subjects" => {
+            "meta" => {
+              "included" => false,
+            },
+          },
+        },
+      },
+      {
+        "id" => "ModernLanguagesSubject",
+        "type" => "subject_areas",
+        "attributes" => {
+          "name" => "Secondary: Modern Languages",
+          "typename" => "ModernLanguagesSubject",
+        },
+        "relationships" => {
+          "subjects" => {
+            "meta" => {
+              "included" => false,
+            },
+          },
+        },
+      },
+      {
+        "id" => "FurtherEducationSubject",
+        "type" => "subject_areas",
+        "attributes" => {
+          "name" => "Further Education",
+          "typename" => "FurtherEducationSubject",
+        },
+        "relationships" => {
+          "subjects" => {
+            "meta" => {
+              "included" => false,
+            },
+          },
+        },
+      },
+    ],
+    "jsonapi" => {
+      "version" => "1.0",
+    })
+  end
+
+  context "when specifying particular fields" do
+    let(:request_path) { "/api/v3/subject_areas?fields[subject_areas]=typename" }
+
+    it "returns the correct data" do
+      expect(json_response).to eq("data" => [
+        {
+          "id" => "PrimarySubject",
+          "type" => "subject_areas",
+          "attributes" => {
+            "typename" => "PrimarySubject",
+          },
+        },
+        {
+          "id" => "SecondarySubject",
+          "type" => "subject_areas",
+          "attributes" => {
+            "typename" => "SecondarySubject",
+          },
+        },
+        {
+          "id" => "ModernLanguagesSubject",
+          "type" => "subject_areas",
+          "attributes" => {
+            "typename" => "ModernLanguagesSubject",
+          },
+        },
+        {
+          "id" => "FurtherEducationSubject",
+          "type" => "subject_areas",
+          "attributes" => {
+            "typename" => "FurtherEducationSubject",
+          },
+        },
+      ],
+      "jsonapi" => {
+        "version" => "1.0",
+      })
+    end
+  end
+
+  context "when including fields" do
+    let(:request_path) { "/api/v3/subject_areas?include=subjects" }
+
+    it "includes the relationship" do
+      expect(json_response["data"].first).to eq(
+        "id" => "PrimarySubject",
+        "type" => "subject_areas",
+        "attributes" => {
+          "typename" => "PrimarySubject",
+          "name" => "Primary",
+        },
+        "relationships" => {
+          "subjects" => {
+            "data" => [
+              {
+                "type" => "subjects",
+                "id" => "1",
+              },
+              {
+                "type" => "subjects",
+                "id" => "2",
+              },
+              {
+                "type" => "subjects",
+                "id" => "3",
+              },
+              {
+                "type" => "subjects",
+                "id" => "4",
+              },
+              {
+                "type" => "subjects",
+                "id" => "5",
+              },
+              {
+                "type" => "subjects",
+                "id" => "6",
+              },
+              {
+                "type" => "subjects",
+                "id" => "7",
+              },
+            ],
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/serializers/api/v2/serializable_subject_spec.rb
+++ b/spec/serializers/api/v2/serializable_subject_spec.rb
@@ -22,7 +22,7 @@ describe API::V2::SerializableSubject do
   end
 
   context "when a bursary subject" do
-    let(:bursary_subject) { find_or_create :secondary_subject, :mathematics }
+    let(:bursary_subject) { find_or_create(:secondary_subject, :mathematics) }
     let(:resource) { API::V2::SerializableSubject.new object: bursary_subject }
 
     it { should have_attribute(:bursary_amount).with_value(bursary_subject.financial_incentive.bursary_amount) }

--- a/spec/serializers/api/v3/serializable_subject_area_spec.rb
+++ b/spec/serializers/api/v3/serializable_subject_area_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe API::V3::SerializableSubjectArea do
+  let(:subject_area) { SubjectArea.first }
+  let(:resource) { described_class.new(object: subject_area) }
+
+  it "sets type to subject_areas" do
+    expect(resource.jsonapi_type).to eq(:subject_areas)
+  end
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it { should have_type "subject_areas" }
+  it { should have_attribute(:typename).with_value(subject_area.typename) }
+  it { should have_attribute(:name).with_value(subject_area.name) }
+end

--- a/spec/serializers/subject_serializer_spec.rb
+++ b/spec/serializers/subject_serializer_spec.rb
@@ -2,16 +2,18 @@
 #
 # Table name: subject
 #
-#  created_at   :datetime
-#  id           :bigint           not null, primary key
-#  subject_code :text
-#  subject_name :text
-#  type         :text
-#  updated_at   :datetime
+#  created_at      :datetime
+#  id              :bigint           not null, primary key
+#  subject_area_id :bigint
+#  subject_code    :text
+#  subject_name    :text
+#  type            :text
+#  updated_at      :datetime
 #
 # Indexes
 #
-#  index_subject_on_subject_name  (subject_name)
+#  index_subject_on_subject_area_id  (subject_area_id)
+#  index_subject_on_subject_name     (subject_name)
 #
 
 require "rails_helper"

--- a/spec/services/course_serializers_service_spec.rb
+++ b/spec/services/course_serializers_service_spec.rb
@@ -10,6 +10,7 @@ describe CourseSerializersService do
   let(:provider_serializer_spy) { spy }
   let(:provider_enrichment_serializer_spy) { spy }
   let(:recruitment_cycle_serializer_spy) { spy }
+  let(:v3_subject_area_serializer_spy) { spy }
 
   let(:course) { spy("course", present?: true) }
 
@@ -30,6 +31,14 @@ describe CourseSerializersService do
       Provider: API::V2::SerializableProvider,
       ProviderEnrichment: API::V2::SerializableProviderEnrichment,
       RecruitmentCycle: API::V2::SerializableRecruitmentCycle,
+      v3: {
+        SubjectArea: API::V3::SerializableSubjectArea,
+        Subject: API::V2::SerializableSubject,
+        PrimarySubject: API::V2::SerializableSubject,
+        SecondarySubject: API::V2::SerializableSubject,
+        ModernLanguagesSubject: API::V2::SerializableSubject,
+        FurtherEducationSubject: API::V2::SerializableSubject,
+      },
     }
   end
 
@@ -46,6 +55,14 @@ describe CourseSerializersService do
       Provider: provider_serializer_spy,
       ProviderEnrichment: provider_enrichment_serializer_spy,
       RecruitmentCycle: recruitment_cycle_serializer_spy,
+      v3: {
+        SubjectArea: v3_subject_area_serializer_spy,
+        Subject: subject_serializer_spy,
+        PrimarySubject: primary_subject_serializer_spy,
+        SecondarySubject: secondary_subject_serializer_spy,
+        ModernLanguagesSubject: modern_languages_subject_serializer_spy,
+        FurtherEducationSubject: further_education_subject_serializer_spy,
+      },
     }
   end
 

--- a/spec/services/subjects/creator_service_spec.rb
+++ b/spec/services/subjects/creator_service_spec.rb
@@ -17,9 +17,9 @@ describe Subjects::CreatorService do
 
   it "creates subject data unless subject already exists" do
     service.execute
-    expect(primary_model).to have_received(:find_or_create_by).with(subject_name: "Primary", subject_code: "00")
-    expect(secondary_model).to have_received(:find_or_create_by).with(subject_name: "Art and design", subject_code: "W1")
-    expect(further_education_model).to have_received(:find_or_create_by).with(subject_name: "Further education", subject_code: "41")
-    expect(discontinued_model).to have_received(:find_or_create_by).with(subject_name: "Humanities")
+    expect(primary_model).to have_received(:find_or_create_by!).with(subject_name: "Primary", subject_code: "00")
+    expect(secondary_model).to have_received(:find_or_create_by!).with(subject_name: "Art and design", subject_code: "W1")
+    expect(further_education_model).to have_received(:find_or_create_by!).with(subject_name: "Further education", subject_code: "41")
+    expect(discontinued_model).to have_received(:find_or_create_by!).with(subject_name: "Humanities")
   end
 end

--- a/spec/services/subjects/populate_subject_areas_service_spec.rb
+++ b/spec/services/subjects/populate_subject_areas_service_spec.rb
@@ -1,0 +1,13 @@
+describe Subjects::SubjectAreaCreatorService do
+  let(:subject_area_spy) { spy }
+  let(:service) { described_class.new(subject_area: subject_area_spy) }
+
+  it "populates subject areas" do
+    service.execute
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "PrimarySubject", name: "Primary")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "SecondarySubject", name: "Secondary")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "ModernLanguagesSubject", name: "Secondary: Modern Languages")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "FurtherEducationSubject", name: "Further Education")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "DiscontinuedSubject", name: "Discontinued")
+  end
+end

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -23,6 +23,7 @@ RSpec.configure do |config|
   # the tag "without_subjects: true" to make sure the subjects table is empty
   # for tests that need it.
   config.before(:all) do
+    Subjects::SubjectAreaCreatorService.new.execute
     Subjects::CreatorService.new.execute
     Subjects::FinancialIncentiveCreatorService.new.execute
     Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute


### PR DESCRIPTION
### Context
In attempting to create the subjects filter on Rails Find we discovered that subject areas as presented in Search and Compare did not exist in the Teacher Training API.

### Changes proposed in this pull request
Add the subject areas model, an index endpoint for it, and populate the database with the appropriate subject areas.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [x] Tested by running locally
