### PR TITLE
[2988] Validate courses dont have duplicate subjects

### DIFF
--- a/app/models/course_subject.rb
+++ b/app/models/course_subject.rb
@@ -21,6 +21,7 @@ class CourseSubject < ApplicationRecord
 
   belongs_to :course
   belongs_to :subject
+  validates_uniqueness_of :subject_id, scope: :course_id
 
   audited associated_with: :course
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,6 +52,7 @@ en:
             subjects:
               blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
               course_creation: "^You must pick at least one subject"
+              duplicate: "^You've already selected this subject - you can only select a subject once"
             modern_languages_subjects:
               select_a_language: "^You must pick at least one language"
             study_mode:


### PR DESCRIPTION
### Context

To prevent people selecting two of the same subject in Publish, we prevent duplicate subject IDs being passed in in the controller

### Changes proposed in this pull request

- Validate uniqueness of `course_subjects`
- Check `subject_ids` in the controller before assignment

### Guidance to review

- Go to publish
- Create a new course -> Add duplicate secondary subjects
- Edit an existing course -> Add duplicate secondary subjects


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
