### PR TITLE
DRAFT [3097] ignore sites with no address in location searches

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -223,6 +223,10 @@ class Course < ApplicationRecord
     where(is_send: true)
   end
 
+  scope :with_locatable_site, -> do
+    where(id: SiteStatus.with_locatable_site.select(:course_id))
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -56,6 +56,8 @@ class Site < ApplicationRecord
 
   after_commit -> { GeocodeJob.perform_later("Site", id) }, if: :needs_geolocation?
 
+  scope :with_locatable_address, -> { where.not(address1: "").or(Site.unscoped.where.not(postcode: "")) }
+
   def needs_geolocation?
     full_address.present? && (
     latitude.nil? || longitude.nil? || address_changed?

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -87,6 +87,8 @@ class SiteStatus < ApplicationRecord
     !no_vacancies?
   end
 
+  scope :with_locatable_site, -> { where(site_id: Site.with_locatable_address.select(:id)) }
+
   def self.default_vac_status_given(study_mode:)
     case study_mode
     when "full_time"

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -12,7 +12,8 @@ class CourseSearchService
   end
 
   def call
-    scope = course_scope.findable
+    scope = course_scope.with_locatable_site
+    scope = scope.findable
 
     scope = scope.ascending_canonical_order if sort_by_provider_ascending?
     scope = scope.descending_canonical_order if sort_by_provider_descending?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -894,6 +894,33 @@ describe Course, type: :model do
         it { is_expected.to be_empty }
       end
     end
+
+    describe "with_locatable_site" do
+      subject { described_class.with_locatable_site }
+
+      let!(:course) { create(:course) }
+
+      before do
+        allow(SiteStatus).to receive(:with_locatable_site).and_return(locatable_scope = double)
+        allow(locatable_scope).to receive(:select).with(:course_id).and_return(locatable_site_course_ids)
+      end
+
+      context "when the course has a locatable site" do
+        let(:locatable_site_course_ids) { [course.id] }
+
+        it "is returned" do
+          expect(subject).to contain_exactly(course)
+        end
+      end
+
+      context "when the course does not have a locatable site" do
+        let(:locatable_site_course_ids) { [] }
+
+        it "is not returned" do
+          expect(subject).not_to contain_exactly(course)
+        end
+      end
+    end
   end
 
   describe "changed_at" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -173,5 +173,51 @@ describe Site, type: :model do
         end
       end
     end
+
+    describe ".with_locatable_address" do
+      subject { described_class.with_locatable_address }
+      let!(:site) do
+        build(:site, address1: address1, postcode: postcode).tap do |site|
+          site.save(validate: false)
+        end
+      end
+
+      context "when a site has a postcode" do
+        let(:postcode) { "L1 9AA" }
+
+        context "and the site has an address line 1" do
+          let(:address1) { "1 Address Street" }
+
+          it "is returned" do
+            expect(subject).to contain_exactly(site)
+          end
+        end
+
+        context "and the site has no address line 1" do
+          let(:address1) { "" }
+          it "is returned" do
+            expect(subject).to contain_exactly(site)
+          end
+        end
+      end
+
+      context "when a site has no postcode" do
+        let(:postcode) { "" }
+
+        context "and the  site has an address line 1" do
+          let(:address1) { "1 Address Street" }
+          it "is returned" do
+            expect(subject).to contain_exactly(site)
+          end
+        end
+
+        context "and the site has no address line 1" do
+          let(:address1) { "" }
+          it "is not returned" do
+            expect(subject).not_to contain_exactly(site)
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -185,4 +185,26 @@ RSpec.describe SiteStatus, type: :model do
       end
     end
   end
+
+  describe ".with_locatable_site" do
+    subject { described_class.with_locatable_site }
+    let(:site_status) { create(:site_status) }
+
+    before do
+      allow(Site).to receive(:with_locatable_address).and_return(locatable_scope = double)
+      allow(locatable_scope).to receive(:select).with(:id).and_return(locatable_site_ids)
+    end
+
+    context "when the site status has a locatable site" do
+      let(:locatable_site_ids) { [site_status.site_id] }
+
+      it { is_expected.to contain_exactly(site_status) }
+    end
+
+    context "when the site status does not have a locatable site" do
+      let(:locatable_site_ids) { [] }
+
+      it { is_expected.not_to contain_exactly(site_status) }
+    end
+  end
 end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -13,6 +13,7 @@ describe CourseSearchService do
     end
 
     let(:scope) { class_double(Course) }
+    let(:locatable_site_scope) { class_double(Course) }
     let(:findable_scope) { class_double(Course) }
     let(:filter) { nil }
     let(:sort) { nil }
@@ -20,7 +21,8 @@ describe CourseSearchService do
     subject { described_class.call(filter: filter, sort: sort, course_scope: scope) }
 
     before do
-      allow(scope).to receive(:findable).and_return(findable_scope)
+      allow(scope).to receive(:with_locatable_site).and_return(locatable_site_scope)
+      allow(locatable_site_scope).to receive(:findable).and_return(findable_scope)
     end
 
     describe "sort by" do


### PR DESCRIPTION
**DRAFT - NOT READY FOR REVIEW**

### Context

Some of the site records in the DB contain inadequate address data. We have decided to continue to omit courses at these sites from search results until we can fix the data.

### Changes proposed in this pull request

Add `Course.with_locatable_site` (which delegates to similar scopes on `SiteStatus` and `Site`) and use it to filter `CourseSearchService` results.

### Guidance to review

I think this code will remove courses without a valid site from all search results. The card only specifies it being removed from location searches and distance ordering. I need to check this before review.

I've added this as a totally separate set of scopes. I think it could also have been incorporated into `.findable` which would have resulted in less changes but I decided it was better to make it explicit as `findable` is already a bit 'mysterious' and adding to it would only make things worse. This code should also only be a stop gap while we clean the data, after which, this PR could be reverted.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
