### PR TITLE
[3102] - Move mail notifications to background jobs

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -40,8 +40,7 @@ module API
       end
 
       def send_welcome_email
-        welcome_email_service = SendWelcomeEmailService.new(mailer: WelcomeEmailMailer)
-        welcome_email_service.execute(current_user: @current_user)
+        SendWelcomeJob.perform_later(current_user: @current_user)
       end
     end
   end

--- a/app/jobs/send_course_create_job.rb
+++ b/app/jobs/send_course_create_job.rb
@@ -1,0 +1,7 @@
+class SendCourseCreateJob < ApplicationJob
+  queue_as :mailer
+
+  def perform(course:, user:)
+    CourseCreateEmailMailer.course_create_email(course, user).deliver_now
+  end
+end

--- a/app/jobs/send_course_update_job.rb
+++ b/app/jobs/send_course_update_job.rb
@@ -1,0 +1,13 @@
+class SendCourseUpdateJob < ApplicationJob
+  queue_as :mailer
+
+  def perform(course:, attribute_name:, original_value:, updated_value:, recipient:)
+    CourseUpdateEmailMailer.course_update_email(
+      course: course,
+      attribute_name: attribute_name,
+      original_value: original_value,
+      updated_value: updated_value,
+      recipient: recipient
+    ).deliver_now
+  end
+end

--- a/app/jobs/send_course_update_job.rb
+++ b/app/jobs/send_course_update_job.rb
@@ -7,7 +7,7 @@ class SendCourseUpdateJob < ApplicationJob
       attribute_name: attribute_name,
       original_value: original_value,
       updated_value: updated_value,
-      recipient: recipient
+      recipient: recipient,
     ).deliver_now
   end
 end

--- a/app/jobs/send_welcome_job.rb
+++ b/app/jobs/send_welcome_job.rb
@@ -1,0 +1,7 @@
+class SendWelcomeJob < ApplicationJob
+  queue_as :mailer
+
+  def perform(current_user:)
+    SendWelcomeEmailService.call(current_user: current_user)
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -273,13 +273,13 @@ class Course < ApplicationRecord
     updated_attribute = (saved_changes.keys & update_notification_attributes).first
 
     users.each do |user|
-      CourseUpdateEmailMailer.course_update_email(
+      SendCourseUpdateJob.perform_later(
         course: self,
         attribute_name: updated_attribute,
         original_value: saved_changes[updated_attribute].first,
         updated_value: saved_changes[updated_attribute].second,
         recipient: user,
-      ).deliver_now
+      )
     end
   end
 

--- a/app/services/courses/publish_service.rb
+++ b/app/services/courses/publish_service.rb
@@ -11,10 +11,10 @@ module Courses
 
       users = User.joins(:user_notifications).merge(UserNotification.course_create_notification_requests(course.accrediting_provider_code))
       users.each do |user|
-        CourseCreateEmailMailer.course_create_email(
+        SendCourseCreateJob.perform_later(
           course,
           user,
-        ).deliver_now
+        )
       end
     end
 

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -1,12 +1,14 @@
 class SendWelcomeEmailService
-  def initialize(mailer:)
-    @mailer = mailer
+  class << self
+    def call(current_user:)
+      new.call(current_user: current_user)
+    end
   end
 
-  def execute(current_user:)
+  def call(current_user:)
     return if current_user.welcome_email_date_utc
 
-    @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now
+    WelcomeEmailMailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now
 
     current_user.update(
       welcome_email_date_utc: Time.now.utc,

--- a/bg-mailer/Dockerfile
+++ b/bg-mailer/Dockerfile
@@ -1,0 +1,7 @@
+ARG  DOCKER_REPOSITORY
+ARG  TEACHER_TRAINING_API
+ARG  CODE_VERSION=latest
+
+FROM ${DOCKER_REPOSITORY}/${TEACHER_TRAINING_API}:${CODE_VERSION}
+
+CMD date; nc -vz -w 10 $DB_HOSTNAME $DB_PORT; bundle exec rails db:migrate && bundle exec sidekiq -q mailer

--- a/spec/jobs/send_course_create_job_spec.rb
+++ b/spec/jobs/send_course_create_job_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+describe SendCourseCreateJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:course) { create(:course) }
+  let(:user) { create(:user) }
+
+  before do
+    clear_enqueued_jobs
+  end
+
+  describe "#perform" do
+    it "calls the CourseCreateEmailMailer" do
+      allow(CourseCreateEmailMailer)
+        .to receive_message_chain(:course_create_email, :deliver_now)
+
+      described_class.new.perform(course: course, user: user)
+
+      expect(CourseCreateEmailMailer)
+        .to have_received(:course_create_email)
+        .with(course, user)
+    end
+  end
+
+  describe ".perform_later" do
+    it "adds the job to the queue :mailer" do
+      allow(CourseCreateEmailMailer)
+        .to receive_message_chain(:course_create_email, :deliver_now)
+
+      described_class.perform_later(course: course, user: user)
+
+      expect(enqueued_jobs.last[:job]).to eq described_class
+      expect(enqueued_jobs.last[:queue]).to eq "mailer"
+    end
+  end
+end

