### PR TITLE
[3132] Fix provider including `course.subjects`

### DIFF
--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -23,6 +23,7 @@ module API
                                       )
 
         render jsonapi: @provider,
+               class: CourseSerializersServiceV3.new.execute,
                include: params[:include],
                fields: { providers: %i[provider_code provider_name courses
                                        recruitment_cycle_year address1 address2

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -89,6 +89,12 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
     get request_path, params: request_params
   end
 
+  context "including courses.subjects" do
+    let(:request_params) { { include: "courses.subjects" } }
+
+    it { should have_http_status(:success) }
+  end
+
   context "including sites" do
     let(:request_params) { { include: "sites" } }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/u4DDrH4M/3132-bug-triage-activemodelunknownattributeerror-apiv3providerscontrollershow-error-unknown-attribute-urlhelpers-for-secondarysubject
- showing a provider and including `courses.subjects` would throw an error

### Changes proposed in this pull request

- Including `courses.subjects` on a provider would throw an error
- This is due to it not able to find correct serializer for subjects
- Now use serializer service to find serializer

### Guidance to review

- visit http://localhost:3001/api/v3/recruitment_cycles/2020/providers/1N1?include=courses.subjects
- should not throw an error
- should see json

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
