### PR TITLE
[2803] Added missing subject knowledge enhancement

### DIFF
--- a/app/models/financial_incentive.rb
+++ b/app/models/financial_incentive.rb
@@ -2,13 +2,14 @@
 #
 # Table name: financial_incentive
 #
-#  bursary_amount        :string
-#  created_at            :datetime         not null
-#  early_career_payments :string
-#  id                    :bigint           not null, primary key
-#  scholarship           :string
-#  subject_id            :bigint           not null
-#  updated_at            :datetime         not null
+#  bursary_amount                                 :string
+#  created_at                                     :datetime         not null
+#  early_career_payments                          :string
+#  id                                             :bigint           not null, primary key
+#  scholarship                                    :string
+#  subject_id                                     :bigint           not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
+#  updated_at                                     :datetime         not null
 #
 # Indexes
 #

--- a/app/services/subject_financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb
+++ b/app/services/subject_financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb
@@ -1,0 +1,12 @@
+class SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService
+  def initialize(financial_incentive: FinancialIncentive)
+    @financial_incentive = financial_incentive
+  end
+
+  def execute
+    subject_with_subject_knowledge_enhancement_course_available = ["Primary with mathematics", "Biology", "Computing", "English", "Design and technology", "Geography", "Chemistry", "Mathematics", "Physics", "French", "German", "Spanish", "Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)", "Religious education"]
+
+    financial_incentives = @financial_incentive.joins(:subject).where(subject: { subject_name: subject_with_subject_knowledge_enhancement_course_available })
+    financial_incentives.update_all(subject_knowledge_enhancement_course_available: true)
+  end
+end

--- a/db/migrate/20200115141035_add_subject_knowledge_enhancement_available_to_financial_incentive.rb
+++ b/db/migrate/20200115141035_add_subject_knowledge_enhancement_available_to_financial_incentive.rb
@@ -1,0 +1,9 @@
+class AddSubjectKnowledgeEnhancementAvailableToFinancialIncentive < ActiveRecord::Migration[6.0]
+  def change
+    add_column :financial_incentive, :subject_knowledge_enhancement_course_available, :boolean, null: false, default: false
+
+    say_with_time "populating finanical incentive subject knowledge enhancement course available" do
+      SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_30_125612) do
+ActiveRecord::Schema.define(version: 2020_01_15_141035) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -157,6 +157,7 @@ ActiveRecord::Schema.define(version: 2019_12_30_125612) do
     t.string "scholarship"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "subject_knowledge_enhancement_course_available", default: false, null: false
     t.index ["subject_id"], name: "index_financial_incentive_on_subject_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -19,6 +19,7 @@ next_recruitment_cycle = RecruitmentCycle.create(year: (current_recruitment_year
 
 SubjectCreatorService.new.execute
 SubjectFinancialIncentiveCreatorService.new.execute
+SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
 
 superuser = User.create!(
   first_name: "Super",

--- a/spec/factories/financial_incentives.rb
+++ b/spec/factories/financial_incentives.rb
@@ -2,13 +2,14 @@
 #
 # Table name: financial_incentive
 #
-#  bursary_amount        :string
-#  created_at            :datetime         not null
-#  early_career_payments :string
-#  id                    :bigint           not null, primary key
-#  scholarship           :string
-#  subject_id            :bigint           not null
-#  updated_at            :datetime         not null
+#  bursary_amount                                 :string
+#  created_at                                     :datetime         not null
+#  early_career_payments                          :string
+#  id                                             :bigint           not null, primary key
+#  scholarship                                    :string
+#  subject_id                                     :bigint           not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
+#  updated_at                                     :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/financial_incentive_spec.rb
+++ b/spec/models/financial_incentive_spec.rb
@@ -2,13 +2,14 @@
 #
 # Table name: financial_incentive
 #
-#  bursary_amount        :string
-#  created_at            :datetime         not null
-#  early_career_payments :string
-#  id                    :bigint           not null, primary key
-#  scholarship           :string
-#  subject_id            :bigint           not null
-#  updated_at            :datetime         not null
+#  bursary_amount                                 :string
+#  created_at                                     :datetime         not null
+#  early_career_payments                          :string
+#  id                                             :bigint           not null, primary key
+#  scholarship                                    :string
+#  subject_id                                     :bigint           not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
+#  updated_at                                     :datetime         not null
 #
 # Indexes
 #

--- a/spec/services/subject_financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
+++ b/spec/services/subject_financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
@@ -1,0 +1,25 @@
+fdescribe SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService do
+  let(:financial_incentive_spy) { spy }
+  let(:financial_incentives_records_spy) { spy }
+
+  let(:service) do
+    described_class.new(
+      financial_incentive: financial_incentive_spy,
+    )
+  end
+
+  before do
+    allow(financial_incentive_spy).to receive(:where).and_return financial_incentives_records_spy
+    allow(financial_incentives_records_spy).to receive(:update_all)
+  end
+
+  it "sets the subject knowledge enhancement course available for existing financial incentive " do
+    service.execute
+    expect(financial_incentive_spy).to have_received(:where)
+      .with(subject: { subject_name: ["Primary with mathematics", "Biology", "Computing", "English", "Design and technology", "Geography", "Chemistry", "Mathematics", "Physics", "French", "German", "Spanish", "Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)", "Religious education"] })
+      .exactly(1).times
+    expect(financial_incentives_records_spy).to have_received(:update_all)
+      .with(subject_knowledge_enhancement_course_available: true)
+      .exactly(1).times
+  end
+end

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -25,6 +25,7 @@ RSpec.configure do |config|
   config.before(:all) do
     SubjectCreatorService.new.execute
     SubjectFinancialIncentiveCreatorService.new.execute
+    SubjectFinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
   end
 
   config.before(:each, without_subjects: true) do


### PR DESCRIPTION
### Context
Missing data for subject knowledge enhancement course available data for financial incentives for a given subject

### Changes proposed in this pull request
Added missing subject knowledge enhancement

### Guidance to review
These are the subject/financial incentive concerned with

"Primary with mathematics", "Biology", "Computing", "English", "Design and technology", "Geography", "Chemistry", "Mathematics", "Physics", "French", "German", "Spanish", "Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)", "Religious education"

![image](https://user-images.githubusercontent.com/470137/72453530-23f4a580-37b7-11ea-83c1-1d7f957b2a78.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
