### PR TITLE
[3057] - Return course count in meta object

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -8,7 +8,7 @@ module API
       def index
         course_search = CourseSearchService.call(filter: params[:filter], sort: params[:sort], course_scope: @courses)
 
-        render jsonapi: paginate(course_search), fields: fields_param, include: params[:include], class: CourseSerializersService.new.execute
+        render jsonapi: paginate(course_search), fields: fields_param, include: params[:include], meta: { count: course_search.count }, class: CourseSerializersService.new.execute
       end
 
       def show

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -16,18 +16,31 @@ describe "GET v3/recruitment_cycles/:year/courses" do
     next_course
   end
 
-  it "returns a paginated list of courses in the recruitment cycle" do
-    get request_path
+  describe "pagination" do
+    it "returns a paginated list of courses in the recruitment cycle" do
+      get request_path
 
-    json_response = JSON.parse(response.body)
-    course_hashes = json_response["data"]
-    expect(course_hashes.count).to eq(1)
-    expect(course_hashes.first["id"]).to eq(current_course.id.to_s)
+      json_response = JSON.parse(response.body)
+      course_hashes = json_response["data"]
+      expect(course_hashes.count).to eq(1)
+      expect(course_hashes.first["id"]).to eq(current_course.id.to_s)
 
-    headers = response.headers
+      headers = response.headers
 
-    expect(headers["Per-Page"]).to be_present
-    expect(headers["Total"]).to be_present
+      expect(headers["Per-Page"]).to be_present
+      expect(headers["Total"]).to be_present
+    end
+  end
+
+  describe "course count" do
+    it "returns the course count in a meta object" do
+      get request_path
+
+      json_response = JSON.parse(response.body)
+      meta = json_response["meta"]
+
+      expect(meta["count"]).to be(1)
+    end
   end
 end
 

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -237,6 +237,9 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 },
               },
             }],
+            "meta" => {
+              "count" => 1,
+            },
             "links"  => {
               "last" => "/api/v3/recruitment_cycles/2020/providers/#{provider.provider_code}/courses?page%5Bpage%5D=1",
             },


### PR DESCRIPTION
### Context
- The inclusion of non-standard meta-information should be returned in a 'meta object'. See https://jsonapi.org/format/#document-meta
- This change is required to fix the inaccurate results page count on Find Teacher Training (a separate PR for Find Teacher Training required, to follow)

### Changes proposed in this pull request
- Return course count in global metal object
- Do not rely on the header 'Total' for accessing course count. This appears to go against the JSON API spec.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
