### PR TITLE
2827 add filtering for courses to api

### DIFF
--- a/app/controllers/api/v3/course_searches_controller.rb
+++ b/app/controllers/api/v3/course_searches_controller.rb
@@ -1,0 +1,10 @@
+module API
+  module V3
+    class CourseSearchesController < API::V3::ApplicationController
+      def index
+        course_scope = CourseSearchService.call(filter: params[:filter])
+        render jsonapi: paginate(course_scope)
+      end
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -148,6 +148,18 @@ class Course < ApplicationRecord
       .not(SiteStatus.table_name => { status: SiteStatus.statuses[:new_status] })
   end
 
+  scope :with_recruitment_cycle, ->(year) { joins(provider: :recruitment_cycle).where(recruitment_cycle: { year: year }) }
+  scope :findable, -> { where(id: SiteStatus.findable.select(:course_id)) }
+  scope :with_vacancies, -> { where(id: SiteStatus.with_vacancies.select(:course_id)) }
+  scope :with_salary, -> { where(program_type: :school_direct_salaried_training_programme) }
+  scope :with_study_modes, ->(study_modes) do
+    where(study_mode: Array(study_modes) << "full_time_or_part_time")
+  end
+
+  scope :with_qualifications, ->(qualifications) do
+    where(qualification: qualifications)
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -11,8 +11,11 @@
 #
 # Indexes
 #
-#  IX_course_site_course_id  (course_id)
-#  IX_course_site_site_id    (site_id)
+#  IX_course_site_course_id         (course_id)
+#  IX_course_site_site_id           (site_id)
+#  index_course_site_on_publish     (publish)
+#  index_course_site_on_status      (status)
+#  index_course_site_on_vac_status  (vac_status)
 #
 
 class SiteStatus < ApplicationRecord

--- a/app/serializers/site_status_serializer.rb
+++ b/app/serializers/site_status_serializer.rb
@@ -11,8 +11,11 @@
 #
 # Indexes
 #
