### PR TITLE
[2906] Add a migration to fix subject areas naming

### DIFF
--- a/app/services/subjects/subject_area_creator_service.rb
+++ b/app/services/subjects/subject_area_creator_service.rb
@@ -7,8 +7,8 @@ module Subjects
     def execute
       @subject_area.find_or_create_by!(typename: "PrimarySubject", name: "Primary")
       @subject_area.find_or_create_by!(typename: "SecondarySubject", name: "Secondary")
-      @subject_area.find_or_create_by!(typename: "ModernLanguagesSubject", name: "Secondary: Modern Languages")
-      @subject_area.find_or_create_by!(typename: "FurtherEducationSubject", name: "Further Education")
+      @subject_area.find_or_create_by!(typename: "ModernLanguagesSubject", name: "Secondary: Modern languages")
+      @subject_area.find_or_create_by!(typename: "FurtherEducationSubject", name: "Further education")
       @subject_area.find_or_create_by!(typename: "DiscontinuedSubject", name: "Discontinued")
     end
   end

--- a/db/migrate/20200207094915_fix_subject_area_name_cases.rb
+++ b/db/migrate/20200207094915_fix_subject_area_name_cases.rb
@@ -1,0 +1,8 @@
+class FixSubjectAreaNameCases < ActiveRecord::Migration[6.0]
+  def up
+    say_with_time "fixing the subject areas naming case" do
+      SubjectArea.where(name: "Secondary: Modern Languages").update(name: "Secondary: Modern languages")
+      SubjectArea.where(name: "Further Education").update(name: "Further education")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_31_104849) do
+ActiveRecord::Schema.define(version: 2020_02_07_094915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"

--- a/spec/requests/api/v3/subject_areas/index_spec.rb
+++ b/spec/requests/api/v3/subject_areas/index_spec.rb
@@ -44,7 +44,7 @@ describe "GET v3 /subject-areas" do
         "id" => "ModernLanguagesSubject",
         "type" => "subject_areas",
         "attributes" => {
-          "name" => "Secondary: Modern Languages",
+          "name" => "Secondary: Modern languages",
           "typename" => "ModernLanguagesSubject",
         },
         "relationships" => {
@@ -59,7 +59,7 @@ describe "GET v3 /subject-areas" do
         "id" => "FurtherEducationSubject",
         "type" => "subject_areas",
         "attributes" => {
-          "name" => "Further Education",
+          "name" => "Further education",
           "typename" => "FurtherEducationSubject",
         },
         "relationships" => {

--- a/spec/services/subjects/populate_subject_areas_service_spec.rb
+++ b/spec/services/subjects/populate_subject_areas_service_spec.rb
@@ -6,8 +6,8 @@ describe Subjects::SubjectAreaCreatorService do
     service.execute
     expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "PrimarySubject", name: "Primary")
     expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "SecondarySubject", name: "Secondary")
-    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "ModernLanguagesSubject", name: "Secondary: Modern Languages")
-    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "FurtherEducationSubject", name: "Further Education")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "ModernLanguagesSubject", name: "Secondary: Modern languages")
+    expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "FurtherEducationSubject", name: "Further education")
     expect(subject_area_spy).to have_received(:find_or_create_by!).with(typename: "DiscontinuedSubject", name: "Discontinued")
   end
 end


### PR DESCRIPTION
### Context

The names of two subjects areas have incorrect casing.

### Changes proposed in this pull request
Change the names of those subject areas so they appear correctly in Find:
* Secondary: Modern `L`anguages => Secondary: Modern `l`anguages
* Further `E`ducation => Further `e`ducation

**Before:**
<img width="481" alt="before" src="https://user-images.githubusercontent.com/38078064/74023360-65800700-4997-11ea-8712-1920feca4644.png">

**After:**
<img width="510" alt="after" src="https://user-images.githubusercontent.com/38078064/74023443-96603c00-4997-11ea-9c4f-22f339b1cb1f.png">


### Guidance to review
* run migration in teacher-training-api: `bundle exec rails db:migrate RAILS_ENV=development`
* visit http://localhost:3002/results/filter/subject

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
