### PR TITLE
[3102] - Update Azure Template

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -976,6 +976,22 @@
               {
                 "name": "BUILD_IMAGE",
                 "value": "[parameters('backgroundContainerImageReference')[copyIndex()]]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__API_KEY",
+                "value": "[parameters('govukNotifyApiKey')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__WELCOME_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyWelcomeEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_UPDATE_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseUpdateEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_CREATE_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseCreateEmailTemplateId')]"
               }
             ]
           },


### PR DESCRIPTION
### Context
The mailer container instance cannot send mail as it does not have access to Notify credentials.

### Changes proposed in this pull request
Add GOV.UK Notify env vars to container instance

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
