### PR TITLE
[2804] - Centralise geocoding logic

### DIFF
--- a/app/jobs/geocode_job.rb
+++ b/app/jobs/geocode_job.rb
@@ -3,13 +3,6 @@ class GeocodeJob < ApplicationJob
 
   def perform(klass, id)
     record = klass.classify.safe_constantize.find(id)
-    results = Geocoder.search(record.full_address, params: { region: "gb" })
-    if results.present?
-      result = results.first
-      record.update!(
-        latitude: result.latitude,
-        longitude: result.longitude,
-      )
-    end
+    GeocoderService.geocode(obj: record) if record
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -63,7 +63,7 @@ class Site < ApplicationRecord
   def full_address
     address = [address1, address2, address3, address4, postcode]
 
-    unless location_name.downcase == MAIN_SITE
+    unless location_name && location_name.downcase == MAIN_SITE
       address.unshift(location_name)
     end
 

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -63,7 +63,7 @@ class Site < ApplicationRecord
   def full_address
     address = [address1, address2, address3, address4, postcode]
 
-    unless location_name && location_name.downcase == MAIN_SITE
+    unless location_name.downcase == MAIN_SITE
       address.unshift(location_name)
     end
 

--- a/app/services/geocoder_service.rb
+++ b/app/services/geocoder_service.rb
@@ -1,0 +1,12 @@
+class GeocoderService
+  def self.geocode(obj:, force: false)
+    results = Geocoder.search(obj.full_address, params: { region: "gb" })
+
+    if results.present?
+      result = results.first
+      obj.latitude = result.latitude
+      obj.longitude = result.longitude
+      obj.save(validate: !force)
+    end
+  end
+end

--- a/app/services/geocoder_service.rb
+++ b/app/services/geocoder_service.rb
@@ -6,7 +6,7 @@ class GeocoderService
       result = results.first
       obj.latitude = result.latitude
       obj.longitude = result.longitude
-      obj.save(validate: !force)
+      obj.save!(validate: !force)
     end
   end
 end

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -478,12 +478,14 @@ module MCB
     end
 
     def geocode(obj:, sleep:, force: false)
-      obj.geocode
-      verbose "Geocoded #{obj.class}:#{obj.id} - #{obj}. " \
-              "New lat/long #{obj.latitude},#{obj.latitude} for full_address '#{obj.full_address}'"
+      verbose "Geocoding #{obj.class}:#{obj.id} - #{obj}. " \
+              "Current lat/long #{obj.latitude || 'nil'},#{obj.longitude || 'nil'} for full_address '#{obj.full_address}'"
 
-      saved = obj.save(validate: !force)
-      warn "Saving failed for #{obj.class}:#{obj.id} - #{obj}. Error: #{obj.errors}" unless saved
+      GeocoderService.geocode(obj: obj, force: force)
+      obj.reload
+
+      verbose "Geocoded #{obj.class}:#{obj.id} - #{obj}. " \
+              "New lat/long #{obj.latitude || 'nil'},#{obj.longitude || 'nil'} for full_address '#{obj.full_address}'"
 
       sleep(sleep)
     end

--- a/lib/mcb/commands/providers/geocode.rb
+++ b/lib/mcb/commands/providers/geocode.rb
@@ -6,8 +6,6 @@ option :b, "batch_size", "batch size", argument: :optional, default: 100, transf
 
 instance_eval(&MCB.remote_connect_options)
 
-require "geocoder"
-
 run do |opts, args, _cmd|
   MCB.init_rails(opts)
 

--- a/lib/mcb/commands/sites/geocode.rb
+++ b/lib/mcb/commands/sites/geocode.rb
@@ -7,8 +7,6 @@ flag :f, "force", "Geocode even if the rest of the site has validation errors"
 
 instance_eval(&MCB.remote_connect_options)
 
-require "geocoder"
-
 # TODO: Once Site codes have been changed to three digit values
 # update this command to geocode by site code
 # See: providers/geocode.rb

--- a/spec/jobs/geocode_job_spec.rb
+++ b/spec/jobs/geocode_job_spec.rb
@@ -28,36 +28,12 @@ describe GeocodeJob, type: :job do
   end
 
   context "executing the job" do
-    it "updates the record when there are results" do
-      results = [
-        OpenStruct.new(latitude: 50.345676, longitude: -1.345676),
-      ]
-
-      allow(Geocoder).to receive(:search).and_return(results)
-      expect(Geocoder).to receive(:search).with(site.full_address, params: { region: "gb" })
+    it "calls the GeocoderService" do
+      expect(GeocoderService).to receive(:geocode).with(obj: site)
 
       site.save!
+
       perform_enqueued_jobs { job }
-
-      updated_site = Site.find(site.id)
-
-      expect(updated_site.latitude).to eq(50.345676)
-      expect(updated_site.longitude).to eq(-1.345676)
-    end
-
-    it "does not attempt to update the record when there are no results" do
-      results = []
-
-      allow(Geocoder).to receive(:search).and_return(results)
-      expect(Geocoder).to receive(:search).with(site.full_address, params: { region: "gb" })
-
-      site.save!
-      perform_enqueued_jobs { job }
-
-      updated_site = Site.find(site.id)
-
-      expect(updated_site.latitude).to eq(nil)
-      expect(updated_site.longitude).to eq(nil)
     end
   end
 end

--- a/spec/services/geocoder_service_spec.rb
+++ b/spec/services/geocoder_service_spec.rb
@@ -1,0 +1,34 @@
+describe GeocoderService do
+  describe "#geocode" do
+    let(:valid_site) { create(:site) }
+
+    let(:invalid_site) do
+      invalid_site = build(:site, postcode: "this is not a postcode")
+      invalid_site.save!(validate: false)
+      invalid_site
+    end
+
+    it "geocodes a valid object" do
+      expect { GeocoderService.geocode(obj: valid_site) }.
+          to change { valid_site.reload.latitude }.from(nil).to(51.4524877).
+              and change { valid_site.longitude }.from(nil).to(-0.1204749)
+    end
+
+    it "does not geocode an invalid object by default" do
+      expect { GeocoderService.geocode(obj: invalid_site) }.
+          to raise_error(ActiveRecord::RecordInvalid)
+    end
+
+    it "geocodes an invalid object if forced" do
+      expect { GeocoderService.geocode(obj: invalid_site, force: true) }.
+          to change { invalid_site.reload.latitude }.from(nil).to(51.4524877).
+              and change { invalid_site.longitude }.from(nil).to(-0.1204749)
+    end
+
+    it "geocodes UK (gb) addresses only" do
+      expect(Geocoder).to receive(:search).with(valid_site.full_address, params: { region: "gb" })
+
+      GeocoderService.geocode(obj: valid_site)
+    end
+  end
+end


### PR DESCRIPTION
### Context
MCB's geocoding logic did not restrict searches to the UK region. This meant that geocoding of any invalid Sites (specifically those without an address) would result in coordinates set to somewhere in the U.S (this is the default behaviour).

### Changes proposed in this pull request
- Extract geocoding logic to a new service. Geocoding is restricted to the UK (gb).
- Update mcb console and background job to use this new service

Centralising this logic will (hopefully) reduce the chances of bugs resulting from diverging paths in future 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
