### PR TITLE
[3168] Near parity of api docs via rswag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,9 @@ gem "openapi3_parser", "0.8.0"
 gem "redcarpet"
 gem "rouge"
 
+gem "open_api-rswag-api"
+gem "open_api-rswag-ui"
+
 group :development, :test do
   # add info about db structure to models and other files
   gem "annotate"
@@ -155,6 +158,8 @@ group :development, :test do
 
   # Allow us to freeze time in tests
   gem "timecop"
+
+  gem "open_api-rswag-specs"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
       guard (~> 2.0)
       rubocop (~> 0.20)
     hashdiff (1.0.1)
+    hashie (4.1.0)
     highline (2.0.3)
     httparty (0.18.0)
       mime-types (~> 3.0)
@@ -199,6 +200,8 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
     jsonapi-rails (0.4.0)
@@ -262,6 +265,16 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
+    open_api-rswag-api (0.1.0)
+      railties (>= 3.1, < 7.0)
+    open_api-rswag-specs (0.1.0)
+      activesupport (>= 3.1, < 7.0)
+      hashie
+      json-schema (~> 2.2)
+      railties (>= 3.1, < 7.0)
+    open_api-rswag-ui (0.1.0)
+      actionpack (>= 3.1, < 7.0)
+      railties (>= 3.1, < 7.0)
     openapi3_parser (0.8.0)
       commonmarker (~> 0.17)
       psych (~> 3.1)
@@ -490,6 +503,9 @@ DEPENDENCIES
   kaminari
   listen (>= 3.0.5, < 3.3)
   logstash-logger (~> 0.26.1)
+  open_api-rswag-api
+  open_api-rswag-specs
+  open_api-rswag-ui
   openapi3_parser (= 0.8.0)
   parallel_tests
   pg

--- a/README.md
+++ b/README.md
@@ -173,7 +173,13 @@ machine wins
 
 Any `Machine based env variables settings` that is not prefixed with `SETTINGS`.* are not considered for general consumption.
 
+### Documentation
 
+Use the following command to generate OpenAPI specification:
+
+```sh
+bundle exec rake rswag:specs:swaggerize
+```
 
 ## CI variables
 

--- a/app/models/api_spec.rb
+++ b/app/models/api_spec.rb
@@ -26,6 +26,6 @@ module APISpec
   end
 
   def to_yaml
-    @to_yaml ||= File.read(@openapi_spec_file)
+    @to_yaml ||= JSON.parse(File.read(@openapi_spec_file)).to_yaml
   end
 end

--- a/app/models/api_spec/public.rb
+++ b/app/models/api_spec/public.rb
@@ -10,7 +10,7 @@ module APISpec
       end
 
       def openapi_file_path
-        "config/public-api-v%{version}.yml"
+        "swagger/v%{version}/swagger.json"
       end
     end
   end

--- a/config/initializers/rswag-ui.rb
+++ b/config/initializers/rswag-ui.rb
@@ -1,0 +1,9 @@
+OpenApi::Rswag::Ui.configure do |c|
+  # List the Swagger endpoints that you want to be documented through the swagger-ui
+  # The first parameter is the path (absolute or relative to the UI host) to the corresponding
+  # JSON endpoint and the second is a title that will be displayed in the document selector
+  # NOTE: If you're using rspec-api to expose Swagger files (under swagger_root) as JSON endpoints,
+  # then the list below should correspond to the relative paths for those endpoints
+
+  c.swagger_endpoint "/api-docs/v1/swagger.json", "API V1 Docs"
+end

