### PR TITLE
2932 m add provider filtering to the api

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -206,6 +206,10 @@ class Course < ApplicationRecord
     where(qualification: qualifications)
   end
 
+  scope :with_provider_name, ->(provider_name) do
+    joins(:provider).merge(Provider.where(provider_name: provider_name))
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -22,6 +22,7 @@ class CourseSearchService
     scope = scope.with_vacancies if has_vacancies?
     scope = scope.with_study_modes(study_types) if study_types.any?
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
+    scope = scope.with_provider_name(provider_name) if provider_name.present?
     scope
   end
 
@@ -63,5 +64,11 @@ private
     return [] if filter[:subjects].blank?
 
     filter[:subjects].split(",")
+  end
+
+  def provider_name
+    return [] if filter[:"provider.provider_name"].blank?
+
+    filter[:"provider.provider_name"]
   end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -853,6 +853,30 @@ describe Course, type: :model do
         end
       end
     end
+
+    describe ".with_provider_name" do
+      let(:provider) { create(:provider, provider_name: "ACME") }
+      let(:provider2) { create(:provider, provider_name: "DAVE") }
+      let(:course) { create(:course, provider: provider) }
+      let(:provider_name) { "ACME" }
+
+      before do
+        provider
+        provider2
+        course
+        provider_name
+      end
+
+      context "with an existing provider name" do
+        subject { described_class.with_provider_name(provider_name) }
+        it { is_expected.to contain_exactly(course) }
+      end
+
+      context "with a provider name with no courses" do
+        subject { described_class.with_provider_name("DAVE") }
+        it { is_expected.to be_empty }
+      end
+    end
   end
 
   describe "changed_at" do

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -257,7 +257,7 @@ describe "GET v3/courses" do
     end
   end
 
-  context "subjects filter" do
+  describe "subjects filter" do
     let(:course_with_A1_subject) do
       create(:course,
              enrichments: [published_enrichment],
@@ -307,6 +307,44 @@ describe "GET v3/courses" do
 
       before do
         course_with_A1_subject
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
+  describe "provider filter" do
+    context "with a provider specified" do
+      let(:request_path) { "/api/v3/courses?filter[provider.provider_name]=#{filtered_provider_course.provider.provider_name}" }
+      let(:provider_filtered_by) { create(:provider) }
+      let(:filtered_provider_course) { create(:course, provider: provider_filtered_by, site_statuses: [findable_status], enrichments: [published_enrichment]) }
+
+      before do
+        provider_filtered_by
+        filtered_provider_course
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a different provider specified" do
+      let(:request_path) { "/api/v3/courses?filter[provider.provider_name]=a+different+provider" }
+      let(:provider_excluded) { create(:provider) }
+      let(:excluded_provider_course) { create(:course, provider: provider_excluded, site_statuses: [build(:site_status, :findable)], enrichments: [published_enrichment]) }
+
+      before do
+        provider_excluded
+        excluded_provider_course
       end
 
       it "is not returned" do


### PR DESCRIPTION
### Context

[Check this trello card](https://trello.com/c/RBaGAf8C/2932-m-add-provider-filtering-to-the-api) for details - we're adding the ability to filter courses by provider name. 

### Changes proposed in this pull request

Add scoping to providers to filter by exact provider name matches
Add scoping to courses to filter by provider names
Add method to CourseSearchService to filter by provider names

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
