### PR TITLE
2855 add filtering for courses to api part 2

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -153,6 +153,10 @@ class Course < ApplicationRecord
       .not(SiteStatus.table_name => { status: SiteStatus.statuses[:new_status] })
   end
 
+  scope :published, -> do
+    where(id: CourseEnrichment.published.select(:course_id))
+  end
+
   scope :with_recruitment_cycle, ->(year) { joins(provider: :recruitment_cycle).where(recruitment_cycle: { year: year }) }
   scope :findable, -> { where(id: SiteStatus.findable.select(:course_id)) }
   scope :with_vacancies, -> { where(id: SiteStatus.with_vacancies.select(:course_id)) }

--- a/app/services/course_search.rb
+++ b/app/services/course_search.rb
@@ -13,6 +13,7 @@ class CourseSearch
   def call
     scope = Course
       .findable
+      .published
       .with_recruitment_cycle(recruitment_cycle_year)
 
     scope = scope.with_salary if funding_filter_salary?

--- a/app/services/course_search.rb
+++ b/app/services/course_search.rb
@@ -1,0 +1,50 @@
+class CourseSearch
+  def initialize(filter:, recruitment_cycle_year: Settings.current_recruitment_cycle_year)
+    @filter = filter || {}
+    @recruitment_cycle_year = recruitment_cycle_year
+  end
+
+  class << self
+    def call(**args)
+      new(args).call
+    end
+  end
+
+  def call
+    scope = Course
+      .findable
+      .with_recruitment_cycle(recruitment_cycle_year)
+
+    scope = scope.with_salary if funding_filter_salary?
+    scope = scope.with_qualifications(qualifications) if qualifications.any?
+    scope = scope.with_vacancies if has_vacancies?
+    scope = scope.with_study_modes(study_types) if study_types.any?
+    scope
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :filter, :recruitment_cycle_year
+
+  def funding_filter_salary?
+    filter[:funding] == "salary"
+  end
+
+  def qualifications
+    return [] if filter[:qualification].blank?
+
+    filter[:qualification].split(",")
+  end
+
+  def has_vacancies?
+    filter[:has_vacancies].to_s.downcase == "true"
+  end
+
+  def study_types
+    return [] if filter[:study_type].blank?
+
+    filter[:study_type].split(",")
+  end
+end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -88,6 +88,7 @@ describe CourseEnrichment, type: :model do
   end
 
   describe "about_course attribute" do
+
     let(:about_course_text) { "this course is great" }
 
     subject { build :course_enrichment, about_course: about_course_text }

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -88,7 +88,6 @@ describe CourseEnrichment, type: :model do
   end
 
   describe "about_course attribute" do
-
     let(:about_course_text) { "this course is great" }
 
     subject { build :course_enrichment, about_course: about_course_text }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -392,6 +392,73 @@ describe Course, type: :model do
   end
 
   describe "scopes" do
+    describe ".published" do
+      subject { described_class.published }
+      let(:test_course) { create(:course, enrichments: enrichments) }
+
+      before do
+        test_course
+      end
+
+      context "when initial draft course" do
+        let(:enrichments) { [build(:course_enrichment, :initial_draft)] }
+
+        it "is not returned" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when draft course" do
+        let(:enrichments) { [build(:course_enrichment)] }
+
+        it "is not returned" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when rolled over course" do
+        let(:enrichments) { [build(:course_enrichment, :rolled_over)] }
+
+        it "is not returned" do
+          expect(subject).to be_empty
+        end
+      end
+
+      context "when published" do
+        let(:enrichments) { [build(:course_enrichment, :published)] }
+
+        it "is returned" do
+          expect(subject).to contain_exactly(test_course)
+        end
+      end
+
+      context "when there are multiple enrichments" do
+        context "published is present" do
+          let(:enrichments) { [build(:course_enrichment, :published)] }
+
+          before do
+            test_course.enrichments << build(:course_enrichment, :withdrawn)
+          end
+
+          it "is returned" do
+            expect(subject).to contain_exactly(test_course)
+          end
+        end
+
+        context "and published not present" do
+          let(:enrichments) { [build(:course_enrichment, :withdrawn)] }
+
+          before do
+            test_course.enrichments << build(:course_enrichment, :initial_draft)
+          end
+
+          it "is not returned" do
+            expect(subject).to be_empty
+          end
+        end
+      end
+    end
+
     describe ".with_recruitment_cycle" do
       subject { described_class.with_recruitment_cycle(provider.recruitment_cycle.year) }
       let(:test_course) { create(:course, provider: provider) }

--- a/spec/services/course_search_spec.rb
+++ b/spec/services/course_search_spec.rb
@@ -6,11 +6,15 @@ RSpec.describe CourseSearch do
 
     let(:recruitment_cycle_year) { "2020" }
     let(:findable_scope) { class_double(Course) }
-    let(:findable_and_current_scope) { class_double(Course) }
+    let(:findable_and_published_scope) { class_double(Course) }
+    let(:findable_published_and_current_scope) { class_double(Course) }
 
     before do
       allow(Course).to receive(:findable).and_return(findable_scope)
