### PR TITLE
[2918] Increase valid age range possibilities

### DIFF
--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -26,11 +26,11 @@ module Courses
     end
 
     def from_age_invalid?(from_age)
-      from_age < 3 || from_age > 14
+      from_age < 3 || from_age > 15
     end
 
     def to_age_invalid?(to_age)
-      to_age < 7 || to_age > 18
+      to_age < 7 || to_age > 19
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -89,7 +89,7 @@ describe "POST /providers/:provider_code/courses/:course_code" do
     end
 
     context "with a to value that does not fall within the valid age range" do
-      let(:age_range_in_years) { "7_to_19" }
+      let(:age_range_in_years) { "7_to_20" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -38,7 +38,7 @@ describe Courses::ValidateCustomAgeRangeService do
     end
 
     context "with a to value that does not fall within the valid age range" do
-      let(:age_range_in_years) { "7_to_19" }
+      let(:age_range_in_years) { "7_to_20" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"


### PR DESCRIPTION
### Context

An option for age ranges on the frontend did not pass validation

### Changes proposed in this pull request

Increase the validation range to support the option the user can select

### Guidance to review

- Create a secondary course on course creation flow
- Select "14 to 19" 
- Press continue

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
