### PR TITLE
[2949] Fix api v3 latest published enrichment

### DIFF
--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -4,7 +4,10 @@ module API
       class << self
         def enrichment_attribute(name, enrichment_name = name)
           attribute name do
-            @object.enrichments.select(&:published?).last&.__send__(enrichment_name)
+            @object.enrichments
+              .select(&:published?)
+              .max_by { |e| [e.created_at, e.id] }
+              &.__send__(enrichment_name)
           end
         end
       end

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -76,7 +76,14 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   end
 
   context "with sites included" do
-    let(:enrichments) { [build(:course_enrichment, :published)] }
+    let(:enrichments) {
+      [
+      build(:course_enrichment, :initial_draft),
+      build(:course_enrichment, :published, fee_details: "Some details about the fees"),
+      build(:course_enrichment, :subsequent_draft),
+      build(:course_enrichment, :published, fee_details: "Some new details about the fees"),
+    ]
+    }
     let(:enrichment) { course.enrichments.last }
     before do
       get "/api/v3/recruitment_cycles/#{current_year}" \
@@ -110,7 +117,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
               course.applications_open_from.to_s,
             "about_course" => enrichment.about_course,
             "course_length" => enrichment.course_length,
-            "fee_details" => enrichment.fee_details,
+            "fee_details" => "Some new details about the fees",
             "fee_international" => enrichment.fee_international,
             "fee_uk_eu" => enrichment.fee_uk_eu,
             "financial_support" => enrichment.financial_support,

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -76,15 +76,14 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   end
 
   context "with sites included" do
-    let(:enrichments) {
+    let(:enrichments) do
       [
-      build(:course_enrichment, :initial_draft),
-      build(:course_enrichment, :published, fee_details: "Some details about the fees"),
-      build(:course_enrichment, :subsequent_draft),
-      build(:course_enrichment, :published, fee_details: "Some new details about the fees"),
-    ]
-    }
-    let(:enrichment) { course.enrichments.last }
+        build(:course_enrichment, :published, fee_details: "Some details about the fees"),
+        build(:course_enrichment, :published, fee_details: "Some new details about the fees"),
+        build(:course_enrichment, :subsequent_draft),
+      ]
+    end
+    let(:enrichment) { course.enrichments.second }
     before do
       get "/api/v3/recruitment_cycles/#{current_year}" \
           "/providers/#{provider.provider_code.downcase}" \
@@ -108,7 +107,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "study_mode" => "full_time",
             "qualification" => "pgce_with_qts",
             "description" => "PGCE with QTS full time teaching apprenticeship",
-            "content_status" => "published",
+            "content_status" => "published_with_unpublished_changes",
             "ucas_status" => "running",
             "funding_type" => "apprenticeship",
             "is_send?" => false,


### PR DESCRIPTION
### Context
The latest published enrichment isn't always correct because of the order 

### Changes proposed in this pull request
Use `max_by` instead of `last` as per - https://github.com/DFE-Digital/teacher-training-api/blob/master/app/serializers/search_and_compare/course_serializer.rb#L152:L156

### Guidance to review
🚢 

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
