### PR TITLE
[2958] Add ability to sort by provider name on v3 course endpoint

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -6,13 +6,7 @@ module API
       before_action :build_courses
 
       def index
-        course_search = CourseSearchService.call(filter: params[:filter], course_scope: @courses)
-
-        if should_sort_by_provider_ascending?
-          course_search = sort_by_provider_ascending(course_search: course_search)
-        elsif should_sort_by_provider_descending?
-          course_search = sort_by_provider_descending(course_search: course_search)
-        end
+        course_search = CourseSearchService.call(filter: params[:filter], sort: params[:sort], course_scope: @courses)
 
         render jsonapi: paginate(course_search), fields: fields_param, include: params[:include], class: CourseSerializersService.new.execute
       end
@@ -29,22 +23,6 @@ module API
       end
 
     private
-
-      def sort_by_provider_ascending(course_search:)
-        course_search.order("provider.provider_name asc")
-      end
-
-      def sort_by_provider_descending(course_search:)
-        course_search.order("provider.provider_name desc")
-      end
-
-      def should_sort_by_provider_ascending?
-        params["sort"] == "provider.provider_name"
-      end
-
-      def should_sort_by_provider_descending?
-        params["sort"] == "-provider.provider_name"
-      end
 
       def build_courses
         @courses = if @provider.present?

--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -7,6 +7,13 @@ module API
 
       def index
         course_search = CourseSearchService.call(filter: params[:filter], course_scope: @courses)
+
+        if should_sort_by_provider_ascending?
+          course_search = sort_by_provider_ascending(course_search: course_search)
+        elsif should_sort_by_provider_descending?
+          course_search = sort_by_provider_descending(course_search: course_search)
+        end
+
         render jsonapi: paginate(course_search), fields: fields_param, include: params[:include], class: CourseSerializersService.new.execute
       end
 
@@ -22,6 +29,22 @@ module API
       end
 
     private
+
+      def sort_by_provider_ascending(course_search:)
+        course_search.order("provider.provider_name asc")
+      end
+
+      def sort_by_provider_descending(course_search:)
+        course_search.order("provider.provider_name desc")
+      end
+
+      def should_sort_by_provider_ascending?
+        params["sort"] == "provider.provider_name"
+      end
+
+      def should_sort_by_provider_descending?
+        params["sort"] == "-provider.provider_name"
+      end
 
       def build_courses
         @courses = if @provider.present?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -139,6 +139,9 @@ class Course < ApplicationRecord
     end
   end
 
+  scope :by_provider_name_ascending, -> { includes(:provider).order("provider.provider_name asc") }
+  scope :by_provider_name_descending, -> { includes(:provider).order("provider.provider_name desc") }
+
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
       where("course.changed_at > ?", timestamp)

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -1,7 +1,8 @@
 class CourseSearchService
-  def initialize(filter:, course_scope: Course)
+  def initialize(filter:, sort: nil, course_scope: Course)
     @filter = filter || {}
     @course_scope = course_scope
+    @sort = sort
   end
 
   class << self
@@ -13,6 +14,9 @@ class CourseSearchService
   def call
     scope = course_scope.findable
 
+    scope = scope.by_provider_name_ascending if sort_by_provider_ascending?
+    scope = scope.by_provider_name_descending if sort_by_provider_descending?
+
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.with_vacancies if has_vacancies?
@@ -23,6 +27,14 @@ class CourseSearchService
   private_class_method :new
 
 private
+
+  def sort_by_provider_ascending?
+    @sort == "provider.provider_name"
+  end
+
+  def sort_by_provider_descending?
+    @sort == "-provider.provider_name"
+  end
 
   attr_reader :filter, :course_scope
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -74,6 +74,54 @@ describe Course, type: :model do
     it { should have_many(:financial_incentives) }
   end
 