--- a/config/initializers/rswag_api.rb
+++ b/config/initializers/rswag_api.rb
@@ -1,0 +1,13 @@
+OpenApi::Rswag::Api.configure do |c|
+  # Specify a root folder where Swagger JSON files are located
+  # This is used by the Swagger middleware to serve requests for API descriptions
+  # NOTE: If you're using rswag-specs to generate Swagger, you'll need to ensure
+  # that it's configured to generate files in the same folder
+  c.swagger_root = Rails.root.to_s + "/swagger"
+
+  # Inject a lamda function to alter the returned Swagger prior to serialization
+  # The function will have access to the rack env for the current request
+  # For example, you could leverage this to dynamically assign the "host" property
+  #
+  #c.swagger_filter = lambda { |swagger, env| swagger['host'] = env['HTTP_HOST'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # == Route Map
 #
 #                                               Prefix Verb   URI Pattern                                                                                                                              Controller#Action
+#                                    open_api_rswag_ui        /api-docs                                                                                                                                OpenApi::Rswag::Ui::Engine
+#                                   open_api_rswag_api        /api-docs                                                                                                                                OpenApi::Rswag::Api::Engine
 #                                                 root GET    /                                                                                                                                        api_docs/pages#home
 #                                                 ping GET    /ping(.:format)                                                                                                                          heartbeat#ping
 #                                          healthcheck GET    /healthcheck(.:format)                                                                                                                   heartbeat#healthcheck
@@ -105,9 +107,16 @@
 #                                 api_v3_subject_areas GET    /api/v3/subject_areas(.:format)                                                                                                          api/v3/subject_areas#index
 #                                            error_500 GET    /error_500(.:format)                                                                                                                     error#error_500
 #                                           error_nodb GET    /error_nodb(.:format)                                                                                                                    error#error_nodb
+#
+# Routes for OpenApi::Rswag::Ui::Engine:
+#
+#
+# Routes for OpenApi::Rswag::Api::Engine:
 
 # rubocop:disable Metrics/BlockLength
 Rails.application.routes.draw do
+  mount OpenApi::Rswag::Ui::Engine => "/api-docs"
+  mount OpenApi::Rswag::Api::Engine => "/api-docs"
   root to: "api_docs/pages#home"
 
   get :ping, controller: :heartbeat

