### PR TITLE
[3117] - Course updated notification: update "view course" link

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -17,7 +17,7 @@ class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
 private
 
   def create_course_url(course)
-    "#{Settings.publish_url}" \
+    "#{Settings.find_url}" \
       "/organisations/#{course.provider.provider_code}" \
       "/#{course.provider.recruitment_cycle.year}" \
       "/courses/#{course.course_code}"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,7 @@ govuk_notify:
   welcome_email_template_id: please_change_me
   course_update_email_template_id: please_change_me
 publish_url: http://localhost:3000
+find_url: http://localhost:3002
 mcbg:
   redis_password: <%= SecureRandom.base64 %>
 system_authentication_token: <%= SecureRandom.base64 %>

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,3 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
+find_url: https://www2.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -8,3 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
+find_url: https://www2.qa.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,3 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
+find_url: https://www2.staging.find-postgraduate-teacher-training.education.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,3 +5,4 @@ govuk_notify:
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
+find_url: https://www2.find-postgraduate-teacher-training.education.gov.uk

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -40,7 +40,7 @@ describe CourseUpdateEmailMailer, type: :mailer do
     end
 
     it "includes the URL for the course in the personalisation" do
-      url = "#{Settings.publish_url}" \
+      url = "#{Settings.find_url}" \
         "/organisations/#{course.provider.provider_code}" \
         "/#{course.provider.recruitment_cycle.year}" \
         "/courses/#{course.course_code}"


### PR DESCRIPTION
### Context
The "view course" link in the course updated email is linking to course details on Publish instead of Find.

### Changes proposed in this pull request
Course update notification email now links to Find Teacher Training

### Guidance to review
Anyone know how I can test this on QA? 
@danielburnley 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
