### PR TITLE
2925 test azure redis cache with tls12

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -783,7 +783,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'), 'redis.json')]",
+          "uri": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/a5e576ce4bded47db318ec9939d357ff724b2741/templates/redis.json",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -795,6 +795,9 @@
           },
           "resourceTags":{
             "value": "[parameters('resourceTags')]"
+          },
+          "minimumTlsVersion":{
+            "value": "1.2"
           }
         }
       }

--- a/azure/template.json
+++ b/azure/template.json
@@ -783,7 +783,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/a5e576ce4bded47db318ec9939d357ff724b2741/templates/redis.json",
+          "uri": "[concat(variables('deploymentUrlBase'), 'redis.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {


### PR DESCRIPTION
### Context
Microsoft is disabling TLS 1.0 and 1.1 from Azure Redis Cache on 31st March.

### Changes proposed in this pull request
Update ARM template and enable TLS1.2 for Azure Redis Cache

### Guidance to review
Apply the changes on QA and Staging initially to ensure Rails code is compatible with TLS1.2.
https://docs.microsoft.com/en-gb/azure/azure-cache-for-redis/cache-remove-tls-10-11

### Checklist
https://trello.com/c/pOTczm7C/2925-test-azure-redis-cache-with-tls12