### PR TITLE
[3116] Add previous value and current value to change email notification

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -16,8 +16,8 @@ class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
       attribute_changed: I18n.t("course.update_email.#{attribute_name}"),
       attribute_change_datetime: format_update_datetime(course.updated_at),
       course_url: create_course_url(course),
-      original_value: original_value,
-      updated_value: updated_value,
+      original_value: formatter.call(name: attribute_name, value: original_value),
+      updated_value: formatter.call(name: attribute_name, value: updated_value),
     )
 
     mail(to: recipient.email)
@@ -33,5 +33,9 @@ private
 
   def format_update_datetime(datetime)
     datetime.strftime("%-k:%M%P on %-e %B %Y")
+  end
+
+  def formatter
+    CourseAttributeFormatterService
   end
 end

--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -13,7 +13,7 @@ class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
       provider_name: course.provider.provider_name,
       course_name: course.name,
       course_code: course.course_code,
-      attribute_changed: attribute_name,
+      attribute_changed: I18n.t("course.update_email.#{attribute_name}"),
       attribute_change_datetime: format_update_datetime(course.updated_at),
       course_url: create_course_url(course),
       original_value: original_value,

--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -1,17 +1,26 @@
 class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
-  def course_update_email(course, attribute_changed, user)
+  def course_update_email(
+    course:,
+    attribute_name:,
+    original_value:,
+    updated_value:,
+    recipient:
+  )
+
     set_template(Settings.govuk_notify.course_update_email_template_id)
 
     set_personalisation(
       provider_name: course.provider.provider_name,
       course_name: course.name,
       course_code: course.course_code,
-      attribute_changed: attribute_changed,
+      attribute_changed: attribute_name,
       attribute_change_datetime: format_update_datetime(course.updated_at),
       course_url: create_course_url(course),
+      original_value: original_value,
+      updated_value: updated_value,
     )
 
-    mail(to: user.email)
+    mail(to: recipient.email)
   end
 
 private

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -275,9 +275,11 @@ class Course < ApplicationRecord
 
     users.each do |user|
       CourseUpdateEmailMailer.course_update_email(
-        self,
-        I18n.t("course.update_email.#{updated_attribute}"),
-        user,
+        course: self,
+        attribute_name: I18n.t("course.update_email.#{updated_attribute}"),
+        original_value: saved_changes[updated_attribute].first,
+        updated_value: saved_changes[updated_attribute].second,
+        recipient: user,
       ).deliver_now
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -276,7 +276,7 @@ class Course < ApplicationRecord
     users.each do |user|
       CourseUpdateEmailMailer.course_update_email(
         course: self,
-        attribute_name: I18n.t("course.update_email.#{updated_attribute}"),
+        attribute_name: updated_attribute,
         original_value: saved_changes[updated_attribute].first,
         updated_value: saved_changes[updated_attribute].second,
         recipient: user,

--- a/app/services/course_attribute_formatter_service.rb
+++ b/app/services/course_attribute_formatter_service.rb
@@ -1,0 +1,63 @@
+class CourseAttributeFormatterService
+  def initialize(name:, value:)
+    @name = name
+    @value = value
+  end
+
+  class << self
+    def call(**args)
+      new(args).call
+    end
+  end
+
+  def call
+    return age_range_value if age_range?
+    return qualification_value if qualification?
+    return study_mode_value if study_mode?
+    return entry_requirements_value if entry_requirements?
+
+    value
+  end
+
+  private_class_method :new
+
+private
+
+  attr_reader :name, :value
+
+  def age_range?
+    name == "age_range_in_years"
+  end
+
+  def age_range_value
+    strip_underscores
+  end
+
+  def qualification?
+    name == "qualification"
+  end
+
+  def qualification_value
+    I18n.t("course.values.qualification.#{value}")
+  end
+
+  def study_mode?
+    name == "study_mode"
+  end
+
+  def study_mode_value
+    strip_underscores
+  end
+
+  def entry_requirements?
+    %w(maths english science).include?(name)
+  end
+
+  def entry_requirements_value
+    strip_underscores
+  end
+
+  def strip_underscores
+    value.tr("_", " ")
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,13 @@ en:
       science: "entry requirements"
       maths: "entry requirements"
       english: "entry requirements"
+    values:
+      qualification:
+        qts: "QTS"
+        pgce_with_qts: "PGCE with QTS"
+        pgce: "PGCE"
+        pgde_with_qts: "PGDE with QTS"
+        pgde: "PGDE"
   activerecord:
     attributes:
       course_enrichment:

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -16,6 +16,16 @@ describe CourseUpdateEmailMailer, type: :mailer do
   before do
     course
     mail
+
+    allow(CourseAttributeFormatterService)
+      .to receive(:call)
+      .with(name: "qualification", value: "original")
+      .and_return("ORIGINAL")
+
+    allow(CourseAttributeFormatterService)
+      .to receive(:call)
+      .with(name: "qualification", value: "updated")
+      .and_return("UPDATED")
   end
 
   context "sending an email to a user" do
@@ -48,11 +58,11 @@ describe CourseUpdateEmailMailer, type: :mailer do
     end
 
     it "includes the original value" do
-      expect(mail.govuk_notify_personalisation[:original_value]).to eq("original")
+      expect(mail.govuk_notify_personalisation[:original_value]).to eq("ORIGINAL")
     end
 
     it "includes the updated value" do
-      expect(mail.govuk_notify_personalisation[:updated_value]).to eq("updated")
+      expect(mail.govuk_notify_personalisation[:updated_value]).to eq("UPDATED")
     end
 
     it "includes the URL for the course in the personalisation" do

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -40,7 +40,7 @@ describe CourseUpdateEmailMailer, type: :mailer do
     end
 
     it "includes the updated detail in the personalisation" do
-      expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("name")
+      expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("outcome")
     end
 
     it "includes the datetime for the detail update in the personalisation" do

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -3,7 +3,15 @@ require "rails_helper"
 describe CourseUpdateEmailMailer, type: :mailer do
   let(:course) { create(:course, :with_accrediting_provider, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6)) }
   let(:user) { create(:user) }
