### PR TITLE
[3080] Format date time to our standard format

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -24,6 +24,6 @@ private
   end
 
   def format_update_datetime(datetime)
-    datetime.strftime("%-k.%M on %-e %B %Y")
+    datetime.strftime("%-k:%M%P on %-e %B %Y")
   end
 end

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -36,7 +36,7 @@ describe CourseUpdateEmailMailer, type: :mailer do
     end
 
     it "includes the datetime for the detail update in the personalisation" do
-      expect(mail.govuk_notify_personalisation[:attribute_change_datetime]).to eq("4.05 on 3 February 2001")
+      expect(mail.govuk_notify_personalisation[:attribute_change_datetime]).to eq("4:05am on 3 February 2001")
     end
 
     it "includes the URL for the course in the personalisation" do


### PR DESCRIPTION
### Context

### Changes proposed in this pull request
Update time format from 14:54 to 2:54pm in the course changes notifications emails.

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
