### PR TITLE
[2905] Add subject_knowledge_enhancement_course_available attribute

### DIFF
--- a/app/serializers/api/v2/serializable_subject.rb
+++ b/app/serializers/api/v2/serializable_subject.rb
@@ -16,6 +16,10 @@ module API
       attribute :scholarship do
         @object.financial_incentive&.scholarship
       end
+
+      attribute :subject_knowledge_enhancement_course_available do
+        @object.financial_incentive&.subject_knowledge_enhancement_course_available
+      end
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -169,6 +169,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                      {
@@ -180,6 +181,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                      {
@@ -191,6 +193,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                      {
@@ -202,6 +205,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => "6000",
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => true,
                        },
                      },
                      {
@@ -213,6 +217,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                      {
@@ -224,6 +229,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                      {
@@ -235,6 +241,7 @@ describe "Courses API v2", type: :request do
                          "bursary_amount" => nil,
                          "early_career_payments" => nil,
                          "scholarship" => nil,
+                         "subject_knowledge_enhancement_course_available" => nil,
                        },
                      },
                   ],
@@ -273,6 +280,7 @@ describe "Courses API v2", type: :request do
                   "bursary_amount" => "6000",
                   "early_career_payments" => nil,
                   "scholarship" => nil,
+                  "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -340,6 +348,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => "28000",
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -351,6 +360,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => nil,
                  "early_career_payments" => nil,
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => nil,
                 },
               },
               {
@@ -362,6 +372,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => "28000",
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -373,6 +384,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -384,6 +396,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -395,6 +408,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -406,6 +420,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -417,6 +432,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => "28000",
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
               {
@@ -428,6 +444,7 @@ describe "Courses API v2", type: :request do
                  "bursary_amount" => "26000",
                  "early_career_payments" => "2000",
                  "scholarship" => nil,
+                 "subject_knowledge_enhancement_course_available" => true,
                 },
               },
             ],
@@ -573,6 +590,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                   {
@@ -584,6 +602,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                   {
@@ -595,6 +614,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                   {
@@ -606,6 +626,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => "6000",
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => true,
                     },
                   },
                   {
@@ -617,6 +638,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                   {
@@ -628,6 +650,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                   {
@@ -639,6 +662,7 @@ describe "Courses API v2", type: :request do
                       "bursary_amount" => nil,
                       "early_career_payments" => nil,
                       "scholarship" => nil,
+                      "subject_knowledge_enhancement_course_available" => nil,
                     },
                   },
                 ],

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -157,6 +157,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                         "bursary_amount" => nil,
                         "early_career_payments" => nil,
                         "scholarship" => nil,
+                        "subject_knowledge_enhancement_course_available" => nil,
                       },
                      },
                     {
@@ -168,6 +169,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -179,6 +181,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -190,6 +193,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => "6000",
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => true,
                      },
                     },
                     {
@@ -201,6 +205,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -212,6 +217,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -223,6 +229,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
   },
                    },
                   ],
@@ -345,6 +352,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                         "bursary_amount" => nil,
                         "early_career_payments" => nil,
                         "scholarship" => nil,
+                        "subject_knowledge_enhancement_course_available" => nil,
                       },
                      },
                     {
@@ -356,6 +364,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -367,6 +376,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -378,6 +388,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => "6000",
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => true,
                      },
                     },
                     {
@@ -389,6 +400,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -400,6 +412,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
                      },
                     },
                     {
@@ -411,6 +424,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                        "bursary_amount" => nil,
                        "early_career_payments" => nil,
                        "scholarship" => nil,
+                       "subject_knowledge_enhancement_course_available" => nil,
   },
                    },
                   ],

--- a/spec/serializers/api/v2/serializable_subject_spec.rb
+++ b/spec/serializers/api/v2/serializable_subject_spec.rb
@@ -19,14 +19,16 @@ describe API::V2::SerializableSubject do
     it { should have_attribute(:bursary_amount).with_value(nil) }
     it { should have_attribute(:early_career_payments).with_value(nil) }
     it { should have_attribute(:scholarship).with_value(nil) }
+    it { should have_attribute(:subject_knowledge_enhancement_course_available).with_value(nil) }
   end
 
-  context "when a bursary subject" do
+  context "when a bursary subject with subject knowledge enhancement course available" do
     let(:bursary_subject) { find_or_create(:secondary_subject, :mathematics) }
     let(:resource) { API::V2::SerializableSubject.new object: bursary_subject }
 
     it { should have_attribute(:bursary_amount).with_value(bursary_subject.financial_incentive.bursary_amount) }
     it { should have_attribute(:early_career_payments).with_value(bursary_subject.financial_incentive.early_career_payments) }
     it { should have_attribute(:scholarship).with_value(bursary_subject.financial_incentive.scholarship) }
+    it { should have_attribute(:subject_knowledge_enhancement_course_available).with_value(true) }
   end
 end


### PR DESCRIPTION
### Context
We need to display information on Subject Knowledge Enhancement (SKE) course availability on subject filter page in Find. 

### Changes proposed in this pull request

Add `subject_knowledge_enhancement_course_available` to Serializable Subject attributes

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
