### PR TITLE
[2993] Add support for sorting by course name as well as provider name

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -16,7 +16,7 @@ module API
                       .includes(:recruitment_cycle)
         providers = providers.where(id: @user.providers) if @user.present?
 
-        render jsonapi: providers.in_order,
+        render jsonapi: providers.by_name_ascending,
                fields: { providers: %i[provider_code provider_name courses
                                        recruitment_cycle_year] }
       end

--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -12,7 +12,7 @@ module API
                        @recruitment_cycle.providers
                      end
 
-        render jsonapi: @providers.in_order, class: { Provider: API::V3::SerializableProvider }, fields: @fields
+        render jsonapi: @providers.by_name_ascending, class: { Provider: API::V3::SerializableProvider }, fields: @fields
       end
 
       def show

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -157,8 +157,21 @@ class Course < ApplicationRecord
     end
   end
 
-  scope :by_provider_name_ascending, -> { includes(:provider).order("provider.provider_name asc") }
-  scope :by_provider_name_descending, -> { includes(:provider).order("provider.provider_name desc") }
+  scope :by_name_ascending, -> do
+    order(name: :asc)
+  end
+
+  scope :by_name_descending, -> do
+    order(name: :desc)
+  end
+
+  scope :ascending_canonical_order, -> do
+    joins(:provider).merge(Provider.by_name_ascending).order("name asc")
+  end
+
+  scope :descending_canonical_order, -> do
+    joins(:provider).merge(Provider.by_name_descending).order("name desc")
+  end
 
   scope :changed_since, ->(timestamp) do
     if timestamp.present?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -106,10 +106,12 @@ class Provider < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
-  scope :in_order, -> { order(:provider_name) }
   scope :search_by_code_or_name, ->(search_term) {
     where("provider_name ILIKE ? OR provider_code ILIKE ?", "%#{search_term}%", "%#{search_term}%")
   }
+
+  scope :by_name_ascending, -> { order(provider_name: :asc) }
+  scope :by_name_descending, -> { order(provider_name: :desc) }
 
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -2,7 +2,7 @@ class CourseSearchService
   def initialize(filter:, sort: nil, course_scope: Course)
     @filter = filter || {}
     @course_scope = course_scope
-    @sort = sort
+    @sort = Set.new(sort&.split(","))
   end
 
   class << self
@@ -14,8 +14,8 @@ class CourseSearchService
   def call
     scope = course_scope.findable
 
-    scope = scope.by_provider_name_ascending if sort_by_provider_ascending?
-    scope = scope.by_provider_name_descending if sort_by_provider_descending?
+    scope = scope.ascending_canonical_order if sort_by_provider_ascending?
+    scope = scope.descending_canonical_order if sort_by_provider_descending?
 
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
@@ -30,11 +30,11 @@ class CourseSearchService
 private
 
   def sort_by_provider_ascending?
-    @sort == "provider.provider_name"
+    @sort == Set["name", "provider.provider_name"]
   end
 
   def sort_by_provider_descending?
-    @sort == "-provider.provider_name"
+    @sort == Set["-name", "-provider.provider_name"]
   end
 
   attr_reader :filter, :course_scope

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -165,51 +165,85 @@ describe Course, type: :model do
     end
   end
 
-  describe "#by_provider_name_ascending" do
-    let(:provider_a) { create(:provider, provider_name: "Provider A") }
-    let(:course_a) do
-      create(:course,
-             name: "Course A",
-             provider: provider_a)
+  context "ordering" do
+    context "canonical" do
+      let(:provider_a) { create(:provider, provider_name: "Provider A") }
+      let(:course_a) do
+        create(:course,
+               name: "Course A",
+               provider: provider_a)
+      end
+
+      let(:course_b) do
+        create(
+          :course,
+          name: "Course B",
+          provider: provider_a,
+        )
+      end
+
+      let(:provider_b) { create(:provider, provider_name: "Provider B") }
+      let(:course_c) do
+        create(
+          :course,
+          name: "Course C",
+          provider: provider_b,
+        )
+      end
+
+      let(:course_d) do
+        create(
+          :course,
+          name: "Course D",
+          provider: provider_b,
+        )
+      end
+
+      before do
+        course_a
+        course_b
+        course_c
+        course_d
+      end
+
+      describe "#ascending_canonical_order" do
+        it "sorts in ascending order of provider name" do
+          expect(described_class.ascending_canonical_order).to eq([course_a, course_b, course_c, course_d])
+        end
+      end
+
+      describe "#descending_canonical_order" do
+        it "sorts in descending order of provider name" do
+          expect(described_class.descending_canonical_order).to eq([course_d, course_c, course_b, course_a])
+        end
+      end
     end
 
-    let(:provider_b) { create(:provider, provider_name: "Provider B") }
-    let(:course_b) do
-      create(
-        :course,
-        name: "Course A",
-        provider: provider_b,
-      )
-    end
+    context "by name" do
+      let(:course_a) do
+        create(:course, name: "Course A")
+      end
 
