### PR TITLE
Add V3 serializer for providers endpoint

### DIFF
--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -6,9 +6,7 @@ module API
       def index
         @providers = @recruitment_cycle.providers
 
-        render jsonapi: @providers.in_order,
-               fields: { providers: %i[provider_code provider_name courses
-                                       recruitment_cycle_year] }
+        render jsonapi: @providers.in_order, class: { Provider: API::V3::SerializableProvider }
       end
 
       def show

--- a/app/serializers/api/v3/serializable_provider.rb
+++ b/app/serializers/api/v3/serializable_provider.rb
@@ -1,0 +1,13 @@
+module API
+  module V3
+    class SerializableProvider < JSONAPI::Serializable::Resource
+      type "providers"
+
+      attributes :provider_code, :provider_name
+
+      attribute :recruitment_cycle_year do
+        @object.recruitment_cycle.year
+      end
+    end
+  end
+end

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -40,13 +40,6 @@ describe "GET v3/providers" do
             "provider_name" => provider.provider_name,
             "recruitment_cycle_year" => provider.recruitment_cycle.year,
           },
-          "relationships" => {
-            "courses" => {
-              "meta" => {
-                "count" => provider.courses.count,
-              },
-            },
-          },
         }],
         "jsonapi" => {
           "version" => "1.0",

--- a/spec/serializers/api/v3/serializable_provider_spec.rb
+++ b/spec/serializers/api/v3/serializable_provider_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+describe API::V3::SerializableProvider do
+  let(:provider) { create :provider }
+  let(:resource) { described_class.new object: provider }
+
+  it "sets type to providers" do
+    expect(resource.jsonapi_type).to eq :providers
+  end
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it { should have_type "providers" }
+  it { should have_attribute(:provider_code).with_value(provider.provider_code) }
+  it { should have_attribute(:provider_name).with_value(provider.provider_name) }
+  it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
+end


### PR DESCRIPTION
### Context
Providers#index =   🐌 

### Changes proposed in this pull request
Remove unused attributes from serializer

### Guidance to review
### Before
```
Completed #index -- { :controller => "API::V3::ProvidersController", :action => "index", :params => { "recruitment_cycle_year" => "2020" }, :format => "HTML", :method => "GET", :path => "/api/v3/recruitment_cycles/2020/providers", :status => 200, :view_runtime => 31667.63, :db_runtime => 47849.95, :status_message => "OK" }
```

### After
```
Completed #index -- { :controller => "API::V3::ProvidersController", :action => "index", :params => { "recruitment_cycle_year" => "2020" }, :format => "HTML", :method => "GET", :path => "/api/v3/recruitment_cycles/2020/providers", :status => 200, :view_runtime => 784.47, :db_runtime => 92.54, :status_message => "OK" }
```

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
