### PR TITLE
[3120] - Accept non-alphanumeric provider suggestion queries

### DIFF
--- a/app/controllers/api/v3/provider_suggestions_controller.rb
+++ b/app/controllers/api/v3/provider_suggestions_controller.rb
@@ -5,7 +5,6 @@ module API
 
       def index
         return render(status: :bad_request) if params[:query].nil? || params[:query].length < 3
-        return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         found_providers = @recruitment_cycle.providers
                               .with_findable_courses

--- a/spec/requests/api/v3/providers/suggest_provider_spec.rb
+++ b/spec/requests/api/v3/providers/suggest_provider_spec.rb
@@ -79,13 +79,13 @@ describe "GET /provider-suggestions" do
     expect(JSON.parse(response.body)["data"].length).to eq(10)
   end
 
-  it "returns bad request if query is empty" do
+  it "returns status: bad request (400) if query is empty" do
     get "/api/v3/provider-suggestions"
 
     expect(response.status).to eq(400)
   end
 
-  it "returns bad request if query is too short" do
+  it "returns status: bad request (400) if query is too short" do
     provider
 
     get "/api/v3/provider-suggestions?query=#{provider.provider_name[0, 2]}"
@@ -93,9 +93,9 @@ describe "GET /provider-suggestions" do
     expect(response.status).to eq(400)
   end
 
-  it "returns bad request if start of query is not alphanumeric" do
+  it "returns status: success (200) if start of query is not alphanumeric" do
     get "/api/v3/provider-suggestions?query=%22%22%22%22"
 
-    expect(response.status).to eq(400)
+    expect(response.status).to eq(200)
   end
 end


### PR DESCRIPTION
### Context
Please see https://github.com/DFE-Digital/find-teacher-training/pull/197 for further context. This PR should be merged first. 

The ProviderSuggestions controller should process encoded queries and not return a Bad request status (400) by default. If a provider search still returns no results then the API will return an empty array and 200 status.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
