### PR TITLE
[3111] Cleanup time formats

### DIFF
--- a/app/controllers/concerns/next_link_header.rb
+++ b/app/controllers/concerns/next_link_header.rb
@@ -1,5 +1,6 @@
 module NextLinkHeader
   extend ActiveSupport::Concern
+  include TimeFormat
 
 private
 
@@ -10,8 +11,7 @@ private
     next_url_params[:per_page] = params[:per_page]
 
     if last_object.present?
-      next_url_params[:changed_since] =
-        incremental_load_timestamp_format last_object.changed_at
+      next_url_params[:changed_since] = precise_time(last_object.changed_at)
     end
 
     if params[:recruitment_year].nil?
@@ -20,15 +20,5 @@ private
     else
       response.headers["Link"] = "#{url_for(recruitment_year: params[:recruitment_year], params: next_url_params)}; rel=\"next\""
     end
-  end
-
-  def incremental_load_timestamp_format(timestamp)
-    # When we extract the changed_at from the last provider, format it with
-    # sub-second timing information (micro-seconds) so that our incremental
-    # fetch can handle many records being updated within the same second.
-    #
-    # The strftime format '%FT%T.%6NZ' is similar to the ISO8601 standard,
-    # (equivalent to %FT%TZ) and adds micro-seconds (%6N).
-    timestamp.strftime("%FT%T.%6NZ")
   end
 end

--- a/app/lib/time_format.rb
+++ b/app/lib/time_format.rb
@@ -1,0 +1,18 @@
+module TimeFormat
+  # Primarily so that our incremental fetch can handle many records being
+  # updated within the same second.
+  #
+  # The strftime format '%FT%T.%6NZ' is similar to the ISO8601 standard,
+  # (equivalent to %FT%TZ) and adds micro-seconds (%6N).
+  def precise_time(time)
+    time.strftime("%FT%T.%6NZ")
+  end
+
+  def written_month_year(time)
+    time.strftime("%B %Y")
+  end
+
+  def short_date(time)
+    time.strftime("%d/%m/%Y")
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -39,6 +39,7 @@ class Course < ApplicationRecord
   include ChangedAt
   include Courses::EditOptions
   include StudyModeVacancyMapper
+  include TimeFormat
 
   after_initialize :set_defaults
 
@@ -648,16 +649,16 @@ private
   end
 
   def validate_start_date
-    errors.add :start_date, "#{start_date.strftime('%B %Y')} is not in the #{recruitment_cycle.year} cycle" unless start_date_options.include?(start_date.strftime("%B %Y"))
+    errors.add :start_date, "#{start_date.strftime('%B %Y')} is not in the #{recruitment_cycle.year} cycle" unless start_date_options.include?(written_month_year(start_date))
   end
 
   def validate_applications_open_from
     if applications_open_from.blank?
       errors.add(:applications_open_from, :blank)
     elsif !valid_date_range.include?(applications_open_from)
-      chosen_date = applications_open_from.strftime("%d/%m/%Y")
-      start_date = recruitment_cycle.application_start_date.strftime("%d/%m/%Y")
-      end_date = recruitment_cycle.application_end_date.strftime("%d/%m/%Y")
+      chosen_date = short_date(applications_open_from)
+      start_date = short_date(recruitment_cycle.application_start_date)
+      end_date = short_date(recruitment_cycle.application_end_date)
       errors.add(
         :applications_open_from,
         "#{chosen_date} is not valid for the #{provider.recruitment_cycle.year} cycle. " +

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SerializableCourse < JSONAPI::Serializable::Resource
+      include TimeFormat
+
       class << self
         def enrichment_attribute(name, enrichment_name = name)
           attribute name do
@@ -19,7 +21,7 @@ module API
                  :accrediting_provider_code, :level
 
       attribute :start_date do
-        @object.start_date.strftime("%B %Y") if @object.start_date
+        written_month_year(@object.start_date) if @object.start_date
       end
 
       attribute :applications_open_from do

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -1,6 +1,8 @@
 module API
   module V3
     class SerializableCourse < JSONAPI::Serializable::Resource
+      include TimeFormat
+
       class << self
         def enrichment_attribute(name, enrichment_name = name)
           attribute name do
@@ -22,7 +24,7 @@ module API
                  :accrediting_provider_code, :level, :changed_at
 
       attribute :start_date do
-        @object.start_date.strftime("%B %Y") if @object.start_date
+        written_month_year(@object.start_date) if @object.start_date
       end
 
       attribute :applications_open_from do

--- a/spec/lib/time_format.rb
+++ b/spec/lib/time_format.rb
@@ -1,0 +1,19 @@
+describe TimeFormat do
+  describe "#precise_time" do
+    it "returns the time in the precise format" do
+      expect(precise_time(Time.utc(1993, 9, 1, 3, 14, 15, 926535))).to eq("1993-09-01T03:14:15.926535Z")
+    end
+  end
+
+  describe "#written_month_year" do
+    it "Year and month in written format" do
+      expect(written_month_year(Time.utc(2019, 8))).to eq("August 2019")
+    end
+  end
+
+  describe "#short_date" do
+    it "Short date" do
+      expect(short_date(Time.utc(2000, 8, 25))).to eq("25/08/2000")
+    end
+  end
+end


### PR DESCRIPTION
### Context
There are a number of date formats used across TTAPI and it's possible that these could begin diverging in implementation as we proceed with adding notifications.

### Changes proposed in this pull request
DRY up all time date formatting using a module.

### Guidance to review
This provides a place for the date format needed by notifications to live.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
