### PR TITLE
[3069] Sort courses by distance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,7 @@ gem "request_store"
 gem "dry-container"
 
 # For geocoding and geographic logic (e.g: filtering sites by ranges)
-gem 'geokit-rails'
+gem "geokit-rails"
 
 group :development, :test do
   # add info about db structure to models and other files

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -48,6 +48,7 @@ class Course < ApplicationRecord
 
   has_associated_audits
   audited
+
   validates :course_code,
             uniqueness: { scope: :provider_id },
             on: %i[create update]
@@ -159,6 +160,10 @@ class Course < ApplicationRecord
 
   scope :within, ->(range, origin:) do
     joins(:sites).merge(Site.within(range, origin: origin))
+  end
+
+  scope :by_distance, ->(origin:) do
+    joins(:sites).merge(Site.by_distance(origin: origin))
   end
 
   scope :by_name_ascending, -> do

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -16,6 +16,7 @@ class CourseSearchService
 
     scope = scope.ascending_canonical_order if sort_by_provider_ascending?
     scope = scope.descending_canonical_order if sort_by_provider_descending?
+    scope = scope.by_distance(origin: origin) if sort_by_distance?
 
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
@@ -24,7 +25,7 @@ class CourseSearchService
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope = scope.with_provider_name(provider_name) if provider_name.present?
     scope = scope.with_send if send_courses_filter?
-    scope = scope.within(filter[:radius], origin: [filter[:latitude], filter[:longitude]]) if locations_filter?
+    scope = scope.within(filter[:radius], origin: origin) if locations_filter?
     scope
   end
 
@@ -44,6 +45,14 @@ private
 
   def sort_by_provider_descending?
     sort == Set["-name", "-provider.provider_name"]
+  end
+
+  def sort_by_distance?
+    sort == Set["distance"]
+  end
+
+  def origin
+    [filter[:latitude], filter[:longitude]]
   end
 
   attr_reader :sort, :filter, :course_scope

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -44,6 +44,18 @@ describe CourseSearchService do
         end
       end
 
+      context "by distance" do
+        let(:sort) { "distance" }
+        let(:filter) do
+          { latitude: 54.9713392, longitude: -1.6112336 }
+        end
+
+        it "orders in descending order" do
+          expect(findable_scope).to receive(:by_distance).with(origin: [54.9713392, -1.6112336]).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
       context "unspecified" do
         it "does not order" do
           expect(findable_scope).not_to receive(:order)


### PR DESCRIPTION
### Context

- https://trello.com/c/8wGCf2P3/3069-m-sort-courses-by-distance-to-sites
- Backend can now sort results by distance from origin

### Changes proposed in this pull request

- Able to sort results by distance from origin
- Does not implement parameter checking

### Guidance to review

- Given you have a dataset with geocoded sites
- via rails console `Course.limit(100).by_distance(origin: [54.9713392, -1.6112336])`
- or other origin. this should return results sorted by distance from origin with closest first
- the should be using the geocoded data from `Site`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [x] Rebased master
- [X] Cleaned commit history
- [x] Tested by running locally
