### PR TITLE
[3118] Ignore ungeocoded sites in distance search

### DIFF
--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -227,6 +227,25 @@ describe "GET v3/courses" do
           expect(course_hashes.second["id"]).to eq(course_a.id.to_s)
         end
       end
+
+      context "when a course has a site that has not been geocoded" do
+        let(:ungeocoded_site) do
+          build(:site, latitude: nil, longitude: nil)
+        end
+
+        before do
+          course_a.site_statuses << build(:site_status, :findable, site: ungeocoded_site)
+        end
+
+        it "ignores the ungeocoded site in the distance ordering" do
+          get request_path
+
+          json_response = JSON.parse(response.body)
+          course_hashes = json_response["data"]
+          expect(course_hashes.first["id"]).to eq(course_b.id.to_s)
+          expect(course_hashes.second["id"]).to eq(course_a.id.to_s)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# Context

- https://trello.com/c/fYgK7vnQ/3118-sort-by-distance-only-uses-sites-that-have-been-geocoded
- We are not excluding un-geocoded sites from distance sorting
- These sites are then deemed be at the origin of the search query as a result

### Changes proposed in this pull request

- When sorting by distance we exclude any site that has not been geocoded
- These are sites that do not have latitude and longitude present

### Guidance to review

- visit http://localhost:3002/results?fulltime=False&hasvacancies=True&l=1&lat=53.9588365&lng=-1.0794777&loc=York+YO1%2C+UK&lq=York+YO1%2C+UK&parttime=False&qualifications=QtsOnly%2CPgdePgceWithQts%2COther&rad=20&senCourses=False&sortby=2&subjects=31%2C32
- Results should be ordered correctly

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally