### PR TITLE
[3056] Fix course update email template ID parameter

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -169,6 +169,13 @@
         "description": "The GOV.UK Notify template id for the find welcome email"
       }
     },
+    "govukNotifyCourseUpdateEmailTemplateId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The GOV.UK Notify template id for the course update email"
+      }
+    },
     "containerInstanceName": {
       "type": "array",
       "metadata": {


### PR DESCRIPTION
### Context

[See this Trello card for more detail](https://trello.com/c/4PlX8ZQF/3056-azure-config-not-set-correctly-for-course-update-email-template-id#)

### Changes proposed in this pull request

Fix the Azure config for the CourseUpdateEmailTemplateId

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
