### PR TITLE
[2909] Change course to support ordering of subjects

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -104,6 +104,7 @@ module API
 
         if @course.errors.empty? && @course.valid?
           @course.save
+          @course.course_subjects.each(&:save)
           render jsonapi: @course.reload
         else
           render jsonapi_errors: @course.errors, status: :unprocessable_entity
@@ -167,7 +168,13 @@ module API
       def update_subjects
         return if subject_ids.nil?
 
-        @course.subjects = Subject.where(id: subject_ids)
+        @course.subjects = []
+        @course.subjects = subject_ids.map { |id| Subject.find(id) }
+
+        subject_ids.each_with_index do |id, index|
+          @course.course_subjects.select { |cs| cs.subject_id == id.to_i }.first.position = index
+        end
+
         @course.name = @course.generate_name
       end
 

--- a/app/models/course_subject.rb
+++ b/app/models/course_subject.rb
@@ -5,6 +5,7 @@
 #  course_id  :integer
 #  created_at :datetime
 #  id         :integer          not null, primary key
+#  position   :integer
 #  subject_id :integer
 #  updated_at :datetime
 #

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -22,6 +22,10 @@ class Subject < ApplicationRecord
   belongs_to :subject_area, foreign_key: :type, inverse_of: :subjects
   has_one :financial_incentive
 
+  def secondary_subject?
+    type == "SecondarySubject"
+  end
+
   def to_sym
     subject_name.parameterize.underscore.to_sym
   end

--- a/db/migrate/20200212161248_add_position_to_course_subject.rb
+++ b/db/migrate/20200212161248_add_position_to_course_subject.rb
@@ -1,0 +1,5 @@
+class AddPositionToCourseSubject < ActiveRecord::Migration[6.0]
+  def change
+    add_column :course_subject, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_07_094915) do
+ActiveRecord::Schema.define(version: 2020_02_12_161248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2020_02_07_094915) do
     t.integer "subject_id"
     t.datetime "created_at", precision: 6
     t.datetime "updated_at", precision: 6
+    t.integer "position"
     t.index ["course_id", "subject_id"], name: "index_course_subject_on_course_id_and_subject_id", unique: true
     t.index ["course_id"], name: "index_course_subject_on_course_id"
     t.index ["subject_id"], name: "index_course_subject_on_subject_id"

--- a/spec/models/course_subject_spec.rb
+++ b/spec/models/course_subject_spec.rb
@@ -5,6 +5,7 @@
 #  course_id  :integer
 #  created_at :datetime
 #  id         :integer          not null, primary key
+#  position   :integer
 #  subject_id :integer
 #  updated_at :datetime
 #

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -66,6 +66,31 @@ describe "/api/v2/build_new_course", type: :request do
     end
   end
 
+  context "With multiple secondary subjects" do
+    let(:params) do
+      { course: {
+        name: "Foo Bar Course",
+        maths: "must_have_qualification_at_application_time",
+        english: "must_have_qualification_at_application_time",
+        subjects_ids: subjects.map(&:id),
+      } }
+    end
+    let(:subjects) { [find_or_create(:secondary_subject, :mathematics), find_or_create(:secondary_subject, :english)] }
+
+    it "Returns the subjects in the order they were given" do
+      response = do_get params
+      json_response = parse_response(response)
+      response_subject_ids = json_response["data"]["relationships"]["subjects"]["data"].map { |s| s["id"].to_i }
+      expect(response_subject_ids).to eq(subjects.map(&:id))
+    end
+
+    it "Generates the title in the correct order" do
+      response = do_get params
+      json_response = parse_response(response)
+      expect(json_response["data"]["attributes"]["name"]).to eq("Mathematics with English")
+    end
+  end
+
   context "providers" do
     let(:site) { build(:site) }
     let(:provider) do

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -57,7 +57,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   end
 
   context "course has subjects" do
-    let(:course) { create(:course, level: :secondary, provider: provider, subjects: []) }
+    let(:course) { create(:course, level: :secondary, provider: provider, subjects: [subject1]) }
     let(:subject1) { find_or_create(:secondary_subject, :english) }
     let(:subject2) { find_or_create(:secondary_subject, :mathematics) }
     let(:updated_subjects) do
@@ -82,6 +82,33 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
 
     it "updates the name of the course" do
       expect(course.reload.name).to eq("English with Mathematics")
+    end
+  end
+
+  context "Changing the order of the subjects on the course" do
+    let(:course) { create(:course, level: :secondary, provider: provider, subjects: [subject1, subject2]) }
+    let(:subject1) { find_or_create(:secondary_subject, :english) }
+    let(:subject2) { find_or_create(:secondary_subject, :mathematics) }
+    let(:updated_subjects) do
+      {
+        subjects: {
+          data: [
+            { type: "subject", id: subject2.id.to_s },
+            { type: "subject", id: subject1.id.to_s },
+          ],
+        },
+      }
+    end
+
+    it "Changes the order correctly" do
+      course.reload
+      expect(course.subjects).to eq([subject2, subject1])
+    end
+
+    it "Updates the name of the course" do
+      course.reload
+
+      expect(course.name).to eq("Mathematics with English")
     end
   end
 end

--- a/spec/services/courses/generate_course_name_service_spec.rb
+++ b/spec/services/courses/generate_course_name_service_spec.rb
@@ -53,10 +53,10 @@ describe Courses::GenerateCourseNameService do
     end
 
     context "With multiple subjects" do
-      let(:subjects) { [Subject.new(subject_name: "English"), Subject.new(subject_name: "Physics")] }
+      let(:subjects) { [find_or_create(:secondary_subject, :physics), find_or_create(:secondary_subject, :english)] }
 
-      it "Returns a name containing both subjects" do
-        expect(generated_title).to eq("English with Physics")
+      it "Returns a name containing both subjects in the order they were given" do
+        expect(generated_title).to eq("Physics with English")
       end
 
       include_examples "with SEND"


### PR DESCRIPTION
### Context

Secondary courses can have multiple subjects that have to be stored in the correct order to ensure that bursaries are calculated correctly.

To solve this, we are adding a `position` value on the `course_subject` in order to keep the original order they are given.

### Changes proposed in this pull request

- Add an integer field `:position`  to `CourseSubject`
- Assign `position` when course subjects are added to a secondary course
- Assign `position` based on the order of the params given when updating/building a new course

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
