### PR TITLE
Readme - update year in example curl for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Quick check that it's working in local development with the token "bats"
 configured in `config/environments/development.rb`:
 
 ```bash
-curl http://localhost:3001/api/v1/2019/subjects.json -H "Authorization: Bearer bats"
+curl http://localhost:3001/api/v1/2020/subjects.json -H "Authorization: Bearer bats"
 ```
 
 ### V2


### PR DESCRIPTION
### Context

The 2019 endpoint no longer responds.

### Changes proposed in this pull request

Readme - update year in example curl for v1

### Guidance to review

:ship:

### Checklist

- [ ] Make sure all information from the Trello card is in here - n/a
- [ ] Attach to Trello card - n/a
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally