### PR TITLE
2827 add filtering for courses to api part 1

### DIFF
--- a/app/controllers/api/v3/course_searches_controller.rb
+++ b/app/controllers/api/v3/course_searches_controller.rb
@@ -1,0 +1,9 @@
+module API
+  module V3
+    class CourseSearchesController < ApplicationController
+      def index
+        render jsonapi: CourseSearch.call(filter: params[:filter], recruitment_cycle_year: params[:recruitment_cycle_year])
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -154,6 +154,9 @@ class Course < ApplicationRecord
     where(study_mode: study_modes)
     .or(full_time_or_part_time)
   end
+  scope :with_qualifications, ->(qualifications) do
+    where(qualification: qualifications)
+  end
 
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -148,9 +148,13 @@ class Course < ApplicationRecord
       .not(SiteStatus.table_name => { status: SiteStatus.statuses[:new_status] })
   end
 
-  scope :study_type,      -> (study_mode) do
-    where(study_mode: study_mode).or(full_time_or_part_time)
+  scope :only_with_salary,      -> { where(program_type: :school_direct_salaried_training_programme) }
+  scope :only_with_vacancies,   -> { select do |c| c.has_vacancies? == true end }
+  scope :with_study_modes, ->(study_modes) do
+    where(study_mode: study_modes)
+    .or(full_time_or_part_time)
   end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -148,6 +148,9 @@ class Course < ApplicationRecord
       .not(SiteStatus.table_name => { status: SiteStatus.statuses[:new_status] })
   end
 
+  scope :study_type,      -> (study_mode) do
+    where(study_mode: study_mode).or(full_time_or_part_time)
+  end
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,7 @@ Rails.application.routes.draw do
       resources :recruitment_cycles,
                 only: :show,
                 param: :year do
+        resources :courses, controller: "course_searches"
         resources :providers,
                   only: %i[index show],
                   param: :code do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -384,6 +384,24 @@ describe Course, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe "study_type" do
+      let(:course) {create(:course, study_mode: :full_time_or_part_time )}
+      let(:course_part_time) {create(:course, study_mode: :part_time)}
+      let(:course_full_time) {create(:course, study_mode: :full_time)}
+
+      describe "full_time" do
+        subject { Course.study_type(:full_time) }
+        it { should match_array([course_full_time, course]) }
+      end
+
+      describe "part_time" do
+        subject { Course.study_type(:part_time) }
+        it { should match_array([course_part_time, course]) }
+      end
+    end
+  end
+
   describe "changed_at" do
     it "is set on create" do
       course = create(:course)

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -529,14 +529,6 @@ describe Course, type: :model do
     its(:has_vacancies?) { should be false }
   end
 
-  describe "scopes" do
-    describe "#only_with_vacancies" do
-      subject { Course.only_with_vacancies }
-
-      it { should be_empty }
-    end
-  end
-
   context "with sites" do
     let(:provider) { build(:provider) }
     let(:first_site) { build(:site, provider: provider) }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -451,6 +451,56 @@ describe Course, type: :model do
       subject { Course.only_with_salary }
       it { should match_array([course_school_direct_salaried_training_programme]) }
     end