-#  IX_course_site_course_id  (course_id)
-#  IX_course_site_site_id    (site_id)
+#  IX_course_site_course_id         (course_id)
+#  IX_course_site_site_id           (site_id)
+#  index_course_site_on_publish     (publish)
+#  index_course_site_on_status      (status)
+#  index_course_site_on_vac_status  (vac_status)
 #
 
 class SiteStatusSerializer < ActiveModel::Serializer

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -1,0 +1,50 @@
+class CourseSearchService
+  def initialize(filter:, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    @filter = filter || {}
+    @recruitment_cycle_year = recruitment_cycle_year
+  end
+
+  class << self
+    def call(**args)
+      new(args).call
+    end
+  end
+
+  def call
+    scope = Course
+      .findable
+      .with_recruitment_cycle(recruitment_cycle_year)
+
+    scope = scope.with_salary if funding_filter_salary?
+    scope = scope.with_qualifications(qualifications) if qualifications.any?
+    scope = scope.with_vacancies if has_vacancies?
+    scope = scope.with_study_modes(study_types) if study_types.any?
+    scope
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :filter, :recruitment_cycle_year
+
+  def funding_filter_salary?
+    filter[:funding] == "salary"
+  end
+
+  def qualifications
+    return [] if filter[:qualification].blank?
+
+    filter[:qualification].split(",")
+  end
+
+  def has_vacancies?
+    filter[:has_vacancies].to_s.downcase == "true"
+  end
+
+  def study_types
+    return [] if filter[:study_type].blank?
+
+    filter[:study_type].split(",")
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@
 #                                                                        PUT    /api/v2/access_requests/:id(.:format)                                                                                                    api/v2/access_requests#update
 #                                                                        DELETE /api/v2/access_requests/:id(.:format)                                                                                                    api/v2/access_requests#destroy
 #                                                api_v2_build_new_course GET    /api/v2/build_new_course(.:format)                                                                                                       api/v2/courses#build_new
+#                                                         api_v3_courses GET    /api/v3/courses(.:format)                                                                                                                api/v3/course_searches#index
 #                              api_v3_recruitment_cycle_provider_courses GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses(.:format)                                            api/v3/courses#index
 #                               api_v3_recruitment_cycle_provider_course GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses/:code(.:format)                                      api/v3/courses#show
 #                                       api_v3_recruitment_cycle_courses GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/courses(.:format)                                                           api/v3/courses#index
@@ -172,6 +173,7 @@ Rails.application.routes.draw do
     end
 
     namespace :v3 do
+      resources :courses, controller: "course_searches", only: :index
       resources :recruitment_cycles,
                 only: :show,
                 param: :year do

--- a/db/migrate/20200131104849_add_site_status_indexes.rb
+++ b/db/migrate/20200131104849_add_site_status_indexes.rb
@@ -1,0 +1,9 @@
+class AddSiteStatusIndexes < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :course_site, :publish, algorithm: :concurrently
+    add_index :course_site, :status, algorithm: :concurrently
+    add_index :course_site, :vac_status, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_15_141035) do
+ActiveRecord::Schema.define(version: 2020_01_31_104849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -119,7 +119,10 @@ ActiveRecord::Schema.define(version: 2020_01_15_141035) do
     t.text "status"
     t.text "vac_status"
     t.index ["course_id"], name: "IX_course_site_course_id"
+    t.index ["publish"], name: "index_course_site_on_publish"
     t.index ["site_id"], name: "IX_course_site_site_id"
+    t.index ["status"], name: "index_course_site_on_status"
+    t.index ["vac_status"], name: "index_course_site_on_vac_status"
   end
 
   create_table "course_subject", id: :serial, force: :cascade do |t|

--- a/spec/factories/site_statuses.rb
+++ b/spec/factories/site_statuses.rb
@@ -11,8 +11,11 @@
 #
 # Indexes
 #
-#  IX_course_site_course_id  (course_id)
-#  IX_course_site_site_id    (site_id)
+#  IX_course_site_course_id         (course_id)
+#  IX_course_site_site_id           (site_id)
+#  index_course_site_on_publish     (publish)
+#  index_course_site_on_status      (status)
+#  index_course_site_on_vac_status  (vac_status)
 #
 
 FactoryBot.define do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -542,11 +542,11 @@ describe Course, type: :model do
     end
 
     describe ".with_qualifications" do
-      let(:course_qts) { create(:course, :resulting_in_qts) }
-      let(:course_pgce_with_qts) { create(:course, :resulting_in_pgce_with_qts) }
-      let(:course_pgde_with_qts) { create(:course, :resulting_in_pgde_with_qts) }
-      let(:course_pgce) { create(:course, :resulting_in_pgce) }
-      let(:course_pgde) { create(:course, :resulting_in_pgde) }
+      let(:course_qts) { TestDataCache.get(:course, :resulting_in_qts) }
+      let(:course_pgce_with_qts) { TestDataCache.get(:course, :resulting_in_pgce_with_qts) }
+      let(:course_pgde_with_qts) { TestDataCache.get(:course, :resulting_in_pgde_with_qts) }
+      let(:course_pgce) { TestDataCache.get(:course, :resulting_in_pgce) }
+      let(:course_pgde) { TestDataCache.get(:course, :resulting_in_pgde) }
 
       subject { described_class.with_qualifications(qualifications) }
 

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -11,8 +11,11 @@
 #
 # Indexes
 #
-#  IX_course_site_course_id  (course_id)
-#  IX_course_site_site_id    (site_id)
+#  IX_course_site_course_id         (course_id)
+#  IX_course_site_site_id           (site_id)
+#  index_course_site_on_publish     (publish)
+#  index_course_site_on_status      (status)
+#  index_course_site_on_vac_status  (vac_status)
 #
 require "rails_helper"
 

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -1,0 +1,198 @@
+require "rails_helper"
+
+describe "GET v3/courses" do
+  let(:current_cycle) { create(:recruitment_cycle) }
+  let(:findable_status) { build(:site_status, :findable) }
+
+  before do
+    current_cycle
+  end
+
+  describe "funding filter" do
+    let(:request_path) { "/api/v3/courses?filter[funding]=salary" }
+
+    context "with a salaried course" do
+      let(:course_with_salary) { create(:course, :with_salary, site_statuses: [findable_status]) }
+
+      before do
+        course_with_salary
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a non-salaried course" do
+      let(:non_salary_course) { create(:course, site_statuses: [findable_status]) }
+
+      before do
+        non_salary_course
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes).to be_empty
+      end
+    end
+  end
+
+  describe "qualifications filter" do
+    let(:request_path) { "/api/v3/courses?filter[qualification]=pgce" }
+
+    context "with a pgce qualification" do
+      let(:course_with_pgce) { create(:course, :resulting_in_pgce, site_statuses: [findable_status]) }
+
+      before do
+        course_with_pgce
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "without a pgce qualification" do
+      let(:course_without_pgce) { create(:course, site_statuses: [findable_status]) }
+
+      before do
+        course_without_pgce
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "vacancies filter" do
+    let(:request_path) { "/api/v3/courses?filter[has_vacancies]=true" }
+
+    context "with a course with vacancies" do
+      let(:findable_status_with_vacancies) { build(:site_status, :findable, :with_any_vacancy) }
+      let(:course_with_vacancies) { create(:course, site_statuses: [findable_status_with_vacancies]) }
+
+      before do
+        course_with_vacancies
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a course with no vacancies" do
+      let(:findable_status_with_no_vacancies) { build(:site_status, :findable, :with_no_vacancies) }
+      let(:course_without_vacancies) { create(:course, site_statuses: [findable_status_with_no_vacancies]) }
+
+      before do
+        course_without_vacancies
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "study type filter" do
+    let(:request_path) { "/api/v3/courses?filter[study_type]=full_time" }
+
+    context "with a full time course" do
+      let(:full_time_course) { create(:course, study_mode: :full_time, site_statuses: [findable_status]) }
+
+      before do
+        full_time_course
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a part time course" do
+      let(:part_time_course) { create(:course, study_mode: :part_time) }
+
+      before do
+        part_time_course
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "recruitment_cycle scoping" do
+    context "course not in the provided recruitment cycle" do
+      let(:provider) { create(:provider, :next_recruitment_cycle) }
+      let(:request_path) { "/api/v3/courses" }
+
+      let(:course_in_next_cycle) { create(:course, provider: provider, site_statuses: [findable_status]) }
+
+      before do
+        course_in_next_cycle
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "findable scoping" do
+    context "course is not findable" do
+      let(:request_path) { "/api/v3/courses" }
+      let(:not_findable_course) { create(:course) }
+
+      before do
+        not_findable_course
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "pagination" do
+    let(:request_path) { "/api/v3/courses" }
+
+    it "paginates the results" do
+      get request_path
+      headers = response.headers
+
+      expect(headers["Per-Page"]).to be_present
+      expect(headers["Total"]).to be_present
+    end
+  end
+end