+  describe "#by_provider_name_ascending" do
+    let(:provider_a) { create(:provider, provider_name: "Provider A") }
+    let(:course_a) do
+      create(:course,
+             name: "Course A",
+             provider: provider_a)
+    end
+
+    let(:provider_b) { create(:provider, provider_name: "Provider B") }
+    let(:course_b) do
+      create(
+        :course,
+        name: "Course A",
+        provider: provider_b,
+      )
+    end
+
+    it "sorts in ascending order of provider name" do
+      course_a
+      course_b
+      expect(described_class.by_provider_name_ascending).to eq([course_a, course_b])
+    end
+  end
+
+  describe "#by_provider_name_descending" do
+    let(:provider_a) { create(:provider, provider_name: "Provider A") }
+    let(:course_a) do
+      create(:course,
+             name: "Course A",
+             provider: provider_a)
+    end
+
+    let(:provider_b) { create(:provider, provider_name: "Provider B") }
+    let(:course_b) do
+      create(
+        :course,
+        name: "Course A",
+        provider: provider_b,
+      )
+    end
+
+    it "sorts in descending order of provider name" do
+      course_a
+      course_b
+      expect(described_class.by_provider_name_descending).to eq([course_b, course_a])
+    end
+  end
+
   describe "#modern_languages_subjects" do
     it "gets modern language subjects" do
       course = create(:course, level: "secondary", subjects: [modern_languages, french])

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -35,7 +35,7 @@ describe "GET v3/courses" do
   let(:findable_status) { build(:site_status, :findable) }
   let(:published_enrichment) { build(:course_enrichment, :published) }
 
-  context "ordering" do
+  describe "ordering" do
     let(:provider_a) { create(:provider, provider_name: "Provider A") }
     let(:course_a) do
       create(:course,
@@ -71,7 +71,6 @@ describe "GET v3/courses" do
         course_hashes = json_response["data"]
         expect(course_hashes.first["id"]).to eq(course_a.id.to_s)
         expect(course_hashes.second["id"]).to eq(course_b.id.to_s)
-        #Course.includes(:provider).order("provider.provider_name")
       end
     end
 
@@ -89,7 +88,7 @@ describe "GET v3/courses" do
     end
   end
 
-  context "without filter params" do
+  describe "without filter params" do
     let(:request_path) { "/api/v3/courses" }
     let(:current_course) do
       create(:course, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)])

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe CourseSearchService do
+describe CourseSearchService do
   describe ".call" do
     describe "when no scope is passed" do
       subject { described_class.call(filter: filter) }
@@ -14,11 +14,42 @@ RSpec.describe CourseSearchService do
 
     let(:scope) { class_double(Course) }
     let(:findable_scope) { class_double(Course) }
+    let(:filter) { nil }
+    let(:sort) { nil }
 
-    subject { described_class.call(filter: filter, course_scope: scope) }
+    subject { described_class.call(filter: filter, sort: sort, course_scope: scope) }
 
     before do
       allow(scope).to receive(:findable).and_return(findable_scope)
+    end
+
+    describe "sort by" do
+      let(:expected_scope) { double }
+
+      context "ascending provider name" do
+        let(:sort) { "provider.provider_name" }
+
+        it "orders in ascending order of provider name" do
+          expect(findable_scope).to receive(:by_provider_name_ascending).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "descending provider name" do
+        let(:sort) { "-provider.provider_name" }
+
+        it "orders in ascending order of provider name" do
+          expect(findable_scope).to receive(:by_provider_name_descending).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "unspecified" do
+        it "does not order" do
+          expect(findable_scope).not_to receive(:order)
+          expect(subject).not_to eq(expected_scope)
+        end
+      end
     end
 
     describe "filter is nil" do


### PR DESCRIPTION
# Context 
Users on Search and Compare can currently sort alphabetically by provider name, in order to provide this functionality for Find we must create an endpoint that supports this behaviour in accordance with JSON API's standards

### Changes proposed in this pull request  

Add an endpoint that supports sorting

### Guidance to review
https://jsonapi.org/format/#fetching-sorting

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