-  let(:mail) { described_class.course_update_email(course, "name", user) }
+  let(:mail) do
+    described_class.course_update_email(
+      course: course,
+      attribute_name: "qualification",
+      original_value: "original",
+      updated_value: "updated",
+      recipient: user,
+    )
+  end
 
   before do
     course
@@ -37,6 +45,14 @@ describe CourseUpdateEmailMailer, type: :mailer do
 
     it "includes the datetime for the detail update in the personalisation" do
       expect(mail.govuk_notify_personalisation[:attribute_change_datetime]).to eq("4:05am on 3 February 2001")
+    end
+
+    it "includes the original value" do
+      expect(mail.govuk_notify_personalisation[:original_value]).to eq("original")
+    end
+
+    it "includes the updated value" do
+      expect(mail.govuk_notify_personalisation[:updated_value]).to eq("updated")
     end
 
     it "includes the URL for the course in the personalisation" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2202,11 +2202,14 @@ describe Course, type: :model do
           end
 
           it "Sends the notification to the correct user" do
-            expect(mailer_spy).to have_received(:course_update_email) do |course, attribute_changed, user|
-              expect(course).to eq(course)
-              expect(attribute_changed).to eq(expected_attribute_change)
-              expect(user).to eq(user_one)
-            end
+            expect(mailer_spy).to have_received(:course_update_email)
+              .with(
+                course: course,
+                attribute_name: expected_attribute_change,
+                original_value: expected_original_value,
+                updated_value: expected_updated_value,
+                recipient: user_one,
+            )
           end
 
           it "Delivers the email" do
@@ -2227,43 +2230,55 @@ describe Course, type: :model do
 
         context "When the course appears on find" do
           context "Age range in years" do
-            let(:course_update) { { age_range_in_years: "10_to_14" } }
+            let(:course_update) { { age_range_in_years: expected_updated_value } }
             let(:expected_attribute_change) { "age range" }
+            let(:expected_original_value) { "11_to_15" }
+            let(:expected_updated_value) { "10_to_14" }
 
             include_examples "Sending update notifications"
           end
 
-          context "Qualfication" do
-            let(:course_update) { { qualification: "pgde_with_qts" } }
+          context "Qualification" do
+            let(:course_update) { { qualification: expected_updated_value } }
             let(:expected_attribute_change) { "outcome" }