--- a/spec/jobs/send_course_update_job_spec.rb
+++ b/spec/jobs/send_course_update_job_spec.rb
@@ -23,7 +23,7 @@ describe SendCourseUpdateJob, type: :job do
         attribute_name: attribute_name,
         original_value: original_value,
         updated_value: updated_value,
-        recipient: recipient
+        recipient: recipient,
       )
 
       expect(CourseUpdateEmailMailer).to have_received(:course_update_email).with(
@@ -31,7 +31,7 @@ describe SendCourseUpdateJob, type: :job do
         attribute_name: attribute_name,
         original_value: original_value,
         updated_value: updated_value,
-        recipient: recipient
+        recipient: recipient,
       )
     end
   end
@@ -45,7 +45,7 @@ describe SendCourseUpdateJob, type: :job do
         attribute_name: attribute_name,
         original_value: original_value,
         updated_value: updated_value,
-        recipient: recipient
+        recipient: recipient,
       )
 
       expect(enqueued_jobs.last[:job]).to eq described_class

--- a/spec/jobs/send_course_update_job_spec.rb
+++ b/spec/jobs/send_course_update_job_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+describe SendCourseUpdateJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  let(:course) { "course" }
+  let(:attribute_name) { "attribute_name" }
+  let(:original_value) { "original_value" }
+  let(:updated_value) { "updated_value" }
+  let(:recipient) { "recipient" }
+
+  describe "#perform" do
+    it "calls the CourseUpdateEmailMailer" do
+      allow(CourseUpdateEmailMailer).to receive_message_chain(:course_update_email, :deliver_now)
+
+      described_class.new.perform(
+        course: course,
+        attribute_name: attribute_name,
+        original_value: original_value,
+        updated_value: updated_value,
+        recipient: recipient
+      )
+
+      expect(CourseUpdateEmailMailer).to have_received(:course_update_email).with(
+        course: course,
+        attribute_name: attribute_name,
+        original_value: original_value,
+        updated_value: updated_value,
+        recipient: recipient
+      )
+    end
+  end
+
+  describe ".perform_later" do
+    it "adds the job to the queue :mailer" do
+      allow(CourseUpdateEmailMailer).to receive_message_chain(:course_update_email, :deliver_now)
+
+      described_class.perform_later(
+        course: course,
+        attribute_name: attribute_name,
+        original_value: original_value,
+        updated_value: updated_value,
+        recipient: recipient
+      )
+
+      expect(enqueued_jobs.last[:job]).to eq described_class
+      expect(enqueued_jobs.last[:queue]).to eq "mailer"
+    end
+  end
+end

--- a/spec/jobs/send_welcome_job_spec.rb
+++ b/spec/jobs/send_welcome_job_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe SendWelcomeJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:current_user) { { first_name: "Whiskers", email: "whiskers@meow.com" } }
+
+  before do
+    clear_enqueued_jobs
+  end
+
+  describe "#perform" do
+    it "calls the WelcomeEmailMailer" do
+      allow(SendWelcomeEmailService).to receive(:call)
+
+      described_class.new.perform(current_user: current_user)
+
+      expect(SendWelcomeEmailService).to have_received(:call)
+    end
+  end
+
+  describe ".perform_later" do
+    it "adds the job to the queue :mailer" do
+      allow(SendWelcomeEmailService).to receive(:call)
+
+      described_class.perform_later(current_user: current_user)
+
+      expect(enqueued_jobs.last[:job]).to eq described_class
+      expect(enqueued_jobs.last[:queue]).to eq "mailer"
+    end
+  end
+end

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -1,6 +1,5 @@
 describe SendWelcomeEmailService do
   let(:mailer_spy) { spy }
-  let(:service) { SendWelcomeEmailService.new(mailer: mailer_spy) }
 
   before { Timecop.freeze }
   after { Timecop.return }
@@ -15,22 +14,25 @@ describe SendWelcomeEmailService do
       )
     end
 
-    before { service.execute(current_user: current_user_spy) }
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_now)
+      described_class.call(current_user: current_user_spy)
+    end
 
     it "sets their welcome email date to now" do
       expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
     end
 
     it "sends the welcome email" do
-      expect(mailer_spy).to have_received(:send_welcome_email)
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email)
     end
 
     it "sends the email to the user" do
-      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
     end
 
     it "sends the users first name in the email" do
-      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
     end
   end
 
@@ -43,7 +45,11 @@ describe SendWelcomeEmailService do
       )
     end
 
-    before { service.execute(current_user: current_user_spy) }
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_now)
+      described_class.call(current_user: current_user_spy)
+    end
+
 
     it "does not update their first login date" do
       expect(current_user_spy).not_to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
@@ -69,20 +75,24 @@ describe SendWelcomeEmailService do
         )
       end
 
+      before do
+        allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_now)
+      end
+
       it "sets their welcome email date to now" do
         expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
       end
 
       it "sends the welcome email" do
-        expect(mailer_spy).to have_received(:send_welcome_email)
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email)
       end
 
       it "sends the email to the user" do
-        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
       end
 
       it "sends the users first name in the email" do
-        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
       end
     end
   end


### PR DESCRIPTION
### Context
- We have a new Sidekiq background container running, similar to geocoding.

https://trello.com/c/jb4y3epg/3102-m-background-mail-notifications

### Changes proposed in this pull request
- Mail notifications are now sent via new background jobs.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
