### PR TITLE
[2861] Add search to V3 Provider Index

### DIFF
--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -4,6 +4,8 @@ module API
       before_action :build_recruitment_cycle
 
       def index
+        build_fields_for_index
+
         @providers = if params[:search].present?
                        @recruitment_cycle.providers.search_by_code_or_name(params[:search])
                      else
@@ -28,6 +30,22 @@ module API
                                        email website telephone train_with_us
                                        train_with_disability sites
                                        accredited_bodies accredited_body?] }
+      end
+
+    private
+
+      def build_fields_for_index
+        @fields = default_fields_for_index
+
+        return if params[:fields].blank? || params[:fields][:providers].blank?
+
+        @fields[:providers] = params[:fields][:providers].split(",")
+      end
+
+      def default_fields_for_index
+        {
+          providers: %w[provider_name provider_code recruitment_cycle_year],
+        }
       end
     end
   end

--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -4,9 +4,13 @@ module API
       before_action :build_recruitment_cycle
 
       def index
-        @providers = @recruitment_cycle.providers
+        @providers = if params[:search].present?
+                       @recruitment_cycle.providers.search_by_code_or_name(params[:search])
+                     else
+                       @recruitment_cycle.providers
+                     end
 
-        render jsonapi: @providers.in_order, class: { Provider: API::V3::SerializableProvider }
+        render jsonapi: @providers.in_order, class: { Provider: API::V3::SerializableProvider }, fields: @fields
       end
 
       def show

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -142,6 +142,17 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
 
+    context "Seaching for a provider by its lower case full name" do
+      let(:request_path) { "#{base_provider_path}?search=second provider" }
+
+      it "Only returns data for the provider" do
+        perform_request
+
+        expect(json_response["data"].count).to eq(1)
+        expect(json_response["data"].first).to have_attribute("provider_code").with_value("2AT")
+      end
+    end
+
     context "Seaching for a provider by part of its name" do
       let(:request_path) { "#{base_provider_path}?search=provider" }
 
@@ -156,6 +167,17 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
 
     context "Seaching for a provider by its provider code" do
       let(:request_path) { "#{base_provider_path}?search=2AT" }
+
+      it "Only returns data for the provider" do
+        perform_request
+
+        expect(json_response["data"].count).to eq(1)
+        expect(json_response["data"].first).to have_attribute("provider_code").with_value("2AT")
+      end
+    end
+
+    context "Seaching for a provider by a lower case provider code" do
+      let(:request_path) { "#{base_provider_path}?search=2at" }
 
       it "Only returns data for the provider" do
         perform_request

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -6,9 +6,12 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
 
   let!(:provider) {
     create(:provider,
+           provider_code: "1AT",
+           provider_name: "First provider",
            organisations: [organisation],
            contacts: [contact])
   }
+
   let(:contact) { build(:contact) }
 
   let(:json_response) { JSON.parse(response.body) }
@@ -110,6 +113,55 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
         expect(json_response["data"].first)
           .to have_attribute("recruitment_cycle_year")
                 .with_value(next_recruitment_cycle.year)
+      end
+    end
+  end
+
+  context "Searching for a provider" do
+    let(:base_provider_path) { "/api/v3/recruitment_cycles/#{recruitment_cycle.year}/providers" }
+    let(:provider_two) do
+      create(:provider,
+             provider_code: "2AT",
+             provider_name: "Second provider",
+             organisations: [organisation],
+             contacts: [contact])
+    end
+
+    before do
+      provider_two
+    end
+
+    context "Seaching for a provider by its full name" do
+      let(:request_path) { "#{base_provider_path}?search=Second provider" }
+
+      it "Only returns data for the provider" do
+        perform_request
+
+        expect(json_response["data"].count).to eq(1)
+        expect(json_response["data"].first).to have_attribute("provider_code").with_value("2AT")
+      end
+    end
+
+    context "Seaching for a provider by part of its name" do
+      let(:request_path) { "#{base_provider_path}?search=provider" }
+
+      it "Returns data for the matching providers" do
+        perform_request
+
+        expect(json_response["data"].count).to eq(2)
+        expect(json_response["data"].first).to have_attribute("provider_code").with_value("1AT")
+        expect(json_response["data"].last).to have_attribute("provider_code").with_value("2AT")
+      end
+    end
+
+    context "Seaching for a provider by its provider code" do
+      let(:request_path) { "#{base_provider_path}?search=2AT" }
+
+      it "Only returns data for the provider" do
+        perform_request
+
+        expect(json_response["data"].count).to eq(1)
+        expect(json_response["data"].first).to have_attribute("provider_code").with_value("2AT")
       end
     end
   end

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -165,4 +165,37 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
   end
+
+  context "Sparse fields" do
+    context "Only returning specified fields" do
+      let(:request_path) { "/api/v3/recruitment_cycles/#{recruitment_cycle.year}/providers?fields[providers]=provider_name,recruitment_cycle_year" }
+
+      it "Only returns the specified field" do
+        perform_request
+
+        expect(json_response["data"].first).to have_attribute("provider_name")
+        expect(json_response["data"].first).to have_attribute("recruitment_cycle_year")
+        expect(json_response["data"].first).not_to have_attribute("provider_code")
+      end
+    end
+
+    context "Default fields" do
+      let(:request_path) { "/api/v3/recruitment_cycles/#{recruitment_cycle.year}/providers" }
+      let(:data) { json_response["data"].first }
+
+      before { perform_request }
+
+      it "Returns the provider name" do
+        expect(data).to have_attribute("provider_name")
+      end
+
+      it "Returns the provider code" do
+        expect(data).to have_attribute("provider_code")
+      end
+
+      it "Returns the recruitment cycle year" do
+        expect(data).to have_attribute("recruitment_cycle_year")
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

In order to support searching by providers on Rails Find - we need the endpoint in order to search for a specific provider by name or code

Additionally, as this endpoint will be getting hit frequently (potentially once ever key press) it needs to avoid slow performance by accidentally loading more than required, as such sparse field support has been added (https://jsonapi.org/format/#fetching-sparse-fieldsets)

### Changes proposed in this pull request

- Add the ability to support a search param at  `v3/.../providers?search=Meow`
- Add the ability to define the fields you wish to return 
  - E.g. `v3/.../providers?fields[providers]=provider_name` for returning only the `provider_name`
  - **Note** This currently defaults to `provider_name`, `provider_code` and `recruitment_cycle_year` to avoid breaking anything that currently depends on the end point

### Guidance to review

- Run the API
- Navigate to localhost:3001/api/v3/recruitment_cycles/2020/providers?search=scitt&fields[providers]=provider_code
- Edit params as you like

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