-      allow(findable_scope).to receive(:with_recruitment_cycle).and_return(findable_and_current_scope)
+      allow(findable_scope).to receive(:published).and_return(findable_and_published_scope)
+      allow(findable_and_published_scope)
+        .to receive(:with_recruitment_cycle)
+        .and_return(findable_published_and_current_scope)
     end
 
     context "no recruitment cycle year passed" do
@@ -23,7 +27,7 @@ RSpec.describe CourseSearch do
       end
 
       it "uses the current year" do
-        expect(findable_scope).to receive(:with_recruitment_cycle)
+        expect(findable_and_published_scope).to receive(:with_recruitment_cycle)
           .with(expected_year)
         subject
       end
@@ -33,7 +37,7 @@ RSpec.describe CourseSearch do
       let(:filter) { nil }
 
       it "returns all" do
-        expect(subject).to eq(findable_and_current_scope)
+        expect(subject).to eq(findable_published_and_current_scope)
       end
     end
 
@@ -42,9 +46,9 @@ RSpec.describe CourseSearch do
       let(:filter) { nil }
 
       it "scopes the correct recruitment cycle" do
-        expect(findable_scope).to receive(:with_recruitment_cycle)
+        expect(findable_and_published_scope).to receive(:with_recruitment_cycle)
           .with(recruitment_cycle_year)
-          .and_return(findable_and_current_scope)
+          .and_return(findable_published_and_current_scope)
         subject
       end
     end
@@ -55,7 +59,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_salary scope" do
-          expect(findable_and_current_scope).to receive(:with_salary).and_return(expected_scope)
+          expect(findable_published_and_current_scope).to receive(:with_salary).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
@@ -64,8 +68,8 @@ RSpec.describe CourseSearch do
         let(:filter) { { funding: "all" } }
 
         it "doesn't add the with_salary scope" do
-          expect(findable_and_current_scope).not_to receive(:with_salary)
-          expect(subject).to eq(findable_and_current_scope)
+          expect(findable_published_and_current_scope).not_to receive(:with_salary)
+          expect(subject).to eq(findable_published_and_current_scope)
         end
       end
     end
@@ -76,7 +80,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_qualifications scope" do
-          expect(findable_and_current_scope)
+          expect(findable_published_and_current_scope)
             .to receive(:with_qualifications)
             .with(%w(pgde pgce_with_qts pgde_with_qts qts pgce))
             .and_return(expected_scope)
@@ -89,10 +93,10 @@ RSpec.describe CourseSearch do
         let(:filter) { {} }
 
         it "adds the with_qualifications scope" do
-          expect(findable_and_current_scope)
+          expect(findable_published_and_current_scope)
             .not_to receive(:with_qualifications)
 
-          expect(subject).to eq(findable_and_current_scope)
+          expect(subject).to eq(findable_published_and_current_scope)
         end
       end
     end
@@ -103,7 +107,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_vacancies scope" do
-          expect(findable_and_current_scope).to receive(:with_vacancies).and_return(expected_scope)
+          expect(findable_published_and_current_scope).to receive(:with_vacancies).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
@@ -112,8 +116,8 @@ RSpec.describe CourseSearch do
         let(:filter) { { has_vacancies: false } }
 
         it "adds the with_vacancies scope" do
-          expect(findable_and_current_scope).not_to receive(:with_vacancies)
-          expect(subject).to eq(findable_and_current_scope)
+          expect(findable_published_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_published_and_current_scope)
         end
       end
 
@@ -121,8 +125,8 @@ RSpec.describe CourseSearch do
         let(:filter) { {} }
 
         it "doesn't add the with_vacancies scope" do
-          expect(findable_and_current_scope).not_to receive(:with_vacancies)
-          expect(subject).to eq(findable_and_current_scope)
+          expect(findable_published_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_published_and_current_scope)
         end
       end
     end