+            let(:expected_original_value) { "pgce_with_qts" }
+            let(:expected_updated_value) { "pgde_with_qts" }
 
             include_examples "Sending update notifications"
           end
 
           context "Study mode" do
-            let(:course_update) { { study_mode: "part_time" } }
+            let(:course_update) { { study_mode: expected_updated_value } }
             let(:expected_attribute_change) { "full or part time" }
+            let(:expected_original_value) { "full_time" }
+            let(:expected_updated_value) { "part_time" }
 
             include_examples "Sending update notifications"
           end
 
           context "Entry requirements: Maths" do
-            let(:course_update) { { maths: "not_required" } }
+            let(:course_update) { { maths: expected_updated_value } }
             let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_original_value) { "equivalence_test" }
+            let(:expected_updated_value) { "not_required" }
 
             include_examples "Sending update notifications"
           end
 
           context "Entry requirements: English" do
-            let(:course_update) { { english: "not_required" } }
+            let(:course_update) { { english: expected_updated_value } }
             let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_original_value) { "equivalence_test" }
+            let(:expected_updated_value) { "not_required" }
 
             include_examples "Sending update notifications"
           end
 
           context "Entry requirements: Science" do
-            let(:course_update) { { science: "not_required" } }
+            let(:course_update) { { science: expected_updated_value } }
             let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_original_value) { "must_have_qualification_at_application_time" }
+            let(:expected_updated_value) { "not_required" }
 
             include_examples "Sending update notifications"
           end
@@ -2294,9 +2309,7 @@ describe Course, type: :model do
         it "only sends the email for the courses accrediting provider" do
           course.update!(age_range_in_years: "10_to_14")
 
-          expect(mailer_spy).to have_received(:course_update_email) do |_course, _attribute, user|
-            expect(user).to eq(user_one)
-          end
+          expect(mailer_spy).to have_received(:course_update_email).with(hash_including(recipient: user_one))
         end
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2231,7 +2231,7 @@ describe Course, type: :model do
         context "When the course appears on find" do
           context "Age range in years" do
             let(:course_update) { { age_range_in_years: expected_updated_value } }
-            let(:expected_attribute_change) { "age range" }
+            let(:expected_attribute_change) { "age_range_in_years" }
             let(:expected_original_value) { "11_to_15" }
             let(:expected_updated_value) { "10_to_14" }
 
@@ -2240,7 +2240,7 @@ describe Course, type: :model do
 
           context "Qualification" do
             let(:course_update) { { qualification: expected_updated_value } }
-            let(:expected_attribute_change) { "outcome" }
+            let(:expected_attribute_change) { "qualification" }
             let(:expected_original_value) { "pgce_with_qts" }
             let(:expected_updated_value) { "pgde_with_qts" }
 
@@ -2249,7 +2249,7 @@ describe Course, type: :model do
 
           context "Study mode" do
             let(:course_update) { { study_mode: expected_updated_value } }
-            let(:expected_attribute_change) { "full or part time" }
+            let(:expected_attribute_change) { "study_mode" }
             let(:expected_original_value) { "full_time" }
             let(:expected_updated_value) { "part_time" }
 
@@ -2258,7 +2258,7 @@ describe Course, type: :model do
 
           context "Entry requirements: Maths" do
             let(:course_update) { { maths: expected_updated_value } }
-            let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_attribute_change) { "maths" }
             let(:expected_original_value) { "equivalence_test" }
             let(:expected_updated_value) { "not_required" }
 
@@ -2267,7 +2267,7 @@ describe Course, type: :model do
 
           context "Entry requirements: English" do
             let(:course_update) { { english: expected_updated_value } }
-            let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_attribute_change) { "english" }
             let(:expected_original_value) { "equivalence_test" }
             let(:expected_updated_value) { "not_required" }
 
@@ -2276,7 +2276,7 @@ describe Course, type: :model do
 
           context "Entry requirements: Science" do
             let(:course_update) { { science: expected_updated_value } }
-            let(:expected_attribute_change) { "entry requirements" }
+            let(:expected_attribute_change) { "science" }
             let(:expected_original_value) { "must_have_qualification_at_application_time" }
             let(:expected_updated_value) { "not_required" }
 