--- a/spec/api/courses_spec.rb
+++ b/spec/api/courses_spec.rb
@@ -1,0 +1,28 @@
+require "swagger_helper"
+
+describe "API" do
+  # http://localhost:3001/api/v3/courses
+  path "/api/v3/courses" do
+    get "Returns courses for the current recruitment cycle" do
+      operationId :public_api_v1_courses
+      tags "course"
+      produces "application/json"
+      parameter name: :filter,
+        in: :query,
+        type: :object,
+        style: "deepObject",
+        required: false
+      parameter name: :sort,
+        in: :query,
+        type: :object,
+        style: "deepObject",
+        required: false
+
+      response "200", "The list of courses in the current recruitment cycle" do
+        schema "$ref": "#/components/schemas/CourseSingleResponse"
+
+        run_test!
+      end
+    end
+  end
+end

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.configure do |config|
+  # Specify a root folder where Swagger JSON files are generated
+  # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
+  # to ensure that it's configured to serve Swagger from the same folder
+  config.swagger_root = Rails.root.join("swagger").to_s
+
+  # Define one or more Swagger documents and provide global metadata for each one
+  # When you run the 'rswag:specs:swaggerize' rake task, the complete Swagger will
+  # be generated at the provided relative path under swagger_root
+  # By default, the operations defined in spec files are added to the first
+  # document below. You can override this behavior by adding a swagger_doc tag to the
+  # the root example_group in your specs, e.g. describe '...', swagger_doc: 'v2/swagger.json'
+  config.swagger_docs = {
+    "v1/swagger.json" => ActiveSupport::HashWithIndifferentAccess.new(YAML.load_file(Rails.root.join("swagger/v1/template.yml"))),
+  }
+end

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "version": "1.0.0",
-    "title": "Postgraduate Teacher Training Courses API",
+    "title": "Teacher Training Courses API",
     "contact": {
       "name": "DfE",
       "email": "becomingateacher@digital.education.gov.uk"

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -410,7 +410,7 @@
         ],
         "properties": {
           "data": {
-            "type": "array,",
+            "type": "array",
             "items": {
               "$ref": "#/components/schemas/CourseResource"
             }

--- a/swagger/v1/swagger.json
+++ b/swagger/v1/swagger.json
@@ -1,0 +1,618 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Postgraduate Teacher Training Courses API",
+    "contact": {
+      "name": "DfE",
+      "email": "becomingateacher@digital.education.gov.uk"
+    },
+    "description": "API for DfE's postgraduate teacher training course service"
+  },
+  "servers": [
+    {
+      "description": "Production",
+      "url": "https://api2.publish-teacher-training-courses.service.gov.uk/api/public/v1"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "CourseAttributes": {
+        "type": "object",
+        "required": [
+          "code",
+          "provider_code",
+          "age_maximum",
+          "age_minimum"
+        ],
+        "properties": {
+          "about_accredited_body": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Description of the accredited body for this course.",
+            "example": ""
+          },
+          "about_course": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Short factual summary of the course.",
+            "example": "The Art and Design PGCE is a challenging and forward-looking\nprogramme which prepares students to teach across the 11-16 age\nrange, encouraging them to relate art, craft and design education to\ncontemporary art practice. It has a strong reputation for promoting\ninnovation in education theory, practice and policy. This programme\naims to inform and inspire, to challenge orthodoxies and encourage a\nfreshness of vision. It provides support and guidance for learning\nand teaching in art and design, identifying strategies to motivate\nand engage pupils in making, discussing and evaluating visual and\nmaterial culture. The IOE provides excellent studio space and\nfacilities for Art and Design, including a computing suite where\nstudents can learn how technology is used in art and design\neducation. The programme also has strong links with galleries,\nmuseums and other sites for learning, which are recognised as an\nimportant resource for engaging students in cultural and social\nissues.Through seminars and studio-based activities, students will\nstudy the concepts, processes and skills of art, craft and design,\nsharing their knowledge and understanding with other student\nteachers and consider how it relates to the secondary curriculum.\nTowards the end of the PGCE, students will build on their own\npractice by initiating a curriculum development project, culminating\nin the display of their own work in a final exhibition that\nrepresents their personal philosophy for art and design education.\n"
+          },
+          "accredited_body_code": {
+            "type": "string",
+            "description": "Unique provider-code for the accredited body of this course. Only\npresent if the course is accredited by a provider other than the one\nrunning this course.\n",
+            "maxLength": 3,
+            "minLength": 3,
+            "nullable": true,
+            "example": "2FR"
+          },
+          "age_minimum": {
+            "type": "integer",
+            "description": "The minimum age of pupils this course is specified for.\n",
+            "example": 11
+          },
+          "age_maximum": {
+            "type": "integer",
+            "description": "The maximum age of pupils this course is specified for.\n",
+            "example": 14
+          },
+          "applications_open_from": {
+            "type": "string",
+            "format": "date",
+            "description": "Date from which applications can be submitted.",
+            "example": "2019-10-08"
+          },
+          "bursary_amount": {
+            "type": "integer",
+            "description": "Bursary amount for this course.",
+            "example": 9000
+          },
+          "bursary_requirements": {
+            "type": "string",
+            "description": "Description of requirements to be eligible for a bursary.",
+            "example": "a degree of 2:2 or above in any subject"
+          },
+          "changed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date-time timestamp of when this course or any of it's related data changed.\n",
+            "example": "2019-06-13T10:44:31Z"
+          },
+          "code": {
+            "type": "string",
+            "description": "Code that uniquely identifies this course within it's providers list of courses.\n",
+            "maxLength": 4,
+            "minLength": 4,
+            "example": "3GTY"
+          },
+          "course_length": {
+            "type": "string",
+            "description": "Text describing how long the course runs.\n",
+            "example": "OneYear"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when this course was created.",
+            "example": "2019-06-13T10:44:31Z"
+          },
+          "fee_details": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Further details about the fees for this course, if applicable.",
+            "example": "fee_details"
+          },
+          "fee_international": {
+            "type": "integer",
+            "description": "Fee for international students (optional).",
+            "example": 13000
+          },
+          "fee_domestic": {
+            "type": "integer",
+            "description": "Fee for UK and EU students.",
+            "example": 9200
+          },
+          "financial_support": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Details about financial support offered, if any.",
+            "example": "financial_support"
+          },
+          "findable": {
+            "type": "boolean",
+            "description": "Is this course currently visible on the Find Postgraduate Teacher Training service.\n",
+            "example": true
+          },
+          "funding_type": {
+            "type": "string",
+            "description": "The type of funding that maybe provided to candidates, if any.\n",
+            "example": "apprenticeship",
+            "enum": [
+              "salary",
+              "apprenticeship",
+              "fee"
+            ]
+          },
+          "gcse_subjects_required": {
+            "type": "string",
+            "example": [
+              "maths",
+              "english"
+            ],
+            "enum": [
+              [
+
+              ],
+              [
+                "maths",
+                "english"
+              ],
+              [
+                "maths",
+                "english",
+                "science"
+              ]
+            ],
+            "description": "GSCE standard equivalent required for this level of course."
+          },
+          "has_bursary": {
+            "type": "boolean",
+            "description": "Are any bursaries available for this course?",
+            "example": true
+          },
+          "has_early_career_payments": {
+            "type": "boolean",
+            "description": "Are early career payments available for this course?",
+            "example": true
+          },
+          "has_scholarship": {
+            "type": "boolean",
+            "description": "Are scholarships available for this course?",
+            "example": true
+          },
+          "has_vacancies": {
+            "type": "boolean",
+            "description": "Do any of the locations for this course have vacancies?",
+            "example": true
+          },
+          "how_school_placements_work": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Additional information about the schools applicants will be teaching in.\n",
+            "example": "how_school_placements_work"
+          },
+          "interview_process": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Additional information about how the interview process will work for applicants.\n",
+            "example": "interview_process"
+          },
+          "is_send": {
+            "type": "boolean",
+            "description": "Does this course have a SEND specialism?",
+            "example": true
+          },
+          "last_published_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when changes to this course's additional information\nsections was published last.\n",
+            "example": "2019-06-13T10:44:31Z"
+          },
+          "level": {
+            "type": "string",
+            "description": "The level of pupils this course is designed for.",
+            "example": "secondary",
+            "enum": [
+              "further_education",
+              "primary",
+              "secondary"
+            ]
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the course.",
+            "example": "Art and Design"
+          },
+          "open_for_applications": {
+            "type": "boolean",
+            "description": "Is the course currently open for applications?",
+            "example": true
+          },
+          "other_requirements": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Any non-academic qualifications or documents the applicant may need.\n",
+            "example": "other_requirements"
+          },
+          "personal_qualities": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Any skills, motivation and experience the provider is looking in applicants.\n",
+            "example": "personal_qualities"
+          },
+          "program_type": {
+            "type": "string",
+            "description": "program_type",
+            "example": "scitt_programme",
+            "enum": [
+              "higher_education_programme",
+              "scitt_programme",
+              "school_direct_training_programme",
+              "school_direct_salaried_training_programme",
+              "pg_teaching_apprenticeship"
+            ]
+          },
+          "provider_code": {
+            "type": "string",
+            "description": "Unique code for the provider of this course.",
+            "maxLength": 3,
+            "minLength": 3,
+            "example": "6CL"
+          },
+          "qualifications": {
+            "type": "string",
+            "description": "The qualifications as an outcome of the course.\n",
+            "example": [
+              "qts"
+            ],
+            "enum": [
+              [
+                "qts"
+              ],
+              [
+                "pgce"
+              ],
+              [
+                "pgde"
+              ],
+              [
+                "qts",
+                "pgce"
+              ],
+              [
+                "qts",
+                "pgde"
+              ]
+            ]
+          },
+          "recruitment_cycle_year": {
+            "type": "string",
+            "description": "The recruitment cycle that this course is available in.",
+            "example": 2020
+          },
+          "required_qualifications": {
+            "type": "string",
+            "format": "markdown",
+            "description": "The minimum academic qualifications needed for this course.\n",
+            "example": "required_qualifications"
+          },
+          "required_qualifications_english": {
+            "type": "string",
+            "description": "English GCSE requirements for applicants.",
+            "example": "equivalence_test",
+            "enum": [
+              "",
+              "must_have_qualification_at_application_time",
+              "expect_to_achieve_before_training_begins",
+              "equivalence_test",
+              "not_required"
+            ]
+          },
+          "required_qualifications_maths": {
+            "type": "string",
+            "description": "Maths GCSE requirements for applicants.",
+            "example": "equivalence_test",
+            "enum": [
+              "",
+              "must_have_qualification_at_application_time",
+              "expect_to_achieve_before_training_begins",
+              "equivalence_test",
+              "not_required"
+            ]
+          },
+          "required_qualifications_science": {
+            "type": "string",
+            "description": "Science GCSE requirements for applicants.",
+            "example": "equivalence_test",
+            "enum": [
+              "",
+              "must_have_qualification_at_application_time",
+              "expect_to_achieve_before_training_begins",
+              "equivalence_test",
+              "not_required"
+            ]
+          },
+          "running": {
+            "type": "boolean",
+            "description": "Is the course currently running.",
+            "example": true
+          },
+          "salary_details": {
+            "type": "string",
+            "description": "Salary details about this course.",
+            "example": "To be eligible for a place on the salaried course you must have the\nsupport of a school who is willing to make contributions towards\nyour salary.\n"
+          },
+          "scholarship_amount": {
+            "type": "integer",
+            "description": "The scholarship amount a candidate may be elligible for this course.",
+            "example": 17000
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Date that the course starts.",
+            "example": "2020-09-01"
+          },
+          "state": {
+            "type": "string",
+            "description": "The state of the course in the postgraduate teacher training system.\n",
+            "example": "published",
+            "enum": [
+              "empty",
+              "rolled_over",
+              "draft",
+              "published",
+              "published_with_unpublished_changes",
+              "withdrawn"
+            ]
+          },
+          "study_mode": {
+            "type": "string",
+            "description": "Whether the course is full-time, part-time or both.",
+            "example": "both",
+            "enum": [
+              "both",
+              "full_time",
+              "part_time"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "Generated summary of the course.",
+            "example": "PGCE with QTS full time"
+          }
+        }
+      },
+      "CourseRelationships": {
+        "type": "object",
+        "properties": {
+          "subjects": {
+            "$ref": "#/components/schemas/RelationshipList"
+          }
+        }
+      },
+      "CourseResource": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/CourseAttributes"
+          },
+          "relationships": {
+            "$ref": "#/components/schemas/CourseRelationships"
+          }
+        }
+      },
+      "CourseSingleResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array,",
+            "items": {
+              "$ref": "#/components/schemas/CourseResource"
+            }
+          },
+          "included": {
+            "$ref": "#/components/schemas/Included"
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
+      "Included": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/Resource"
+        }
+      },
+      "JSONAPI": {
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "type": "string",
+            "example": "1.0"
+          }
+        }
+      },
+      "Relationship": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/ResourceIdentifier"
+          },
+          "meta": {
+            "type": "object"
+          }
+        }
+      },
+      "RelationshipList": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResourceIdentifier"
+            }
+          }
+        }
+      },
+      "Resource": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/CourseResource"
+          },
+          {
+            "$ref": "#/components/schemas/RecruitmentCycleResource"
+          },
+          {
+            "$ref": "#/components/schemas/SubjectResource"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type"
+        }
+      },
+      "ResourceIdentifier": {
+        "type": "object",
+        "required": [
+          "type",
+          "id"
+        ],
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "RecruitmentCycleAttributes": {
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "year": {
+            "type": "integer",
+            "description": "The year that this recruitment cycle applies to."
+          },
+          "application_start_date": {
+            "type": "string",
+            "format": "date",
+            "description": "The default date applications start being taken for this recruitment cycle.\n"
+          },
+          "application_end_date": {
+            "type": "string",
+            "format": "date",
+            "description": "The default date applications stop being taken for this recruitment cycle.\n"
+          }
+        }
+      },
+      "RecruitmentCycleResource": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/RecruitmentCycleAttributes"
+          }
+        }
+      },
+      "SubjectAttributes": {
+        "type": "object",
+        "required": [
+          "code"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Subject name."
+          },
+          "code": {
+            "type": "string",
+            "description": "Unique subject code."
+          }
+        }
+      },
+      "SubjectResource": {
+        "type": "object",
+        "required": [
+          "id",
+          "type",
+          "attributes"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "string"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/SubjectAttributes"
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/api/v3/courses": {
+      "get": {
+        "summary": "Returns courses for the current recruitment cycle",
+        "operationId": "public_api_v1_courses",
+        "tags": [
+          "course"
+        ],
+        "parameters": [
+          {
+            "name": "filter",
+            "in": "query",
+            "style": "deepObject",
+            "required": false,
+            "schema": {
+              "type": "object"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "style": "deepObject",
+            "required": false,
+            "schema": {
+              "type": "object"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of courses in the current recruitment cycle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseSingleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/swagger/v1/template.yml
+++ b/swagger/v1/template.yml
@@ -2,7 +2,7 @@
 openapi: 3.0.0
 info:
   version: 1.0.0
-  title: Postgraduate Teacher Training Courses API
+  title: Teacher Training Courses API
   contact:
     name: DfE
     email: becomingateacher@digital.education.gov.uk

--- a/swagger/v1/template.yml
+++ b/swagger/v1/template.yml
@@ -353,7 +353,7 @@ components:
         - data
       properties:
         data:
-          type: array,
+          type: array
           items:
             $ref: "#/components/schemas/CourseResource"
         included:

--- a/swagger/v1/template.yml
+++ b/swagger/v1/template.yml
@@ -10,28 +10,6 @@ info:
 servers:
   - description: Production
     url: https://api2.publish-teacher-training-courses.service.gov.uk/api/public/v1
-paths:
-  /courses:
-    get:
-      operationId: public_api_v1_courses
-      parameters:
-        - name: filter
-          in: query
-          schema:
-            type: object
-          style: deepObject
-        - name: sort
-          in: query
-          schema:
-            type: object
-          style: deepObject
-      responses:
-        '200':
-          description: The list of courses in the current recruitment cycle
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/CourseSingleResponse"
 components:
   schemas:
     CourseAttributes:
@@ -375,7 +353,9 @@ components:
         - data
       properties:
         data:
-          $ref: "#/components/schemas/CourseResource"
+          type: array,
+          items:
+            $ref: "#/components/schemas/CourseResource"
         included:
           $ref: "#/components/schemas/Included"
         jsonapi:


### PR DESCRIPTION
### Context

- This implements rswag which allows for API endpoints to be documented more easily
- It also allows responses to be tested against the generated OpenAPI specification that we now generate 

### Changes proposed in this pull request

- Added rswag related gems
- Documentation via swagger available at /api-docs
- Updates api spec, CourseSingleResponse.data is now an array
- Update readme on how to generate OpenAPI spec
- Add test on api courses response matches JSON schema

### Guidance to review

- swagger docs available at http://localhost:3001/api-docs
- generated OpenAPI specification should be similar to previous hand crafted one

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