+
+    describe "#with_qualifications" do
+      let(:course) { create(:course, :resulting_in_qts) }
+      let(:course_pgce_with_qts) { create(:course, :resulting_in_pgce_with_qts) }
+      let(:course_pgde_with_qts) { create(:course, :resulting_in_pgde_with_qts) }
+      let(:course_pgce) { create(:course, :resulting_in_pgce) }
+      let(:course_pgde) { create(:course, :resulting_in_pgde) }
+
+      describe "qts" do
+        subject { Course.with_qualifications(:qts) }
+
+        it { should match_array([course]) }
+      end
+
+      describe "pgce_with_qts" do
+        subject { Course.with_qualifications(:pgce_with_qts) }
+
+        it { should match_array([course_pgce_with_qts]) }
+      end
+
+      describe "pgde_with_qts" do
+        subject { Course.with_qualifications(:pgde_with_qts) }
+
+        it { should match_array([course_pgde_with_qts]) }
+      end
+
+      describe "pgce" do
+        subject { Course.with_qualifications(:pgce) }
+
+        it { should match_array([course_pgce]) }
+      end
+
+      describe "pgde" do
+        subject { Course.with_qualifications(:pgde) }
+
+        it { should match_array([course_pgde]) }
+      end
+
+      describe "pgce_with_qts and pgde_with_qts (PgdePgceWithQts)" do
+        subject { Course.with_qualifications(%i[pgce_with_qts pgde_with_qts]) }
+
+        it { should match_array([course_pgce_with_qts, course_pgde_with_qts]) }
+      end
+
+      describe "pgce and pgde (Other)" do
+        subject { Course.with_qualifications(%i[pgce pgde]) }
+
+        it { should match_array([course_pgce, course_pgde]) }
+      end
+    end
   end
 
   describe "changed_at" do

--- a/spec/requests/api/v3/providers/courses/index_with_filters_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_with_filters_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe "GET v3/recruitment_cycle/:recruitment_cycle_year/courses" do
+  let(:current_cycle) { create(:recruitment_cycle) }
+
+  describe "funding filter" do
+    context "filter[funding]=salary" do
+      let(:request_path) { "/api/v3/recruitment_cycles/#{current_cycle.year}/courses?filter[funding]=salary" }
+
+      context "salary course" do
+        let(:expected_course) { create(:course, :with_salary) }
+
+        before do
+          expected_course
+        end
+
+        it "returns salary courses" do
+          get request_path
+          json_response = JSON.parse(response.body)
+          course_hashes = json_response["data"]
+          expect(course_hashes.count).to eq(1)
+        end
+      end
+
+      context "non salaried course" do
+        let(:non_salary_course) { create(:course, :with_salary) }
+
+        before do
+          non_salary_course
+        end
+
+        it "returns salary courses" do
+          get request_path
+          json_response = JSON.parse(response.body)
+          course_hashes = json_response["data"]
+          expect(course_hashes).to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/services/course_search_spec.rb
+++ b/spec/services/course_search_spec.rb
@@ -1,0 +1,61 @@
+class CourseSearch
+  def initialize(filter:, recruitment_cycle_year:)
+    @filter = filter
+    @recruitment_cycle_year = recruitment_cycle_year
+  end
+
+  class << self
+    def call(**args)
+      new(args).call
+    end
+  end
+
+  def call
+    scope = Course.all
+    scope = scope.only_with_salary if funding_filter_salary?
+    scope
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :filter, :recruitment_cycle_year
+
+  def funding_filter_salary?
+    filter[:funding] == "salary"
+  end
+end
+
+RSpec.describe CourseSearch do
+  describe ".call" do
+    subject { described_class.call(filter: filter, recruitment_cycle_year: current_recruitment_cycle_year) }
+
+    let(:current_recruitment_cycle_year) { Settings.current_recruitment_cycle_year }
+
+    context "filter[funding]" do
+      let(:salary_course) { create(:course, :with_salary) }
+      let(:not_salary_course) { create(:course) }
+
+      before do
+        salary_course
+        not_salary_course
+      end
+
+      context "salary" do
+        let(:filter) { { funding: "salary" } }
+
+        # expect(Course).to receive(:all).and_return(all_scope)
+        # expect(all_scope).to receive(:only_with_salary)
+
+        it { is_expected.to contain_exactly(salary_course) }
+      end
+
+      context "all" do
+        let(:filter) { { funding: "all" } }
+
+        it { is_expected.to contain_exactly(salary_course, not_salary_course) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Scope

### Changes proposed in this pull request
Added scopes for the course model

### Guidance to review

Nice cut off point

Will have a following PR for exposing it on the api endpoint

its going to shaped up something like this in the controller

```
@course.only_with_salary(params)
	.only_with_vacancies(params)
	.with_study_modes(params)
	.with_qualifications(params)
```


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
