### PR TITLE
[3130] Add redisCacheSKU to ARM template

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -222,6 +222,10 @@
         "description": "The name of the Azure Redis Cache to create."
       }
     },
+    "redisCacheSKU": {
+      "type": "string",
+      "defaultValue": "Basic"
+    },
     "logstashHost": {
       "type": "string",
       "metadata": {
@@ -819,6 +823,9 @@
           },
           "minimumTlsVersion":{
             "value": "1.2"
+          },
+          "redisCacheSKU":{
+            "value": "[parameters('redisCacheSKU')]"
           }
         }
       }


### PR DESCRIPTION
### Context
On 11 March 2020 at 9:20pm we had an outage on Azure Redis Cache. This was caused by Microsoft patching the underlying resources.
Since we are using Basic tier, when that once VM goes down for patching (either OS or Redis Runtime), then the Redis instance will be inaccessible for the duration of the pating. For this reason we do not offer an SLA for the Basic cache SKU. Basic caches are good for test/development environments but if your cache is not able to tolerate this kind of downtime, we suggest you to go with a Standard cache which does offer an SLA.

### Changes proposed in this pull request
Parameterise the redis template ARM so we can specify a different instance type with high availability.

### Guidance to review
Review the redis ARM template and the building block.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
