### PR TITLE
[3018] Update subject db schema

### DIFF
--- a/db/migrate/20200221150255_add_subject_indexes.rb
+++ b/db/migrate/20200221150255_add_subject_indexes.rb
@@ -1,0 +1,6 @@
+class AddSubjectIndexes < ActiveRecord::Migration[6.0]
+  def change
+    add_index :subject, :type
+    add_index :subject, :subject_code
+  end
+end

--- a/db/migrate/20200221150821_add_subject_area_indexes.rb
+++ b/db/migrate/20200221150821_add_subject_area_indexes.rb
@@ -1,0 +1,5 @@
+class AddSubjectAreaIndexes < ActiveRecord::Migration[6.0]
+  def change
+    add_index :subject_area, :typename
+  end
+end

--- a/db/migrate/20200221151215_remove_unused_subject_columns.rb
+++ b/db/migrate/20200221151215_remove_unused_subject_columns.rb
@@ -1,0 +1,17 @@
+class RemoveUnusedSubjectColumns < ActiveRecord::Migration[6.0]
+  def up
+    change_table :subject, bulk: true do |t|
+      t.remove :created_at
+      t.remove :updated_at
+      t.remove :subject_area_id
+    end
+  end
+
+  def down
+    change_table :subject, bulk: true do |t|
+      t.datetime :created_at
+      t.datetime :updated_at
+      t.integer :subject_area_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_12_161248) do
+ActiveRecord::Schema.define(version: 2020_02_21_151215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -275,11 +275,9 @@ ActiveRecord::Schema.define(version: 2020_02_12_161248) do
     t.text "type"
     t.text "subject_code"
     t.text "subject_name"
-    t.datetime "created_at", precision: 6
-    t.datetime "updated_at", precision: 6
-    t.bigint "subject_area_id"
-    t.index ["subject_area_id"], name: "index_subject_on_subject_area_id"
+    t.index ["subject_code"], name: "index_subject_on_subject_code"
     t.index ["subject_name"], name: "index_subject_on_subject_name"
+    t.index ["type"], name: "index_subject_on_type"
   end
 
   create_table "subject_area", id: false, force: :cascade do |t|
@@ -287,6 +285,7 @@ ActiveRecord::Schema.define(version: 2020_02_12_161248) do
     t.text "name"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["typename"], name: "index_subject_area_on_typename"
   end
 
   create_table "user", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
###Context

There were some production issues on 20/2/2020 after we deployed some subject updates. The updates don't look to have caused the issues but while investigating I spotted a couple of minor things in the DB.

### Changes proposed in this pull request

* Remove unused subject area columns
* Add index to subject type as it is the foreign key for subject area
* Add index to subject subject_code as we use it in the API query
* Add index to subject area typename as it is the primary key

### Guidance to review

`SubjectArea` uses `typename` as the primary key. The fields on subject that have been removed are all `nil` on production.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
