### PR TITLE
[3108] Improve parallel specs

### DIFF
--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -1,0 +1,3 @@
+--require rails_helper
+--format progress
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -86,4 +86,14 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  # Report N+1 queries
+  if Bullet.enable?
+    config.before(:each) { Bullet.start_request }
+    config.after(:each)  { Bullet.end_request }
+  end
+
+  config.include ActiveJob::TestHelper, type: :request
+
+  ActiveJob::Base.queue_adapter = :test
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -139,14 +139,4 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
   config.include JSONAPI::RSpec
-
-  # Report N+1 queries
-  if Bullet.enable?
-    config.before(:each) { Bullet.start_request }
-    config.after(:each)  { Bullet.end_request }
-  end
-
-  config.include ActiveJob::TestHelper, type: :request
-
-  ActiveJob::Base.queue_adapter = :test
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/VKUaOutH/3108-improve-parallel-tests-speed
- Improve test suite running time

### Changes proposed in this pull request

- This uses a feature in parallel_tests to even tests across cores
- This is done by logging test run times
- For me this has shaved 2 minutes off the test suite

### Guidance to review

- Run the test suite via `bundle exec rake` twice
- The second run through should be quicker

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
