### PR TITLE
[3003] Add mailer for course updates

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -1,0 +1,29 @@
+class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
+  def course_update_email(course, attribute_changed, user)
+    set_template(Settings.govuk_notify.course_update_email_template_id)
+
+    set_personalisation(
+      provider_name: course.provider.provider_name,
+      course_name: course.name,
+      course_code: course.course_code,
+      attribute_changed: attribute_changed,
+      attribute_change_datetime: format_update_datetime(course.updated_at),
+      course_url: create_course_url(course),
+    )
+
+    mail(to: user.email)
+  end
+
+private
+
+  def create_course_url(course)
+    "#{Settings.publish_url}" \
+      "/organisations/#{course.provider.provider_code}" \
+      "/#{course.provider.recruitment_cycle.year}" \
+      "/courses/#{course.course_code}"
+  end
+
+  def format_update_datetime(datetime)
+    datetime.strftime("%-k.%M on %-e %B %Y")
+  end
+end

--- a/azure/template.json
+++ b/azure/template.json
@@ -476,6 +476,10 @@
                 "value": "[parameters('govukNotifyWelcomeEmailTemplateId')]"
               },
               {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_UPDATE_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseUpdateEmailTemplateId')]"
+              },
+              {
                 "name": "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",
                 "value": "[parameters('mcbeSystemAuthenticationToken')]"
               },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,8 @@ current_recruitment_cycle_year: 2020
 govuk_notify:
   api_key: please_change_me
   welcome_email_template_id: please_change_me
+  course_update_email_template_id: please_change_me
+publish_url: http://localhost:3000
 mcbg:
   redis_password: <%= SecureRandom.base64 %>
 system_authentication_token: <%= SecureRandom.base64 %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,3 +7,4 @@ bg_jobs:
     class: "BulkSyncCoursesToFindJob"
     queue: find_sync
 gcp_api_key: please_change_me
+publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -7,3 +7,4 @@ bg_jobs:
     class: "BulkSyncCoursesToFindJob"
     queue: find_sync
 gcp_api_key: please_change_me
+publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -7,3 +7,4 @@ bg_jobs:
     class: "BulkSyncCoursesToFindJob"
     queue: find_sync
 gcp_api_key: please_change_me
+publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,5 +1,7 @@
 govuk_notify:
   api_key: cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe
   welcome_email_template_id: please_change_me
+  course_update_email_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
+publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe CourseUpdateEmailMailer, type: :mailer do
+  let(:course) { create(:course, :with_accrediting_provider, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6)) }
+  let(:user) { create(:user) }
+  let(:mail) { described_class.course_update_email(course, "name", user) }
+
+  before do
+    course
+    mail
+  end
+
+  context "sending an email to a user" do
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_update_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the provider name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:provider_name]).to eq(course.provider.provider_name)
+    end
+
+    it "includes the course name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_name]).to eq(course.name)
+    end
+
+    it "includes the course code in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_code]).to eq(course.course_code)
+    end
+
+    it "includes the updated detail in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("name")
+    end
+
+    it "includes the datetime for the detail update in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:attribute_change_datetime]).to eq("4.05 on 3 February 2001")
+    end
+
+    it "includes the URL for the course in the personalisation" do
+      url = "#{Settings.publish_url}" \
+        "/organisations/#{course.provider.provider_code}" \
+        "/#{course.provider.recruitment_cycle.year}" \
+        "/courses/#{course.course_code}"
+      expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
+    end
+  end
+end


### PR DESCRIPTION
Co-authored-by: defong <de_fong2k@yahoo.com>

### Context

[See this card for more details](https://trello.com/c/Xnoghg3q/3003-s-notify-accredited-body-users-that-something-has-changed-on-a-course)

There is also a Notify template that needs to be finalised, which this will directly link to. There's a template ID that will need to be included in the live environments as a result. 

### Changes proposed in this pull request

Adds a mailer to mailer set that can be used to invoke an API call to notify.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