-    it "sorts in ascending order of provider name" do
-      course_a
-      course_b
-      expect(described_class.by_provider_name_ascending).to eq([course_a, course_b])
-    end
-  end
+      let(:course_b) do
+        create(:course, name: "Course B")
+      end
 
-  describe "#by_provider_name_descending" do
-    let(:provider_a) { create(:provider, provider_name: "Provider A") }
-    let(:course_a) do
-      create(:course,
-             name: "Course A",
-             provider: provider_a)
-    end
+      before do
+        course_a
+        course_b
+      end
 
-    let(:provider_b) { create(:provider, provider_name: "Provider B") }
-    let(:course_b) do
-      create(
-        :course,
-        name: "Course A",
-        provider: provider_b,
-      )
-    end
+      describe "#by_name_ascending" do
+        it "sorts in ascending order of provider name" do
+          expect(described_class.by_name_ascending).to eq([course_a, course_b])
+        end
+      end
 
-    it "sorts in descending order of provider name" do
-      course_a
-      course_b
-      expect(described_class.by_provider_name_descending).to eq([course_b, course_a])
+      describe "#by_name_descending" do
+        it "sorts in descending order of provider name" do
+          expect(described_class.by_name_descending).to eq([course_b, course_a])
+        end
+      end
     end
   end
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -95,6 +95,26 @@ describe Provider, type: :model do
     end
   end
 
+  context "order" do
+    let(:provider_a) { create(:provider, provider_name: "Provider A") }
+    let(:provider_b) { create(:provider, provider_name: "Provider B") }
+    describe "#by_name_ascending" do
+      it "orders the providers by name in ascending order" do
+        provider_a
+        provider_b
+        expect(Provider.by_name_ascending).to eq([provider_a, provider_b])
+      end
+    end
+
+    describe "#by_name_descending" do
+      it "orders the providers by name in descending order" do
+        provider_a
+        provider_b
+        expect(Provider.by_name_descending).to eq([provider_b, provider_a])
+      end
+    end
+  end
+
   describe "#changed_since" do
     context "with a provider that has been changed after the given timestamp" do
       let(:provider) { create(:provider, changed_at: 5.minutes.ago) }
@@ -147,15 +167,6 @@ describe Provider, type: :model do
           "website"     => provider.website,
         ),
       )
-    end
-  end
-
-  describe ".in_order" do
-    let!(:second_alphabetical_provider) { create(:provider, provider_name: "Zork") }
-    let!(:first_alphabetical_provider) { create(:provider, provider_name: "Acme") }
-
-    it "returns sorted providers" do
-      expect(Provider.in_order).to match_array([first_alphabetical_provider, second_alphabetical_provider])
     end
   end
 

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -62,7 +62,7 @@ describe "GET v3/courses" do
     end
 
     context "in ascending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=provider.provider_name" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=name,provider.provider_name" }
 
       it "returns an ordered list" do
         get request_path
@@ -75,7 +75,7 @@ describe "GET v3/courses" do
     end
 
     context "in descending order" do
-      let(:request_path) { "/api/v3/courses?include=provider&sort=-provider.provider_name" }
+      let(:request_path) { "/api/v3/courses?include=provider&sort=-name,-provider.provider_name" }
 
       it "returns an ordered list" do
         get request_path

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -26,20 +26,20 @@ describe CourseSearchService do
     describe "sort by" do
       let(:expected_scope) { double }
 
-      context "ascending provider name" do
-        let(:sort) { "provider.provider_name" }
+      context "ascending provider name and course name" do
+        let(:sort) { "name,provider.provider_name" }
 
-        it "orders in ascending order of provider name" do
-          expect(findable_scope).to receive(:by_provider_name_ascending).and_return(expected_scope)
+        it "orders in ascending order" do
+          expect(findable_scope).to receive(:ascending_canonical_order).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end
 
-      context "descending provider name" do
-        let(:sort) { "-provider.provider_name" }
+      context "descending provider name and course name" do
+        let(:sort) { "-provider.provider_name,-name" }
 
-        it "orders in ascending order of provider name" do
-          expect(findable_scope).to receive(:by_provider_name_descending).and_return(expected_scope)
+        it "orders in descending order" do
+          expect(findable_scope).to receive(:descending_canonical_order).and_return(expected_scope)
           expect(subject).to eq(expected_scope)
         end
       end


### PR DESCRIPTION
### Context
https://github.com/DFE-Digital/find-teacher-training/pull/106 highlighted that we need the ability to sort by both course name and provider name, as this is what C# does.  

### Changes proposed in this pull request
Add canonical sorting.

### Guidance to review
https://github.com/DFE-Digital/search-and-compare-api/blob/3aa6be82dcf5548892580e900ea1e37decf63a0f/src/api/Controllers/CoursesController.cs#L226

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
