### PR TITLE
[3141] Fixed query for provider_name

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -217,7 +217,14 @@ class Course < ApplicationRecord
   end
 
   scope :with_provider_name, ->(provider_name) do
-    joins(:provider).merge(Provider.where(provider_name: provider_name))
+    where(
+      provider_id: Provider.where(provider_name: provider_name),
+    ).or(
+      self.where(
+        accrediting_provider_code: Provider.where(provider_name: provider_name)
+                                       .select(:provider_code),
+      ),
+    )
   end
 
   scope :with_send, -> do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -876,6 +876,9 @@ describe Course, type: :model do
       let(:provider2) { create(:provider, provider_name: "DAVE") }
       let(:course) { create(:course, provider: provider) }
       let(:provider_name) { "ACME" }
+      let(:accredited_provider_name) { "University of Awesome" }
+      let(:accredited_provider) { build(:provider, :accredited_body, provider_name: accredited_provider_name) }
+      let(:accredited_course) { create(:course, accrediting_provider: accredited_provider) }
 
       before do
         provider
@@ -892,6 +895,11 @@ describe Course, type: :model do
       context "with a provider name with no courses" do
         subject { described_class.with_provider_name("DAVE") }
         it { is_expected.to be_empty }
+      end
+
+      context "with an accredited provider name" do
+        subject { described_class.with_provider_name(accredited_provider_name) }
+        it { is_expected.to contain_exactly(accredited_course) }
       end
     end
   end


### PR DESCRIPTION
### Context

The accredited body does not see all the courses they expected to see on Find when they search for a specific provider.

### What should have happened? (expected results)

The Find search should have displayed all the courses that U80 accredits including their own courses.

### Changes proposed in this pull request

When you search for a provider on Find, you should see all courses offered by the provider, including the courses they accredit.

### Guidance to review
:ship:

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
