### PR TITLE
3058-Add parameter for app service plan tier

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -151,6 +151,13 @@
       ],
       "defaultValue": "1"
     },
+    "appServicePlanTier": {
+      "type": "string",
+      "defaultValue": "Standard",
+      "metadata": {
+          "description": "The App Service Plan tier."
+      }
+    },
     "appServicePlanInstances": {
       "type": "int",
       "defaultValue": 1
@@ -359,6 +366,9 @@
           },
           "appServicePlanSize": {
             "value": "[parameters('appServicePlanSize')]"
+          },
+          "appServicePlanTier": {
+              "value": "[parameters('appServicePlanTier')]"
           },
           "appServicePlanInstances": {
             "value": "[parameters('appServicePlanInstances')]"


### PR DESCRIPTION
### Context
Add parameter for Azure app service plan tier in ARM template so it can be changed during deployment.
We have noticed significant increase in response time during app deployment.
PSQL server logs are showing connection termination from remote host (app services) during deployment. Furthermore TTAPI metrics are showing sudden increase in working memory set usage which suggests that TTAPI could benefit from resource scale up.

### Changes proposed in this pull request
Add a parameter to arm template

### Checklist
https://trello.com/c/vqwqyEg5/3058-upgrade-ptt-and-ttapi-app-service-to-premium-v2-plan
