### PR TITLE
208-Parameterised PSQL DB autogrowth

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -91,6 +91,14 @@
         "description": "The password used to connect to the database."
       }
     },
+    "databaseStorageAutoGrow": {
+      "type": "string",
+      "allowedValues": [ "enabled", "disabled" ],
+      "defaultValue": "disabled",
+      "metadata": {
+        "description": "Used to configure autogrow for database storage. If enabled database storage will automatically be increased by 5GB when the free storage is below the greater of 1GB or 10% of the provisioned storage."
+      }
+    },
     "secretKeyBase": {
       "type": "string",
       "metadata": {
@@ -587,6 +595,9 @@
           },
           "resourceTags":{
             "value": "[parameters('resourceTags')]"
+          },
+          "storageAutoGrow": {
+            "value": "[parameters('databaseStorageAutoGrow')]"
           }
         }
       },


### PR DESCRIPTION
### Context
When a server reaches the allocated storage limit, the server is marked as read-only. However, if we enable storage auto grow, the server storage increases to accommodate the growing data
 
### Guidance to review
Allow enable/disable of PSQL DB storage auto growth through a parameter/pipeline variable 

### Checklist
https://trello.com/c/sgCZ91FB/208-auto-growth-for-postgresql-databases
