### PR TITLE
[3142] Add request output middleware

### DIFF
--- a/config/initializers/request_output.rb
+++ b/config/initializers/request_output.rb
@@ -1,0 +1,5 @@
+if Rails.env.development?
+  require "rack/request_output"
+
+  Rails.application.config.middleware.insert_after Raven::Rack, Rack::RequestOutput
+end

--- a/lib/rack/request_output.rb
+++ b/lib/rack/request_output.rb
@@ -1,0 +1,13 @@
+module Rack
+  class RequestOutput
+    def initialize app
+      @app = app
+    end
+
+    def call(env)
+      Rails.logger.debug("API HIT => #{env['rack.url_scheme']}://#{env['HTTP_HOST']}#{env['REQUEST_URI']}")
+
+      @app.call(env)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- Developers find it hard to see what API endpoint is being hit
- And also what response is being sent back

### Changes proposed in this pull request

- In development this adds a piece of rack middleware
- This outputs the URL that hit the API
- This allows devs to repeat the same API calls in their tool of their choice to see the response

### Guidance to review

- fire up locally in dev mode
- hit the api directly or via find
- should see api endpoint being hit
- should able to curl the url to see response given

![image](https://user-images.githubusercontent.com/92580/76848243-45b3ec80-683b-11ea-989d-41aa2503a5ae.png)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally