### PR TITLE
[3061] Can return all courses for sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem "request_store"
 gem "dry-container"
 
 # For geocoding and geographic logic (e.g: filtering sites by ranges)
-gem 'geokit-rails'
+gem "geokit-rails"
 
 group :development, :test do
   # add info about db structure to models and other files

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -19,7 +19,7 @@ module API
                  :content_status, :ucas_status, :funding_type,
                  :level, :is_send?, :english, :maths, :science, :gcse_subjects_required,
                  :age_range_in_years, :accrediting_provider,
-                 :accrediting_provider_code, :level
+                 :accrediting_provider_code, :level, :changed_at
 
       attribute :start_date do
         @object.start_date.strftime("%B %Y") if @object.start_date

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -62,7 +62,10 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
         it "has a data section with the correct attributes" do
           perform_request
 
-          json_response = JSON.parse response.body
+          json_response = JSON.parse(response.body)
+          changed_at = Time.zone.parse(json_response["data"][0]["attributes"].delete("changed_at"))
+          expect(changed_at).to be_within(60).of(Time.zone.now)
+
           expect(json_response).to eq(
             "data" => [{
               "id" => provider.courses[0].id.to_s,
@@ -113,128 +116,6 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "site_statuses" => { "meta" => { "included" => false } },
                 "sites" => { "meta" => { "included" => false } },
                 "subjects" => { "meta" => { "included" => false } },
-              },
-              "meta" => {
-                "edit_options" => {
-                  "entry_requirements" => %w[must_have_qualification_at_application_time expect_to_achieve_before_training_begins equivalence_test],
-                  "qualifications" => %w[qts pgce_with_qts pgde_with_qts],
-                  "age_range_in_years" => %w[3_to_7 5_to_11 7_to_11 7_to_14],
-                  "start_dates" => [
-                    "October #{previous_year}",
-                    "November #{previous_year}",
-                    "December #{previous_year}",
-                    "January #{current_year}",
-                    "February #{current_year}",
-                    "March #{current_year}",
-                    "April #{current_year}",
-                    "May #{current_year}",
-                    "June #{current_year}",
-                    "July #{current_year}",
-                    "August #{current_year}",
-                    "September #{current_year}",
-                    "October #{current_year}",
-                    "November #{current_year}",
-                    "December #{current_year}",
-                    "January #{next_year}",
-                    "February #{next_year}",
-                    "March #{next_year}",
-                    "April #{next_year}",
-                    "May #{next_year}",
-                    "June #{next_year}",
-                    "July #{next_year}",
-                  ],
-                  "study_modes" => %w[full_time part_time full_time_or_part_time],
-                  "show_is_send" => false,
-                  "show_start_date" => false,
-                  "show_applications_open" => false,
-                  "subjects" => [
-                    {
-                      "id" => "1",
-                      "type" => "subjects",
-                      "attributes" => {
-                        "subject_name" => "Primary",
-                        "subject_code" => "00",
-                        "bursary_amount" => nil,
-                        "early_career_payments" => nil,
-                        "scholarship" => nil,
-                        "subject_knowledge_enhancement_course_available" => nil,
-                      },
-                     },
-                    {
-                     "id" => "2",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with English",
-                       "subject_code" => "01",
-                       "bursary_amount" => nil,
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => nil,
-                     },
-                    },
-                    {
-                     "id" => "3",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with geography and history",
-                       "subject_code" => "02",
-                       "bursary_amount" => nil,
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => nil,
-                     },
-                    },
-                    {
-                     "id" => "4",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with mathematics",
-                       "subject_code" => "03",
-                       "bursary_amount" => "6000",
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => true,
-                     },
-                    },
-                    {
-                     "id" => "5",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with modern languages",
-                       "subject_code" => "04",
-                       "bursary_amount" => nil,
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => nil,
-                     },
-                    },
-                    {
-                     "id" => "6",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with physical education",
-                       "subject_code" => "06",
-                       "bursary_amount" => nil,
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => nil,
-                     },
-                    },
-                    {
-                     "id" => "7",
-                     "type" => "subjects",
-                     "attributes" => {
-                       "subject_name" => "Primary with science",
-                       "subject_code" => "07",
-                       "bursary_amount" => nil,
-                       "early_career_payments" => nil,
-                       "scholarship" => nil,
-                       "subject_knowledge_enhancement_course_available" => nil,
-  },
-                   },
-                  ],
-                  "modern_languages" => nil,
-                },
               },
             }],
             "meta" => {

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -92,7 +92,11 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
     end
 
     it "has a data section with the correct attributes" do
-      json_response = JSON.parse response.body
+      json_response = JSON.parse(response.body)
+
+      changed_at = Time.zone.parse(json_response["data"]["attributes"].delete("changed_at"))
+      expect(changed_at).to be_within(60).of(Time.zone.now)
+
       expect(json_response).to eq(
         "data" => {
           "id" => course.id.to_s,


### PR DESCRIPTION
### Context

- https://trello.com/c/zOB0CYyM/3061-fix-sitemap
- Sitemap currently only able to generate 10 courses due to pagination
- This is the backend fix to remove pagination from courses if correct parameters are sent

### Changes proposed in this pull request

- If correct params are given to courses endpoint we remove pagination
and return all courses
- So that it can be used by Find to generate sitemap
- Switch v3 courses controller to use v3 courses serialiser
- Courses controller now always includes provider association
- This is to prevent n+1 queries
- jsonapi :include is not used as causes many additional SQL queries
- Test slices out `updated_at` as cannot use `Timecop` as multiple
providers cannot be created at the same time due to uniqueness index

### Guidance to review

- Visit http://localhost:3001/api/v3/recruitment_cycles/2020/courses?fields[courses]=course_code,provider_code,updated_at
- Should return all records without pagination
- Should only return enough data to generate sitemap client side

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
