### PR TITLE
[2980] - Add subject filtering to the V3 API

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -186,7 +186,7 @@ class Course < ApplicationRecord
     where(study_mode: Array(study_modes) << "full_time_or_part_time")
   end
   scope :with_subjects, ->(subject_codes) do
-    includes(:subjects).where(subject: { subject_code: subject_codes })
+    joins(:subjects).merge(Subject.with_subject_codes(subject_codes))
   end
 
   scope :with_qualifications, ->(qualifications) do

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -185,6 +185,9 @@ class Course < ApplicationRecord
   scope :with_study_modes, ->(study_modes) do
     where(study_mode: Array(study_modes) << "full_time_or_part_time")
   end
+  scope :with_subjects, ->(subject_codes) do
+    includes(:subjects).where(subject: { subject_code: subject_codes })
+  end
 
   scope :with_qualifications, ->(qualifications) do
     where(qualification: qualifications)

--- a/app/models/subject.rb
+++ b/app/models/subject.rb
@@ -22,6 +22,10 @@ class Subject < ApplicationRecord
   belongs_to :subject_area, foreign_key: :type, inverse_of: :subjects
   has_one :financial_incentive
 
+  scope :with_subject_codes, ->(subject_codes) do
+    where(subject_code: subject_codes)
+  end
+
   def secondary_subject?
     type == "SecondarySubject"
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -21,6 +21,7 @@ class CourseSearchService
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.with_vacancies if has_vacancies?
     scope = scope.with_study_modes(study_types) if study_types.any?
+    scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope
   end
 
@@ -56,5 +57,11 @@ private
     return [] if filter[:study_type].blank?
 
     filter[:study_type].split(",")
+  end
+
+  def subject_codes
+    return [] if filter[:subjects].blank?
+
+    filter[:subjects].split(",")
   end
 end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -179,6 +179,37 @@ describe CourseSearchService do
       end
     end
 
+    describe "filter[subjects]" do
+      context "a single subject code" do
+        let(:filter) { { subjects: "A1" } }
+        let(:expected_scope) { double }
+
+        it "adds the subject scope" do
+          expect(findable_scope).to receive(:with_subjects).with(%w(A1)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "multiple subject codes" do
+        let(:filter) { { subjects: "A1,B2" } }
+        let(:expected_scope) { double }
+
+        it "adds the subject scope" do
+          expect(findable_scope).to receive(:with_subjects).with(%w(A1 B2)).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the scope" do
+          expect(findable_scope).not_to receive(:with_subjects)
+          expect(subject).to eq(findable_scope)
+        end
+      end
+    end
+
     describe "multiple filters" do
       let(:filter) { { study_type: "part_time", funding: "salary" } }
       let(:salary_scope) { double }


### PR DESCRIPTION
### Context
Allow courses to be filtered by subject(s) (V3 API)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
