### PR TITLE
[3139] Fix course link in the notification email

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -18,9 +18,8 @@ private
 
   def create_course_url(course)
     "#{Settings.find_url}" \
-      "/organisations/#{course.provider.provider_code}" \
-      "/#{course.provider.recruitment_cycle.year}" \
-      "/courses/#{course.course_code}"
+      "/course/#{course.provider.provider_code}" \
+      "/#{course.course_code}"
   end
 
   def format_update_datetime(datetime)

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -41,9 +41,8 @@ describe CourseUpdateEmailMailer, type: :mailer do
 
     it "includes the URL for the course in the personalisation" do
       url = "#{Settings.find_url}" \
-        "/organisations/#{course.provider.provider_code}" \
-        "/#{course.provider.recruitment_cycle.year}" \
-        "/courses/#{course.course_code}"
+        "/course/#{course.provider.provider_code}" \
+        "/#{course.course_code}"
       expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
     end
   end


### PR DESCRIPTION
### Context
Email notification points users to t https://www2.qa.find-postgraduate-teacher-training.education.gov.uk/organisations/1DD/2020/courses/28TR which does not exist.

Instead, it should point them to t https://www2.qa.find-postgraduate-teacher-training.education.gov.uk/course/1DD/28TR
### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