@@ -133,7 +137,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_study_modes scope" do
-          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(full_time)).and_return(expected_scope)
+          expect(findable_published_and_current_scope).to receive(:with_study_modes).with(%w(full_time)).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
@@ -143,7 +147,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_study_modes scope" do
-          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
+          expect(findable_published_and_current_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
@@ -153,7 +157,7 @@ RSpec.describe CourseSearch do
         let(:expected_scope) { double }
 
         it "adds the with_study_modes scope with an array of both arguments" do
-          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(expected_scope)
+          expect(findable_published_and_current_scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
@@ -162,8 +166,8 @@ RSpec.describe CourseSearch do
         let(:filter) { {} }
 
         it "doesn't add the scope" do
-          expect(findable_and_current_scope).not_to receive(:with_study_modes)
-          expect(subject).to eq(findable_and_current_scope)
+          expect(findable_published_and_current_scope).not_to receive(:with_study_modes)
+          expect(subject).to eq(findable_published_and_current_scope)
         end
       end
     end
@@ -174,7 +178,7 @@ RSpec.describe CourseSearch do
       let(:expected_scope) { double }
 
       it "combines scopes" do
-        expect(findable_and_current_scope).to receive(:with_salary).and_return(salary_scope)
+        expect(findable_published_and_current_scope).to receive(:with_salary).and_return(salary_scope)
         expect(salary_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
         expect(subject).to eq(expected_scope)
       end

--- a/spec/services/course_search_spec.rb
+++ b/spec/services/course_search_spec.rb
@@ -1,0 +1,183 @@
+require "rails_helper"
+
+RSpec.describe CourseSearch do
+  describe ".call" do
+    subject { described_class.call(filter: filter, recruitment_cycle_year: recruitment_cycle_year) }
+
+    let(:recruitment_cycle_year) { "2020" }
+    let(:findable_scope) { class_double(Course) }
+    let(:findable_and_current_scope) { class_double(Course) }
+
+    before do
+      allow(Course).to receive(:findable).and_return(findable_scope)
+      allow(findable_scope).to receive(:with_recruitment_cycle).and_return(findable_and_current_scope)
+    end
+
+    context "no recruitment cycle year passed" do
+      subject { described_class.call(filter: {}) }
+      let(:expected_year) { "2000" }
+
+      before do
+        allow(Settings).to receive(:current_recruitment_cycle_year)
+          .and_return(expected_year)
+      end
+
+      it "uses the current year" do
+        expect(findable_scope).to receive(:with_recruitment_cycle)
+          .with(expected_year)
+        subject
+      end
+    end
+
+    describe "filter is nil" do
+      let(:filter) { nil }
+
+      it "returns all" do
+        expect(subject).to eq(findable_and_current_scope)
+      end
+    end
+
+    describe "passed recruitment cycle" do
+      let(:recruitment_cycle_year) { "2021" }
+      let(:filter) { nil }
+
+      it "scopes the correct recruitment cycle" do
+        expect(findable_scope).to receive(:with_recruitment_cycle)
+          .with(recruitment_cycle_year)
+          .and_return(findable_and_current_scope)
+        subject
+      end
+    end
+
+    describe "filter[funding]" do
+      context "when value is salary" do
+        let(:filter) { { funding: "salary" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_salary scope" do
+          expect(findable_and_current_scope).to receive(:with_salary).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when value is all" do
+        let(:filter) { { funding: "all" } }
+
+        it "doesn't add the with_salary scope" do
+          expect(findable_and_current_scope).not_to receive(:with_salary)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[qualification]" do
+      context "when qualifications passed" do
+        let(:filter) { { qualification: "pgde,pgce_with_qts,pgde_with_qts,qts,pgce" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_qualifications scope" do
+          expect(findable_and_current_scope)
+            .to receive(:with_qualifications)
+            .with(%w(pgde pgce_with_qts pgde_with_qts qts pgce))
+            .and_return(expected_scope)
+
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when no qualifications passed" do
+        let(:filter) { {} }
+
+        it "adds the with_qualifications scope" do
+          expect(findable_and_current_scope)
+            .not_to receive(:with_qualifications)
+
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[with_vacancies]" do
+      context "when true" do
+        let(:filter) { { has_vacancies: true } }
+        let(:expected_scope) { double }
+
+        it "adds the with_vacancies scope" do
+          expect(findable_and_current_scope).to receive(:with_vacancies).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when false" do
+        let(:filter) { { has_vacancies: false } }
+
+        it "adds the with_vacancies scope" do
+          expect(findable_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the with_vacancies scope" do
+          expect(findable_and_current_scope).not_to receive(:with_vacancies)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "filter[study_type]" do
+      context "when full_time" do
+        let(:filter) { { study_type: "full_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(full_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when part_time" do
+        let(:filter) { { study_type: "part_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when both" do
+        let(:filter) { { study_type: "part_time,full_time" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_study_modes scope with an array of both arguments" do
+          expect(findable_and_current_scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the scope" do
+          expect(findable_and_current_scope).not_to receive(:with_study_modes)
+          expect(subject).to eq(findable_and_current_scope)
+        end
+      end
+    end
+
+    describe "multiple filters" do
+      let(:filter) { { study_type: "part_time", funding: "salary" } }
+      let(:salary_scope) { double }
+      let(:expected_scope) { double }
+
+      it "combines scopes" do
+        expect(findable_and_current_scope).to receive(:with_salary).and_return(salary_scope)
+        expect(salary_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(expected_scope)
+        expect(subject).to eq(expected_scope)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

The courses endpoint should only return published courses. In this context a 'published' course is one that has its most recent associated `CourseEnrichment` in `published` state.

### Changes proposed in this pull request

* Add `Course.published` scope. This delegates the 'what is published' stuff to `CourseEnrichment`. I think that's the right place for it but it's tricky to get a chainable scope back from `CourseEnrichment.current_published`. I tried variations on SQL and Arel but it either didn't work or was super slow. This seems to work ok but the `group` calls need to be 'creatively' namespaced.
* Add the `published` scope into `CourseSearch`

### Guidance to review

This is on top of #1142 which is still in review and likely to change. The CI failures aren't directly related to this work. I'm looking at those separately.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
