### PR TITLE
[3094] Added prevention for suggesting providers with no courses

### DIFF
--- a/app/controllers/api/v3/provider_suggestions_controller.rb
+++ b/app/controllers/api/v3/provider_suggestions_controller.rb
@@ -7,12 +7,8 @@ module API
         return render(status: :bad_request) if params[:query].nil? || params[:query].length < 3
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
-        providers_ids = @recruitment_cycle.courses.findable.distinct.pluck(:provider_id)
-        accrediting_provider_codes = @recruitment_cycle.courses.findable.distinct.pluck(:accrediting_provider_code).compact
-
         found_providers = @recruitment_cycle.providers
-                              .where(provider_code: accrediting_provider_codes)
-                              .or(@recruitment_cycle.providers.where(id: providers_ids))
+                              .with_findable_courses
                               .search_by_code_or_name(params[:query])
                               .limit(10)
 

--- a/app/controllers/api/v3/provider_suggestions_controller.rb
+++ b/app/controllers/api/v3/provider_suggestions_controller.rb
@@ -7,7 +7,12 @@ module API
         return render(status: :bad_request) if params[:query].nil? || params[:query].length < 3
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
+        providers_ids = @recruitment_cycle.courses.findable.distinct.pluck(:provider_id)
+        accrediting_provider_codes = @recruitment_cycle.courses.findable.distinct.pluck(:accrediting_provider_code).compact
+
         found_providers = @recruitment_cycle.providers
+                              .where(provider_code: accrediting_provider_codes)
+                              .or(@recruitment_cycle.providers.where(id: providers_ids))
                               .search_by_code_or_name(params[:query])
                               .limit(10)
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -118,6 +118,11 @@ class Provider < ApplicationRecord
   scope :by_name_ascending, -> { order(provider_name: :asc) }
   scope :by_name_descending, -> { order(provider_name: :desc) }
 
+  scope :with_findable_courses, -> do
+    where(id: Course.findable.select(:provider_id))
+      .or(self.where(provider_code: Course.findable.select(:accrediting_provider_code)))
+  end
+
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer
 
   validates :train_with_us, words_count: { maximum: 250, message: "^Reduce the word count for training with you" }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -588,6 +588,47 @@ describe Provider, type: :model do
     end
   end
 
+  describe "scopes" do
+    describe ".with_findable_courses" do
+      let(:findable_course) do
+        create(:course, site_statuses: [build(:site_status, :findable)])
+      end
+
+      let(:findable_course_with_accrediting_provider) do
+        create(:course, :with_accrediting_provider, site_statuses: [build(:site_status, :findable)])
+      end
+
+      let(:non_findable_course) do
+        create(:course, site_statuses: [build(:site_status)])
+      end
+
+      let(:non_findable_course_with_accrediting_provider) do
+        create(:course, :with_accrediting_provider, site_statuses: [build(:site_status)])
+      end
+
+      before do
+        findable_course
+        findable_course_with_accrediting_provider
+        non_findable_course
+        non_findable_course_with_accrediting_provider
+      end
+
+      subject {
+        described_class.with_findable_courses
+      }
+
+      it "should return only findable courses' provider and/or accrediting provider" do
+        expect(subject).to include(findable_course.provider,
+                                   findable_course_with_accrediting_provider.provider,
+                                   findable_course_with_accrediting_provider.accrediting_provider)
+
+        expect(subject).to_not include(non_findable_course.provider,
+                                       non_findable_course_with_accrediting_provider.provider,
+                                       non_findable_course_with_accrediting_provider.accrediting_provider)
+      end
+    end
+  end
+
   describe "geolocation" do
     include ActiveJob::TestHelper
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -606,25 +606,50 @@ describe Provider, type: :model do
         create(:course, :with_accrediting_provider, site_statuses: [build(:site_status)])
       end
 
-      before do
-        findable_course
-        findable_course_with_accrediting_provider
-        non_findable_course
-        non_findable_course_with_accrediting_provider
-      end
-
       subject {
         described_class.with_findable_courses
       }
 
       it "should return only findable courses' provider and/or accrediting provider" do
-        expect(subject).to include(findable_course.provider,
-                                   findable_course_with_accrediting_provider.provider,
-                                   findable_course_with_accrediting_provider.accrediting_provider)
+        expect(subject).to contain_exactly(findable_course.provider,
+                                           findable_course_with_accrediting_provider.provider,
+                                           findable_course_with_accrediting_provider.accrediting_provider)
+      end
 
-        expect(subject).to_not include(non_findable_course.provider,
-                                       non_findable_course_with_accrediting_provider.provider,
-                                       non_findable_course_with_accrediting_provider.accrediting_provider)
+      context "when the provider is the accredited body for a course" do
+        before do
+          findable_course_with_accrediting_provider
+          non_findable_course_with_accrediting_provider
+        end
+
+        it "is returned" do
+          expect(subject).to contain_exactly(
+            findable_course_with_accrediting_provider.provider,
+            findable_course_with_accrediting_provider.accrediting_provider,
+          )
+        end
+      end
+
+      context "when the course is delivered by the provider" do
+        before do
+          findable_course
+          non_findable_course
+        end
+        it "is returned" do
+          expect(subject).to contain_exactly(findable_course.provider)
+        end
+      end
+
+      context "when the course is not findable" do
+        before do
+          non_findable_course
+          non_findable_course_with_accrediting_provider
+        end
+        it "is not returned" do
+          expect(subject).to_not include(non_findable_course.provider,
+                                         non_findable_course_with_accrediting_provider.provider,
+                                         non_findable_course_with_accrediting_provider.accrediting_provider)
+        end
       end
     end
   end

--- a/spec/requests/api/v3/providers/suggest_provider_spec.rb
+++ b/spec/requests/api/v3/providers/suggest_provider_spec.rb
@@ -2,8 +2,10 @@ require "rails_helper"
 
 describe "GET /provider-suggestions" do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
-  let(:provider) { create(:provider, provider_name: "PROVIDER 1") }
-  let(:provider2) { create(:provider, provider_name: "PROVIDER 2") }
+  let(:courses) { [build(:course, site_statuses: [build(:site_status, :findable)])] }
+  let(:courses2) { [build(:course, site_statuses: [build(:site_status, :findable)])] }
+  let(:provider) { create(:provider, provider_name: "PROVIDER 1", courses: courses) }
+  let(:provider2) { create(:provider, provider_name: "PROVIDER 2", courses: courses2) }
 
   context "current recruitment cycle" do
     before do
@@ -68,7 +70,8 @@ describe "GET /provider-suggestions" do
 
   it "limits responses to a maximum of 10 items" do
     11.times do
-      create(:provider, provider_name: "provider X")
+      courses = [build(:course, site_statuses: [build(:site_status, :findable)])]
+      create(:provider, provider_name: "provider X", courses: courses)
     end
 
     get "/api/v3/provider-suggestions?query=provider"


### PR DESCRIPTION
### Context
prevention for suggesting providers with no courses

### Changes proposed in this pull request
Added prevention for suggesting providers with no courses

### Guidance to review
Provider that are either the accredited body or the provider of a findable course will only be shown

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
