### PR TITLE
[3086] De-duplicate search results

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -11,7 +11,7 @@ module API
         render jsonapi: paginate(course_search),
           fields: fields_param,
           include: params[:include],
-          meta: { count: course_search.count },
+          meta: { count: course_search.count("course.id") },
           class: CourseSerializersServiceV3.new.execute
       end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/c8h5V8zx/3086-qa-order-by-distance-not-always-correct
- This removes duplicates from search results
- Duplicates mainly due to courses having multiple sites

### Changes proposed in this pull request

- when sorting by distance from origin deal with courses with multiple
sites
- only return a course once even if it has multiple sites
- use the closest site when sorting by distance
- only use site that are new or running
- now select `distinct` courses for search results
- meta count scopes to `course.id`
- add tests to cover duplicate results bug

### Guidance to review

- http://localhost:3002/results?fulltime=False&hasvacancies=True&l=1&lat=50.82253000000001&lng=-0.137163&loc=Brighton%2C+UK&lq=Brighton%2C+UK&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&rad=20&senCourses=false&sortby=2&subjects=31
- There should be no duplicate courses
- Courses should be sorted by distance

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