--- a/spec/serializers/site_status_serializer_spec.rb
+++ b/spec/serializers/site_status_serializer_spec.rb
@@ -11,8 +11,11 @@
 #
 # Indexes
 #
-#  IX_course_site_course_id  (course_id)
-#  IX_course_site_site_id    (site_id)
+#  IX_course_site_course_id         (course_id)
+#  IX_course_site_site_id           (site_id)
+#  index_course_site_on_publish     (publish)
+#  index_course_site_on_status      (status)
+#  index_course_site_on_vac_status  (vac_status)
 #
 
 require "rails_helper"

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -1,0 +1,183 @@
+require "rails_helper"
+
+RSpec.describe CourseSearchService do
+  describe ".call" do
+    subject { described_class.call(filter: filter, recruitment_cycle_year: recruitment_cycle_year) }
+
+    let(:recruitment_cycle_year) { "2020" }
+    let(:findable_scope) { class_double(Course) }
+    let(:findable_and_current_scope) { class_double(Course) }
+
+    before do
+      allow(Course).to receive(:findable).and_return(findable_scope)
+      allow(findable_scope).to receive(:with_recruitment_cycle).and_return(findable_and_current_scope)
+    end
+
+    context "no recruitment cycle year passed" do
+      subject { described_class.call(filter: {}) }
+      let(:expected_year) { "2000" }
+
+      before do
+        allow(Settings).to receive(:current_recruitment_cycle_year)
+          .and_return(expected_year)
+      end
+
+      it "uses the current year" do
+        expect(findable_scope).to receive(:with_recruitment_cycle)
+          .with(expected_year)
+        subject
+      end
+    end
+
+    describe "filter is nil" do
+      let(:filter) { nil }
+
+      it "returns all" do
+        expect(subject).to eq(findable_and_current_scope)
+      end
+    end
+
+    describe "passed recruitment cycle" do
+      let(:recruitment_cycle_year) { "2021" }
+      let(:filter) { nil }
+
+      it "scopes the correct recruitment cycle" do
+        expect(findable_scope).to receive(:with_recruitment_cycle)
+          .with(recruitment_cycle_year)
+          .and_return(findable_and_current_scope)
+        subject
+      end
+    end
+
+    describe "filter[funding]" do
+      context "when value is salary" do
+        let(:filter) { { funding: "salary" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_salary scope" do
+          expect(findable_and_current_scope).to receive(:with_salary).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when value is all" do
+        let(:filter) { { funding: "all" } }
+
+        it "doesn't add the with_salary scope" do
+          expect(findable_and_current_scope).not_to receive(:with_salary)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[qualification]" do
+      context "when qualifications passed" do
+        let(:filter) { { qualification: "pgde,pgce_with_qts,pgde_with_qts,qts,pgce" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_qualifications scope" do
+          expect(findable_and_current_scope)
+            .to receive(:with_qualifications)
+            .with(%w(pgde pgce_with_qts pgde_with_qts qts pgce))
+            .and_return(expected_scope)
+
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when no qualifications passed" do
+        let(:filter) { {} }
+
+        it "adds the with_qualifications scope" do
+          expect(findable_and_current_scope)
+            .not_to receive(:with_qualifications)
+
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[with_vacancies]" do
+      context "when true" do
+        let(:filter) { { has_vacancies: true } }
+        let(:expected_scope) { double }
+
+        it "adds the with_vacancies scope" do
+          expect(findable_and_current_scope).to receive(:with_vacancies).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when false" do
+        let(:filter) { { has_vacancies: false } }
+
+        it "adds the with_vacancies scope" do
+          expect(findable_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the with_vacancies scope" do
+          expect(findable_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[study_type]" do
+      context "when full_time" do
+        let(:filter) { { study_type: "full_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(full_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when part_time" do
+        let(:filter) { { study_type: "part_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when both" do
+        let(:filter) { { study_type: "part_time,full_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope with an array of both arguments" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the scope" do
+          expect(findable_and_current_scope).not_to receive(:with_study_modes)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "multiple filters" do
+      let(:filter) { { study_type: "part_time", funding: "salary" } }
+      let(:salary_scope) { double }
+      let(:expected_scope) { double }
+
+      it "combines scopes" do
+        expect(findable_and_current_scope).to receive(:with_salary).and_return(salary_scope)
+        expect(salary_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
+        expect(subject).to eq(expected_scope)
+      end
+    end
+  end
+end

--- a/spec/support/test_data_cache.rb
+++ b/spec/support/test_data_cache.rb
@@ -48,6 +48,21 @@ class TestDataCache
           %i[primary unpublished] => -> do
             FactoryBot.create(:course, :primary, :unpublished)
           end,
+          %i[resulting_in_qts] => -> do
+            FactoryBot.create(:course, :resulting_in_qts)
+          end,
+          %i[resulting_in_pgce_with_qts] => -> do
+            FactoryBot.create(:course, :resulting_in_pgce_with_qts)
+          end,
+          %i[resulting_in_pgde_with_qts] => -> do
+            FactoryBot.create(:course, :resulting_in_pgde_with_qts)
+          end,
+          %i[resulting_in_pgce] => -> do
+            FactoryBot.create(:course, :resulting_in_pgce)
+          end,
+          %i[resulting_in_pgde] => -> do
+            FactoryBot.create(:course, :resulting_in_pgde)
+          end,
       }
     end
 


### PR DESCRIPTION
### Context

Find needs to be able to display a list of currently available courses and filter them by various filters.

### Changes proposed in this pull request

* Add scopes to `Course` to enable filtering
* Add a `CourseSearch` service that builds a `Course` scope based on the provided filter parameters.
* Add `/api/v3/recruitment_cycle/<year>/courses` endpoint
* Add indexes to `course_site` table for the enums on `SiteStatus`

### Guidance to review

Filter params are passed in the following format:

`/api/v3/recruitment_cycle/<year>/courses?filter[salary]=true&filter[qualifications]=pgce,pgde`

Out of scope in this PR

* Only returning 'published' courses
* Location filtering

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
