### PR TITLE
[3102] - Background mail notifications

### DIFF
--- a/app/controllers/api/v2/sessions_controller.rb
+++ b/app/controllers/api/v2/sessions_controller.rb
@@ -40,8 +40,7 @@ module API
       end
 
       def send_welcome_email
-        welcome_email_service = SendWelcomeEmailService.new(mailer: WelcomeEmailMailer)
-        welcome_email_service.execute(current_user: @current_user)
+        SendWelcomeEmailService.call(current_user: @current_user)
       end
     end
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -285,7 +285,7 @@ class Course < ApplicationRecord
         original_value: saved_changes[updated_attribute].first,
         updated_value: saved_changes[updated_attribute].second,
         recipient: user,
-      ).deliver_now
+      ).deliver_later(queue: "mailer")
     end
   end
 

--- a/app/services/courses/publish_service.rb
+++ b/app/services/courses/publish_service.rb
@@ -14,7 +14,7 @@ module Courses
         CourseCreateEmailMailer.course_create_email(
           course,
           user,
-        ).deliver_now
+        ).deliver_later(queue: "mailer")
       end
     end
 

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -1,12 +1,16 @@
 class SendWelcomeEmailService
-  def initialize(mailer:)
-    @mailer = mailer
+  class << self
+    def call(current_user:)
+      new.call(current_user: current_user)
+    end
   end
 
-  def execute(current_user:)
+  def call(current_user:)
     return if current_user.welcome_email_date_utc
 
-    @mailer.send_welcome_email(first_name: current_user.first_name, email: current_user.email).deliver_now
+    WelcomeEmailMailer.
+      send_welcome_email(first_name: current_user.first_name, email: current_user.email).
+      deliver_now
 
     current_user.update(
       welcome_email_date_utc: Time.now.utc,

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -10,7 +10,7 @@ class SendWelcomeEmailService
 
     WelcomeEmailMailer.
       send_welcome_email(first_name: current_user.first_name, email: current_user.email).
-      deliver_now
+      deliver_later(queue: "mailer")
 
     current_user.update(
       welcome_email_date_utc: Time.now.utc,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,6 +10,7 @@ pool:
 variables:
   imageName: 'teacher-training-api'
   imageNameBgGeoCode: 'teacher-training-bg-geocode'
+  imageNameBgMailer: 'teacher-training-bg-mailer'
   dockerOverride: 'docker-compose -f docker-compose.yml'
 
 steps:
@@ -18,10 +19,12 @@ steps:
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     docker_path=$(dockerHubUsername)/$(imageName)
     docker_bg_geocode_path=$(dockerHubUsername)/$(imageNameBgGeoCode)
+    docker_bg_mailer_path=$(dockerHubUsername)/$(imageNameBgMailer)
     set +x # We confuse VSTS if we trace these commands
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=docker_path;]$docker_path"
     echo "##vso[task.setvariable variable=docker_bg_geocode_path;]$docker_bg_geocode_path"
+    echo "##vso[task.setvariable variable=docker_bg_mailer_path;]$docker_bg_mailer_path"
   displayName: 'Set version number'
 
 - script: |
@@ -123,6 +126,19 @@ steps:
   inputs:
     command: Push an image
     imageName: "$(docker_bg_geocode_path):$(Build.BuildNumber)"
+
+- task: Docker@1
+  displayName: Tag bg_geocode image with current build number $(Build.BuildNumber)
+  inputs:
+    command: Tag image
+    imageName: "$(docker_bg_mailer_path):latest"
+    arguments: "$(docker_bg_mailer_path):$(Build.BuildNumber)"
+
+- task: Docker@1
+  displayName: Push tagged image
+  inputs:
+    command: Push an image
+    imageName: "$(docker_bg_mailer_path):$(Build.BuildNumber)"
 
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(build.artifactstagingdirectory)'

--- a/bg-mailer/Dockerfile
+++ b/bg-mailer/Dockerfile
@@ -1,0 +1,7 @@
+ARG  DOCKER_REPOSITORY
+ARG  TEACHER_TRAINING_API
+ARG  CODE_VERSION=latest
+
+FROM ${DOCKER_REPOSITORY}/${TEACHER_TRAINING_API}:${CODE_VERSION}
+
+CMD date; nc -vz -w 10 $DB_HOSTNAME $DB_PORT; bundle exec rails db:migrate && bundle exec sidekiq -q mailer

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,7 @@ module ManageCoursesBackend
     # https://github.com/rails/rails/commit/ddb6d788d6a611fd1ba6cf92ad6d1342079517a8
     config.action_dispatch.return_only_media_type_on_content_type = false
     config.autoload_paths += %W(#{config.root}/app/models/subjects)
+
+    config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,3 +47,23 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=developmentpassword
       - SETTINGS__APPLICATION=teacher-training-api-bg-geocode
+
+  bg-mailer:
+    build:
+      args:
+        - DOCKER_REPOSITORY=${dockerHubUsername:-dfedigital}
+        - TEACHER_TRAINING_API=${dockerHubImageName:-teacher-training-api}
+      context: bg-mailer
+      cache_from:
+        - ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:latest
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:latest
+    volumes:
+      - .:/app
+    depends_on:
+      - web
+      - db
+    environment:
+      - DB_HOSTNAME=db
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=developmentpassword
+      - SETTINGS__APPLICATION=teacher-training-api-bg-mailer

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2165,7 +2165,8 @@ describe Course, type: :model do
           end
 
           it "Delivers the email" do
-            expect(mail_spy).to have_received(:deliver_now)
+            expect(mail_spy).to have_received(:deliver_later).
+              with(queue: "mailer")
           end
         end
 

--- a/spec/requests/api/v2/session_spec.rb
+++ b/spec/requests/api/v2/session_spec.rb
@@ -49,17 +49,8 @@ describe "/api/v2/sessions", type: :request do
       let(:user) { create(:user, last_login_date_utc: 10.days.ago) }
       let(:returned_json_response) { JSON.parse response.body }
 
-      let(:govuk_notify_request) do
-        stub_request(:post, "https://api.notifications.service.gov.uk/v2/notifications/email").
-           with(
-             body: { email_address: user.email, template_id: Settings.govuk_notify.welcome_email_template_id, personalisation: { first_name: user.first_name } }.to_json,
-            ).
-            to_return(status: 200, body: "{}", headers: {})
-      end
-
-
       before do
-        govuk_notify_request
+        allow(SendWelcomeEmailService).to receive(:call)
         Timecop.freeze
         post "/api/v2/sessions",
              headers: { "HTTP_AUTHORIZATION" => credentials },
@@ -106,19 +97,9 @@ describe "/api/v2/sessions", type: :request do
         end
       end
 
-      context "When the user has not received a welcome email" do
-        let(:user) { create(:user, welcome_email_date_utc: nil) }
-
-        it "Sends a welcome email to the user" do
-          expect(govuk_notify_request).to have_been_made
-        end
-      end
-
-      context "When the user has received a welcome email" do
-        let(:user) { create(:user) }
-
-        it "Does not send a welcome email to the user" do
-          expect(govuk_notify_request).not_to have_been_made
+      context "welcome email" do
+        it "Enqueues the sending the welcome email" do
+          expect(SendWelcomeEmailService).to have_received(:call).with(current_user: user)
         end
       end
     end

--- a/spec/services/courses/publish_service_spec.rb
+++ b/spec/services/courses/publish_service_spec.rb
@@ -105,7 +105,7 @@ describe Courses::PublishService do
           end
 
           it "delivers the email" do
-            expect(mail_spy).to have_received(:deliver_now)
+            expect(mail_spy).to have_received(:deliver_later)
           end
 
           context "when the course does not appear on find" do

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -1,7 +1,4 @@
 describe SendWelcomeEmailService do
-  let(:mailer_spy) { spy }
-  let(:service) { SendWelcomeEmailService.new(mailer: mailer_spy) }
-
   before { Timecop.freeze }
   after { Timecop.return }
 
@@ -15,22 +12,25 @@ describe SendWelcomeEmailService do
       )
     end
 
-    before { service.execute(current_user: current_user_spy) }
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_later)
+      described_class.call(current_user: current_user_spy)
+    end
 
     it "sets their welcome email date to now" do
       expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
     end
 
     it "sends the welcome email" do
