### PR TITLE
[3061] Able to disable pagination for v3

### DIFF
--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -3,11 +3,29 @@ module API
     class ApplicationController < ActionController::API
       rescue_from ActiveRecord::RecordNotFound, with: :jsonapi_404
 
+      before_action :check_disable_pagination
+
       def jsonapi_404
         render jsonapi: nil, status: :not_found
       end
 
     private
+
+      def check_disable_pagination
+        return unless params[:page]
+
+        if params[:page][:per_page].to_i > Kaminari.config.default_per_page
+          return if allowed_to_disable_pagination?
+
+          params[:page][:per_page] = Kaminari.config.default_per_page
+        end
+      end
+
+      # Override if you want to allow an endpoint to disable pagaination
+      # e.g. by checking params
+      def allowed_to_disable_pagination?
+        false
+      end
 
       def build_recruitment_cycle
         @recruitment_cycle = RecruitmentCycle.find_by(

--- a/config/initializers/api_pagination.rb
+++ b/config/initializers/api_pagination.rb
@@ -4,6 +4,6 @@ ApiPagination.configure do |config|
   end
 
   config.per_page_param do |params|
-    params.dig(:page, :per_page) || 10
+    params.dig(:page, :per_page) || Kaminari.config.default_per_page
   end
 end

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -2,7 +2,7 @@
 
 Kaminari.configure do |config|
   config.default_per_page = 100
-  config.max_per_page = 100
+  config.max_per_page = 20_000
   # config.window = 4
   # config.outer_window = 0
   # config.left = 0

--- a/spec/controllers/api/v3/application_controller_spec.rb
+++ b/spec/controllers/api/v3/application_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe API::V3::ApplicationController do
+  controller do
+    def index
+      render jsonapi: paginate(Course.all),
+             class: CourseSerializersService.new.execute
+    end
+
+  private
+
+    def page_url(_)
+      "/"
+    end
+  end
+
+  around :each do |example|
+    default_per_page = Kaminari.config.default_per_page
+
+    Kaminari.configure do |config|
+      config.default_per_page = 1
+    end
+
+    example.run
+
+    Kaminari.configure do |config|
+      config.default_per_page = default_per_page
+    end
+  end
+
+  describe "pagination" do
+    before do
+      provider = create(:provider)
+      2.times.map { create(:course, provider: provider) }
+    end
+
+    it "is enabled by default" do
+      get :index
+      expect(JSON.parse(response.body)["data"].size).to eql(1)
+    end
+
+    it "can not be disabled only with per_page param" do
+      get :index, params: { page: { per_page: 100_000 } }
+      expect(JSON.parse(response.body)["data"].size).to eql(1)
+    end
+
+    context "when allowed_to_disable_pagination? returns true" do
+      it "can be disabled with per_page param and implemented method" do
+        controller.instance_eval do
+          def allowed_to_disable_pagination?
+            true
+          end
+        end
+
+        get :index, params: { page: { per_page: 100_000 } }
+        expect(JSON.parse(response.body)["data"].size).to eql(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/zOB0CYyM/3061-fix-sitemap-backend
- We firstly need to solve the problem of being able to disable pagination before we even begin to fix the sitemap
- This PR allows v3 endpoints to disable pagination if desired
- There will be a subsequent PR to fix the sitemap

### Changes proposed in this pull request

- If requested pagination is over the default number we check if this is allowed
- This check is done by implementing `allowed_to_disable_pagination?`
- If not implemented or returns false then we fallback to the default

### Guidance to review

- Existing endpoints should still be paginated to 100
- Implement `allowed_to_disable_pagination?` on a controller to return true
- if `params[:page][:per_page]` provided pagination should be respected
- There will be a subsequent PR to fix the sitemap

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally