### PR TITLE
[3112] enable Rails to serve static files in deployed environments

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -319,6 +319,13 @@
       "metadata": {
           "description": "List of resource tags as a JSON object"
       }
+    },
+    "railsServeStaticFiles": {
+      "type": "string",
+      "defaultValue": "1",
+      "metadata": {
+        "description": "Configure Rails to serve out static files from the public folder."
+      }
     }
   },
   "variables": {
@@ -524,6 +531,10 @@
               {
                 "name": "SETTINGS__GCP_API_KEY",
                 "value": "[parameters('googleCloudPlatformAPIKey')]"
+              },
+              {
+                "name": "RAILS_SERVE_STATIC_FILES",
+                "value": "[parameters('railsServeStaticFiles')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

We're adding API docs which benefit from some static assets like CSS and JS files. This API app doesn't have an asset pipeline, so we've chosen to serve out static files to manage this.

### Changes proposed in this pull request

Enable serving out static files in deployed environments.

### Guidance to review

Normally this isn't recommended. Some thoughts I added to the Trello card:

> Normally this is discouraged as the upstream webserver, e.g. Apache or NGinx, is better placed to serve out this content. However, we don't have the luxury of one of those webservers fronting our app, and I don't believe that whatever it is can be configured to serve this file out.
>
> We could also enable the asset pipeline, but it's kind of nice that this app is API-only, and we are unlikely to get enough legitimate requests for these assets for it to be an issue. Mitigating against a malicious actor would be an independent issue.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
