### PR TITLE
[3025] Add User notifications table

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -76,6 +76,11 @@ class Provider < ApplicationRecord
 
   has_many :sites
 
+  has_many :user_notifications,
+           foreign_key: :provider_code,
+           primary_key: :provider_code,
+           inverse_of: :provider
+
   has_many :courses, -> { kept }, inverse_of: false
   has_one :ucas_preferences, class_name: "ProviderUCASPreference"
   has_many :contacts

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,7 +28,10 @@ class User < ApplicationRecord
   # dependent destroy because https://stackoverflow.com/questions/34073757/removing-relations-is-not-being-audited-by-audited-gem/34078860#34078860
   has_many :organisations, through: :organisation_users, dependent: :destroy
 
+  has_many :user_notifications
+
   has_many :providers, through: :organisations
+
   has_many :access_requests,
            foreign_key: :requester_id,
            primary_key: :id,

--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: user_notification
+#
+#  course_update :boolean          default("false")
+#  created_at    :datetime         not null
+#  id            :bigint           not null, primary key
+#  provider_code :string           not null
+#  updated_at    :datetime         not null
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_user_notification_on_provider_code  (provider_code)
+#
+class UserNotification < ApplicationRecord
+  belongs_to :user,
+             inverse_of: :user_notifications
+
+  belongs_to :provider,
+             foreign_key: :provider_code,
+             primary_key: :provider_code,
+             inverse_of: :user_notifications
+end

--- a/db/migrate/20200227105316_add_user_notifications_table.rb
+++ b/db/migrate/20200227105316_add_user_notifications_table.rb
@@ -1,0 +1,14 @@
+class AddUserNotificationsTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_notification do |t|
+      t.integer :user_id, null: false
+      t.string :provider_code, null: false
+      t.boolean :course_update, default: false
+
+      t.timestamps
+    end
+
+    add_foreign_key :user_notification, :user
+    add_index :user_notification, :provider_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_21_151215) do
+ActiveRecord::Schema.define(version: 2020_02_27_105316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -303,6 +303,15 @@ ActiveRecord::Schema.define(version: 2020_02_21_151215) do
     t.index ["email"], name: "IX_user_email", unique: true
   end
 
+  create_table "user_notification", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "provider_code", null: false
+    t.boolean "course_update", default: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["provider_code"], name: "index_user_notification_on_provider_code"
+  end
+
   add_foreign_key "access_request", "\"user\"", column: "requester_id", name: "FK_access_request_user_requester_id", on_delete: :nullify
   add_foreign_key "contact", "provider", name: "fk_contact_provider"
   add_foreign_key "course", "provider", name: "FK_course_provider_provider_id", on_delete: :cascade
@@ -323,4 +332,5 @@ ActiveRecord::Schema.define(version: 2020_02_21_151215) do
   add_foreign_key "provider_ucas_preference", "provider", name: "fk_provider_ucas_preference__provider"
   add_foreign_key "session", "\"user\"", column: "user_id", name: "FK_session_user_user_id", on_delete: :cascade
   add_foreign_key "site", "provider", name: "FK_site_provider_provider_id", on_delete: :cascade
+  add_foreign_key "user_notification", "\"user\"", column: "user_id"
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -65,6 +65,7 @@ describe Provider, type: :model do
     it { should have_many(:users).through(:organisations) }
     it { should have_one(:ucas_preferences).class_name("ProviderUCASPreference") }
     it { should have_many(:contacts) }
+    it { should have_many(:user_notifications) }
   end
 
   describe "organisation" do

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: user_notification
+#
+#  course_update :boolean          default("false")
+#  created_at    :datetime         not null
+#  id            :bigint           not null, primary key
+#  provider_code :string           not null
+#  updated_at    :datetime         not null
+#  user_id       :integer          not null
+#
+# Indexes
+#
+#  index_user_notification_on_provider_code  (provider_code)
+#
+describe UserNotification, type: :model do
+  describe "associations" do
+    let(:organisation) { create(:organisation, providers: [provider]) }
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:provider) { create(:provider) }
+
+    subject { described_class.new(user_id: user.id, provider_code: provider.provider_code) }
+
+    it { should belong_to(:provider) }
+    it { should belong_to(:user) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -29,6 +29,7 @@ describe User, type: :model do
     it { should have_many(:organisation_users) }
     it { should have_many(:organisations).through(:organisation_users) }
     it { should have_many(:providers).through(:organisations) }
+    it { should have_many(:user_notifications) }
   end
 
   describe "validations" do


### PR DESCRIPTION
### Context

In order to control which users have notifications on for which provider - we need to add a join
table between the `User` and `Provider`.

### Changes proposed in this pull request

- Add a join table between user and provider

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
