### PR TITLE
Fix find URL

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -8,4 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.find-postgraduate-teacher-training.education.gov.uk
+find_url: https://www2.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -8,4 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.qa.find-postgraduate-teacher-training.education.gov.uk
+find_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -8,4 +8,4 @@ bg_jobs:
     queue: find_sync
 gcp_api_key: please_change_me
 publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.staging.find-postgraduate-teacher-training.education.gov.uk
+find_url: https://www2.staging.find-postgraduate-teacher-training.service.gov.uk

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -6,4 +6,4 @@ govuk_notify:
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.find-postgraduate-teacher-training.education.gov.uk
+find_url: https://www2.find-postgraduate-teacher-training.service.gov.uk


### PR DESCRIPTION
### Context

We are using this URL in links within the course update/create email. Turns out it doesn't work.

### Changes proposed in this pull request

Change `service` to `education`.

### Guidance to review

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
