### PR TITLE
[2859] Basic seperation of modern language subjects and subjects

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -31,7 +31,7 @@ module API
           include: [:subjects, :sites, :accrediting_provider, :provider, provider: [:sites]],
         )
 
-        if !@current_user.admin?
+        unless @current_user.admin?
           json_data[:data][:meta][:edit_options][:subjects]&.reject! do |subject|
             subject[:attributes][:subject_name] == "Physical education"
           end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -104,6 +104,11 @@ class Course < ApplicationRecord
            -> { distinct.merge(SiteStatus.where(status: %i[new_status running])) },
            through: :site_statuses
 
+  has_many :modern_languages_subjects,
+           through: :course_subjects,
+           source: :subject,
+           class_name: "ModernLanguagesSubject"
+
   has_many :enrichments,
            class_name: "CourseEnrichment" do
     def find_or_initialize_draft
@@ -607,7 +612,7 @@ private
 
   def validate_has_languages
     unless has_any_modern_language_subject_type?
-      errors.add(:subjects, :select_a_language)
+      errors.add(:modern_languages_subjects, :select_a_language)
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
             subjects:
               blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
               course_creation: "^You must pick at least one subject"
+            modern_languages_subjects:
               select_a_language: "^You must pick at least one language"
             study_mode:
               blank: "^You need to pick an option"

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -61,17 +61,24 @@ describe Course, type: :model do
 
   describe "associations" do
     it { should belong_to(:provider) }
-    it {
+    it do
       should belong_to(:accrediting_provider)
                   .with_foreign_key(:accrediting_provider_code)
                   .with_primary_key(:provider_code)
                   .optional
-    }
+    end
     it { should have_many(:subjects).through(:course_subjects) }
     it { should have_many(:site_statuses) }
     it { should have_many(:sites) }
     it { should have_many(:enrichments) }
     it { should have_many(:financial_incentives) }
+  end
+
+  describe "#modern_languages_subjects" do
+    it "gets modern language subjects" do
+      course = create(:course, level: "secondary", subjects: [modern_languages, french])
+      expect(course.modern_languages_subjects).to match_array([french])
+    end
   end
 
   describe "#ensure_modern_languages" do
@@ -139,7 +146,7 @@ describe Course, type: :model do
           let(:course) { Course.new(provider: provider, subjects: [modern_languages]) }
 
           it "Requires a language to be selected" do
-            error = errors[:subjects]
+            error = errors[:modern_languages_subjects]
             expect(error).not_to be_empty
             expect(error.first).to include("You must pick at least one language")
           end
@@ -147,7 +154,7 @@ describe Course, type: :model do
           it "Does not add an error if a language is selected" do
             course.subjects << french
             course.valid?(:new)
-            error = course.errors.messages[:subjects]
+            error = course.errors.messages[:modern_languages_subjects]
             expect(error).to be_empty
           end
         end

--- a/spec/serializers/site_status_serializer_spec.rb
+++ b/spec/serializers/site_status_serializer_spec.rb
@@ -20,7 +20,7 @@
 
 require "rails_helper"
 
-RSpec.describe SiteStatusSerializer do
+describe SiteStatusSerializer do
   subject { serialize(site_status) }
 
   context "when the site status has some vacancies" do


### PR DESCRIPTION
### Context
The subjects page is unable to select modern languages because the validation for modern languages is triggered

### Changes proposed in this pull request
Separate the error for modern languages being missing from other subject errors and create a method for retrieving modern language subjects only.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
