### PR TITLE
[3097] Exclude non-locatable sites from ordering

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -52,6 +52,12 @@ private
     # only want new and running sites
     new_and_running_sites = sites_with_status.where(site_status[:status].in(%w[new_status running]))
 
+    # only sites that have a locatable address
+    # there are some sites with no address1 or postcode that cannot be
+    # accurately geocoded. We don't want to return these as the closest site.
+    # This should be removed once the data is fixed
+    new_and_running_sites = new_and_running_sites.where(sites[:address1].not_eq("").or(sites[:postcode].not_eq("")))
+
     # select course_id and nearest site with shortest distance from origin
     # as courses may have multiple sites
     # this will remove duplicates by aggregating on course_id


### PR DESCRIPTION
### Context

When we calculate the nearest site for a course we want to exclude sites
that have insufficient address data as they cannot be accurately
geocoded.

### Changes proposed in this pull request

Add a where clause that only includes sites if they have an `address1` or
`postcode` value when building the sites with distance Arel table.

### Guidance to review

To test run a location search. Select one of the lower ranking results. In the console create a `Site` with only lat, lng, code and provider ID and `save(validate: false)`. Use the lat and lng of the search and the provider ID of the chosen course. Add the site to the course `Course.sites << site`. This course should now appear first before this change but remain in its original position after the change.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally

Before: The course Chemistry(test) has had a site with no address added that has a lat/lng that matches the search criteria. So it is first even though the site has no other address data.

<img width="1101" alt="Screenshot 2020-03-11 at 10 41 53" src="https://user-images.githubusercontent.com/5216/76408633-232a5b00-6385-11ea-8b31-c76f57e072a7.png">

After: The course now sits third as the site it has that has complete address data has been used for distance calculation

<img width="1102" alt="Screenshot 2020-03-11 at 10 45 23" src="https://user-images.githubusercontent.com/5216/76408808-72708b80-6385-11ea-91c3-07354a807e27.png">