--- a/spec/services/course_attribute_formatter_service_spec.rb
+++ b/spec/services/course_attribute_formatter_service_spec.rb
@@ -1,0 +1,135 @@
+require_relative "../../app/services/course_attribute_formatter_service"
+
+RSpec.describe CourseAttributeFormatterService do
+  subject { CourseAttributeFormatterService.call(name: name, value: value) }
+
+  context "with an attribute that doesn't require formatting" do
+    let(:name) { "name" }
+    let(:value) { "course name" }
+
+    it "is returned" do
+      expect(subject).to eq(value)
+    end
+  end
+
+  context "with an age range" do
+    let(:name) { "age_range_in_years" }
+    let(:value) { "10_to_14" }
+
+    it "removes underscores" do
+      expect(subject).to eq("10 to 14")
+    end
+  end
+
+  context "with a qualification" do
+    let(:name) { "qualification" }
+
+    context "qts" do
+      let(:value) { "qts" }
+      let(:expected_value) { "QTS" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "pgce_with_qts" do
+      let(:value) { "pgce_with_qts" }
+      let(:expected_value) { "PGCE with QTS" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "pgce" do
+      let(:value) { "pgce" }
+      let(:expected_value) { "PGCE" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "pgde_with_qts" do
+      let(:value) { "pgde_with_qts" }
+      let(:expected_value) { "PGDE with QTS" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "pgde" do
+      let(:value) { "pgde" }
+      let(:expected_value) { "PGDE" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+  end
+
+  context "with a study mode" do
+    let(:name) { "study_mode" }
+
+    context "full_time" do
+      let(:value) { "full_time" }
+      let(:expected_value) { "full time" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "full_time_or_part_time" do
+      let(:value) { "full_time_or_part_time" }
+      let(:expected_value) { "full time or part time" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "part_time" do
+      let(:value) { "part_time" }
+      let(:expected_value) { "part time" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+  end
+
+  shared_examples_for "entry requirements" do
+    context "must_have_qualification_at_application_time" do
+      let(:value) { "must_have_qualification_at_application_time" }
+      let(:expected_value) { "must have qualification at application time" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "equivalence_test" do
+      let(:value) { "equivalence_test" }
+      let(:expected_value) { "equivalence test" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "expect_to_achieve_before_training_begins" do
+      let(:value) { "expect_to_achieve_before_training_begins" }
+      let(:expected_value) { "expect to achieve before training begins" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+
+    context "not_required" do
+      let(:value) { "not_required" }
+      let(:expected_value) { "not required" }
+
+      it { is_expected.to eq(expected_value) }
+    end
+  end
+
+  context "maths" do
+    let(:name) { "maths" }
+
+    it_behaves_like "entry requirements"
+  end
+
+  context "english" do
+    let(:name) { "english" }
+
+    it_behaves_like "entry requirements"
+  end
+
+  context "science" do
+    let(:name) { "science" }
+
+    it_behaves_like "entry requirements"
+  end
+end


### PR DESCRIPTION
### Context

We want to send an email notification when a course is updated. The email will contain the name of the attribute that has been updated, the original value and the updated value. This PR adds the original and updated value.

Note: The API currently only supports one attribute being updated per update. This has been implemented because the Publish app only supports updating one attribute at a time (I think). The API does support updating more than one attribute at a time so we shouldn't assume that a caller won't do that. I've not addressed that here. I've added a card to refactor this code too to move the notification and email concerns out of the Course model. [Trello](https://trello.com/c/vItr7tVZ/340-move-notification-sending-out-of-course-callbacks)

### Changes proposed in this pull request

* Update the mailer to receive original and updated field values
* Update `Course` to send the values
* Move formatting of the attribute name into the mailer as it's really a 'view' concern. The mailer is at least a bit closer to the view. We can't do it 'in' the view as that's in Notify.
* Add `CourseAttributeFormatterService` to handle the formatting of the values (they are `under_scored_values` in the DB

### Guidance to review

The template for this is in Notify and it hasn't been updated as yet so it's a bit tricky to review the functionality.

### Implemented formatting

Age: `10_to_14` -> "10 to 14"
Study mode: `part_time` -> "part time"
Qualification: `pgce_with_qts` -> "PGCE with QTS"
Entry requirements: `not_required` -> "not required"

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
