### PR TITLE
[2809] add ElastAlert definition for slow requests

### DIFF
--- a/etc/ttapi-slow-response-times.yaml
+++ b/etc/ttapi-slow-response-times.yaml
@@ -1,0 +1,47 @@
+# This defines an ElastAlert alert that triggers when we detect a certain number
+# of slow requests, averaged over a period of time.
+#
+# You will need a to copy in the "Kibana Dashboard URL" for the "Publish
+# Requests" dashboard, and the appropriate "Slack Incoming Webhook" Slack app
+# that is created.
+#
+# For more info see:
+#   https://api.slack.com/incoming-webhooks
+#   https://help.logit.io/en/articles/2398435-how-to-send-alerts-from-logit-to-slack
+#   https://elastalert.readthedocs.io/en/latest/index.html
+name: "TTAPI Slow Response Alert"
+index: logstash-*
+type: metric_aggregation
+
+generate_kibana_link: true
+use_kibana4_dashboard: "[Kibana Dashboard URL]"
+
+doc_type: doc
+metric_agg_key: duration
+metric_agg_type: avg
+max_threshold: 2500
+buffer_time:
+  seconds: 60
+
+exponential_realert:
+  hours: 1
+
+alert_text_type: alert_text_only
+alert_text: |
+  Average response time of `{average_time:.0f}ms` recorded at `{timestamp}` exceeds threshold of `{threshold}ms` over `{measure_time}`.
+
+  <{kibana_link}|View dashboard for {timestamp}>
+
+alert_text_kw:
+  max_threshold: threshold
+  buffer_time: measure_time
+  metric_duration_avg: average_time
+  kibana_link: kibana_link
+  "@timestamp": timestamp
+
+alert:
+- slack
+
+slack_webhook_url:
+ - "[Slack Incoming Webhook]"
+slack_title: "TTAPI Slow Response Time Alert"


### PR DESCRIPTION
### Context

After the recent outage we had, I've taken a look into how to get alerts out of logit.i to let us know that we're getting slow requests. I've created an ElastAlert there that will trigger if the average request time is over 2.5s over a period of 60 seconds.

### Changes proposed in this pull request

Add the ElastAlert YAML definition to the repo so we have it. Note that sensitive information has been stripped out of the definition and have to be re-added.

### Guidance to review

A sample of the alert is here: https://ukgovernmentdfe.slack.com/archives/CGVNJ2Q2F/p1579091158144800

This alert is already deployed.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
