### PR TITLE
[3016] Add send_courses filtering to the V3 

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -210,6 +210,10 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.where(provider_name: provider_name))
   end
 
+  scope :with_send, -> do
+    where(is_send: true)
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -23,6 +23,7 @@ class CourseSearchService
     scope = scope.with_study_modes(study_types) if study_types.any?
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope = scope.with_provider_name(provider_name) if provider_name.present?
+    scope = scope.with_send if send_courses_filter?
     scope
   end
 
@@ -70,5 +71,9 @@ private
     return [] if filter[:"provider.provider_name"].blank?
 
     filter[:"provider.provider_name"]
+  end
+
+  def send_courses_filter?
+    filter[:send_courses].to_s.downcase == "true"
   end
 end

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -356,6 +356,40 @@ describe "GET v3/courses" do
     end
   end
 
+  describe "SEND courses filter" do
+    let(:request_path) { "/api/v3/courses?filter[send_courses]=true" }
+
+    context "with a SEND course" do
+      let(:send_course) { create(:course, is_send: true, site_statuses: [findable_status], enrichments: [published_enrichment]) }
+
+      before do
+        send_course
+      end
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a course without SEND specialism" do
+      let(:course) { create(:course, site_statuses: [findable_status], enrichments: [published_enrichment]) }
+
+      before do
+        course
+      end
+
+      it "is not returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
   describe "recruitment_cycle scoping" do
     context "course not in the provided recruitment cycle" do
       let(:provider) { create(:provider, :next_recruitment_cycle) }

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -210,6 +210,36 @@ describe CourseSearchService do
       end
     end
 
+    describe "filter[send_courses]" do
+      context "when true" do
+        let(:filter) { { send_courses: true } }
+        let(:expected_scope) { double }
+
+        it "adds the with_send scope" do
+          expect(findable_scope).to receive(:with_send).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when false" do
+        let(:filter) { { send_courses: false } }
+
+        it "adds the with_send scope" do
+          expect(findable_scope).not_to receive(:with_send)
+          expect(subject).to eq(findable_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the with_send scope" do
+          expect(findable_scope).not_to receive(:with_send)
+          expect(subject).to eq(findable_scope)
+        end
+      end
+    end
+
     describe "multiple filters" do
       let(:filter) { { study_type: "part_time", funding: "salary" } }
       let(:salary_scope) { double }


### PR DESCRIPTION

We need to allow to filter `send_courses` as it is [used by Find](https://github.com/DFE-Digital/find-teacher-training/blob/master/app/view_objects/results_view.rb#L108) 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
