### PR TITLE
[2827] Clear modern language cache

### DIFF
--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -9,7 +9,10 @@ describe Courses::GenerateCourseNameService do
   let(:modern_languages) { find_or_create(:secondary_subject, :modern_languages) }
   let(:generated_title) { service.execute(course: course) }
 
-  before { modern_languages }
+  before do
+    SecondarySubject.clear_modern_languages_cache
+    modern_languages
+  end
 
   shared_examples "with SEND" do
     context "With SEND" do


### PR DESCRIPTION
This is being cached on the class and so bleeds between specs. Card
added to fix but this will unflakiness the specs in the meantime.

### Context

The spec/services/courses/generate_course_name_service_spec.rb are failing intermittently on various builds [(example)](https://dfe-ssp.visualstudio.com/Become-A-Teacher/_build/results?buildId=43165&view=ms.vss-test-web.build-test-results-tab&runId=1148374&resultId=101092&paneView=debug) 

There is caching on the Secondary subject but the value is cached on the class so it is bleeding across specs.

This change is temporary to get PRs through CI for now. I've added another card to fix the cacheing to work properly.

### Changes proposed in this pull request

* Clear the modern languages cache before each course name spec

### Guidance to review

The failures are intermittent and only happen when the full suite is run so this is tricky to manually test. Hopefully the code should be self explanatory.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