-      expect(mailer_spy).to have_received(:send_welcome_email)
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email)
     end
 
     it "sends the email to the user" do
-      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
     end
 
     it "sends the users first name in the email" do
-      expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
+      expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
     end
   end
 
@@ -43,7 +43,11 @@ describe SendWelcomeEmailService do
       )
     end
 
-    before { service.execute(current_user: current_user_spy) }
+    before do
+      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, deliver_later: { queue: "mailer" })
+      described_class.call(current_user: current_user_spy)
+    end
+
 
     it "does not update their first login date" do
       expect(current_user_spy).not_to have_received(:update).with(hash_including(first_login_date_utc: Time.now.utc))
@@ -55,7 +59,7 @@ describe SendWelcomeEmailService do
       end
 
       it "does not send the welcome email" do
-        expect(mailer_spy).not_to have_received(:send_welcome_email)
+        expect(WelcomeEmailMailer).not_to have_received(:send_welcome_email)
       end
     end
 
@@ -69,20 +73,24 @@ describe SendWelcomeEmailService do
         )
       end
 
+      before do
+        allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_later)
+      end
+
       it "sets their welcome email date to now" do
         expect(current_user_spy).to have_received(:update).with(hash_including(welcome_email_date_utc: Time.now.utc))
       end
 
       it "sends the welcome email" do
-        expect(mailer_spy).to have_received(:send_welcome_email)
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email)
       end
 
       it "sends the email to the user" do
-        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(email: "meowington@cat.net"))
       end
 
       it "sends the users first name in the email" do
-        expect(mailer_spy).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
+        expect(WelcomeEmailMailer).to have_received(:send_welcome_email).with(hash_including(first_name: "Meowington"))
       end
     end
   end


### PR DESCRIPTION
### Context
* We have a new Sidekiq background container running, similar to geocoding.

### Changes proposed in this pull request
* Mail is sent out via a background task.
* When you call `.deliver_later` on the mailers it will [automatically use an ActionMailer::DeliveryJob.](https://edgeapi.rubyonrails.org/classes/ActionMailer/MessageDelivery.html#method-i-deliver_later)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
