### PR TITLE
[2907] Require first/last name in user model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,8 @@ class User < ApplicationRecord
 
   validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }
   validate :email_is_lowercase
+  validates :first_name, presence: true
+  validates :last_name, presence: true
 
   validates :email, if: :admin?, format: {
     with: /\A.*@(digital\.){0,1}education\.gov\.uk\z/,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -35,6 +35,12 @@ describe User, type: :model do
     it { is_expected.to validate_presence_of(:email).with_message("must contain @") }
     it { should_not allow_value("CAPS_IN_EMAIL@ACME.ORG").for(:email) }
     it { should_not allow_value("email_without_at").for(:email) }
+    it { should_not allow_value(nil).for(:first_name) }
+    it { should_not allow_value(nil).for(:last_name) }
+    it { should_not allow_value("").for(:first_name) }
+    it { should_not allow_value("").for(:last_name) }
+    it { should_not allow_value("  ").for(:first_name) }
+    it { should_not allow_value("  ").for(:last_name) }
 
     context "for an admin-user" do
       subject { create(:user, :admin) }


### PR DESCRIPTION
### Context

We get late failures when trying to send the welcome email.

Adding the valuation will flush out whatever is incorrectly setting
these to nil.

I believe this has affected our provider users too.

### Changes proposed in this pull request

[2907] Require first/last name in user model

#### before

```
tim@fox:~/repo/dfe/teacher-training-api(master)
$ bin/mcb users grant wibble@timwise.co.uk
Audit user: Tim Abell <tim.abell@digital.education.gov.uk>
wibble@timwise.co.uk appears to be a new user
First name?  
Last name?  
User:
+------------------------+----------------------+
| id                     |                      |
| email                  | wibble@timwise.co.uk |
| first_name             |                      |
| last_name              |                      |
| first_login_date_utc   |                      |
| last_login_date_utc    |                      |
| sign_in_user_id        |                      |
| welcome_email_date_utc |                      |
| invite_date_utc        |                      |
| accept_terms_date_utc  |                      |
| state                  | new                  |
| admin                  | false                |
+------------------------+----------------------+

Has access to providers:
-none-
...
```
#### after

```
tim@fox:~/repo/dfe/teacher-training-api(2907-bug-welcome-fails-with-nil-firstname-add-model-validations)
$ bin/mcb users grant wibble@timwise.co.uk                                                                                    
Audit user: Tim Abell <tim.abell@digital.education.gov.uk>
wibble@timwise.co.uk appears to be a new user
First name?  
Last name?  
User:
+------------------------+----------------------+
| id                     |                      |
| email                  | wibble@timwise.co.uk |
| first_name             |                      |
| last_name              |                      |
| first_login_date_utc   |                      |
| last_login_date_utc    |                      |
| sign_in_user_id        |                      |
| welcome_email_date_utc |                      |
| invite_date_utc        |                      |
| accept_terms_date_utc  |                      |
| state                  | new                  |
| admin                  | false                |
+------------------------+----------------------+

Has access to providers:
-none-
Cannot create this user:
- First name can't be blank
- Last name can't be blank
```


### Guidance to review

~~Think of reasons why this is a bad idea and reject the PR~~ :ship: 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally