### PR TITLE
rename dbs to teacher-training

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,7 @@ steps:
     set -x
     $DOCKER_OVERRIDE build
     $DOCKER_OVERRIDE up --no-build -d
+    $DOCKER_OVERRIDE logs -t --no-color
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rails db:setup"
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "apk --no-cache add curl"

--- a/config/database.yml
+++ b/config/database.yml
@@ -10,11 +10,11 @@ default: &default
 
 development:
   <<: *default
-  database: <%= ENV.fetch('DB_DATABASE', 'manage_courses_backend_development') %>
+  database: <%= ENV.fetch('DB_DATABASE', 'teacher_training_development') %>
 
 test:
   <<: *default
-  database: <%= ENV.fetch('DB_DATABASE') { "manage_courses_backend_test#{ENV['TEST_ENV_NUMBER']}" } %>
+  database: <%= ENV.fetch('DB_DATABASE') { "teacher_training_test#{ENV['TEST_ENV_NUMBER']}" } %>
 
 staging:
   <<: *default

--- a/lib/mcb.rb
+++ b/lib/mcb.rb
@@ -393,9 +393,9 @@ module MCB
     def configure_local_database_env
       # values to match database.yml
       ENV["DB_HOSTNAME"] = "localhost"
-      ENV["DB_USERNAME"] = "manage_courses_backend"
-      ENV["DB_PASSWORD"] = "manage_courses_backend"
-      ENV["DB_DATABASE"] = "manage_courses_backend_development"
+      ENV["DB_USERNAME"] = "teacher_training"
+      ENV["DB_PASSWORD"] = "teacher_training"
+      ENV["DB_DATABASE"] = "teacher_training_development"
     end
 
     def pageable_output(output)


### PR DESCRIPTION
### Context

We're renaming the app to `{find,publish}-teacher-training{,-api}`.

### Changes proposed in this pull request

Change the name of the db that's used in tests (and local dev) to `teacher-training`.

### Guidance to review

Because we've started to change some of the CI build scripts we appear to need this change to unblock the pipeline.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
