### PR TITLE
[3072] - GeocodingService bug fix

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -152,7 +152,11 @@ class Provider < ApplicationRecord
   end
 
   def full_address
-    [provider_name, address1, address2, address3, address4, postcode].compact.join(", ")
+    address = [provider_name, address1, address2, address3, address4, postcode]
+
+    return "" if address.all?(&:blank?)
+
+    address.compact.join(", ")
   end
 
   def address_changed?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -69,6 +69,8 @@ class Site < ApplicationRecord
       address.unshift(location_name)
     end
 
+    return "" if address.all?(&:blank?)
+
     address.compact.join(", ")
   end
 

--- a/app/services/geocoder_service.rb
+++ b/app/services/geocoder_service.rb
@@ -1,8 +1,10 @@
 class GeocoderService
   def self.geocode(obj:, force: false)
+    return if obj.full_address.blank?
+
     result = Geokit::Geocoders::GoogleGeocoder.geocode(obj.full_address, bias: "gb")
 
-    if result.present?
+    if result&.success == true
       obj.latitude = result.latitude
       obj.longitude = result.longitude
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -663,6 +663,21 @@ describe Provider, type: :model do
       it "Concatenates address details" do
         expect(provider.full_address).to eq("Southampton High School, Long Lane, Holbury, Southampton, SO45 2PA")
       end
+
+      context "address is missing" do
+        before do
+          provider.provider_name = ""
+          provider.address1 = ""
+          provider.address2 = ""
+          provider.address3 = ""
+          provider.address4 = ""
+          provider.postcode = ""
+        end
+
+        it "returns an empty string" do
+          expect(provider.full_address).to eq("")
+        end
+      end
     end
 
     describe "#needs_geolocation?" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -121,6 +121,21 @@ describe Site, type: :model do
           expect(site.full_address).to eq("Long Lane, Holbury, Southampton, SO45 2PA")
         end
       end
+
+      context "address is missing" do
+        before do
+          site.location_name = ""
+          site.address1 = ""
+          site.address2 = ""
+          site.address3 = ""
+          site.address4 = ""
+          site.postcode = ""
+        end
+
+        it "returns an empty string" do
+          expect(site.full_address).to eq("")
+        end
+      end
     end
 
     describe "#needs_geolocation?" do

--- a/spec/services/geocoder_service_spec.rb
+++ b/spec/services/geocoder_service_spec.rb
@@ -1,6 +1,15 @@
 describe GeocoderService do
   describe "#geocode" do
-    let(:valid_site) { create(:site, region_code: nil) }
+    let(:valid_site) {
+      create(:site,
+             location_name: "Fun Academy",
+                 address1: "Long Lane",
+                 address2: "Holbury",
+                 address3: "Southampton",
+                 address4: "UK",
+                 postcode: "SO45 2PA",
+                 region_code: nil)
+    }
 
     let(:invalid_site) do
       invalid_site = build(:site, postcode: "this is not a postcode", region_code: nil)
@@ -8,29 +17,53 @@ describe GeocoderService do
       invalid_site
     end
 
-    it "geocodes a valid object" do
-      expect { GeocoderService.geocode(obj: valid_site) }.
-          to change { valid_site.reload.latitude }.from(nil).to(51.4524877).
-              and change { valid_site.longitude }.from(nil).to(-0.1204749).
-              and change { valid_site.region_code }.from(nil).to("london")
+    let(:site_with_no_address) do
+      site = build(:site,
+                   location_name: "",
+                   address1: "",
+                   address2: "",
+                   address3: "",
+                   address4: "",
+                   postcode: "",
+                   region_code: nil)
+      site.save!(validate: false)
+      site
     end
 
-    it "does not geocode an invalid object by default" do
-      expect { GeocoderService.geocode(obj: invalid_site) }.
+    context "a valid object" do
+      it "geocodes a valid object" do
+        expect { GeocoderService.geocode(obj: valid_site) }.
+          to change { valid_site.reload.latitude }.from(nil).to(50.8312522).
+            and change { valid_site.longitude }.from(nil).to(-1.3792036).
+            and change { valid_site.region_code }.from(nil).to("south_east")
+      end
+
+      it "geocodes UK (gb) addresses only" do
+        expect(Geokit::Geocoders::GoogleGeocoder).to receive(:geocode).with(valid_site.full_address, bias: "gb")
+
+        GeocoderService.geocode(obj: valid_site)
+      end
+    end
+
+    context "invalid object" do
+      it "does not geocode an invalid object by default" do
+        expect { GeocoderService.geocode(obj: invalid_site) }.
           to raise_error(ActiveRecord::RecordInvalid)
-    end
+      end
 
-    it "geocodes an invalid object if forced" do
-      expect { GeocoderService.geocode(obj: invalid_site, force: true) }.
+      it "geocodes an invalid object if forced" do
+        expect { GeocoderService.geocode(obj: invalid_site, force: true) }.
           to change { invalid_site.reload.latitude }.from(nil).to(51.4524877).
-              and change { invalid_site.longitude }.from(nil).to(-0.1204749).
-              and change { invalid_site.region_code }.from(nil).to("london")
-    end
+            and change { invalid_site.longitude }.from(nil).to(-0.1204749).
+            and change { invalid_site.region_code }.from(nil).to("london")
+      end
 
-    it "geocodes UK (gb) addresses only" do
-      expect(Geokit::Geocoders::GoogleGeocoder).to receive(:geocode).with(valid_site.full_address, bias: "gb")
-
-      GeocoderService.geocode(obj: valid_site)
+      it "does not save to database if Geocoder returns an unsuccessful response" do
+        expect { GeocoderService.geocode(obj: site_with_no_address, force: true) }.
+          to not_change { site_with_no_address.latitude }.
+            and(not_change { site_with_no_address.longitude }).
+            and(not_change { site_with_no_address.region_code })
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,6 +41,9 @@ Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 # it.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.configure do |config|
   # Reduce noise in console when running specs in parallel
   config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]

--- a/spec/support/geocoder_helper.rb
+++ b/spec/support/geocoder_helper.rb
@@ -2,17 +2,25 @@ module GeocoderHelper
   class GeocoderStub
     def geocode(address, **_params)
       case address
-      when "Long Lane, Holbury, Southampton, SO45 2PA"
+      when "Fun Academy, Long Lane, Holbury, Southampton, UK, SO45 2PA"
         Geokit::GeoLoc.new(
           lat: 50.8312522,
           lng: -1.3792036,
-          full_address: "Long Lane, Holbury, Southampton, SO45 2PA",
+          full_address: "Long Lane, Holbury, Southampton, UK, SO45 2PA",
           zip: "SO45 2PA",
           state: "England",
           state_code: "England",
           country: "United Kingdom",
           country_code: "gb",
-        ).tap { |loc| loc.district = "Hampshire" }
+        ).tap do |loc|
+          loc.district = "Hampshire"
+          loc.success = true
+        end
+      # Some legacy sites and providers have no address whatsoever
+      when nil
+        Geokit::GeoLoc.new.tap do |loc|
+          loc.success = false
+        end
       else
         Geokit::GeoLoc.new(
           lat: 51.4524877,
@@ -23,7 +31,11 @@ module GeocoderHelper
           state_code: "England",
           country: "United Kingdom",
           country_code: "UK",
-        ).tap { |loc| loc.district = "Greater London" }
+          success: true,
+        ).tap do |loc|
+          loc.district = "Greater London"
+          loc.success = true
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
Some legacy sites and providers have missing address details, which are considered 'invalid'. When we batch geocode we override the validation checks and attempt to geocode their address with what little information we have. 

A problem arises when we attempt to geocode Sites and Providers with no address details whatsoever (i.e. `address1`, `address2`, `address3`, `address4`, `postcode` are all blank).

Batch geocoding is done in a single process. On Publish, when a site or provider is updated, this is done in a separate process via a back ground job. 

_Currently_, where a Site or Provider **has no address** whatsoever:

1. The mcb geocode command geocodes the object via the GeocoderService.
2. The Geocoder API returns an unsuccessful response. The GeocoderService still attempts to update the record regardless.
3. Upon save, an after db commit hook is called to checked if the object requires geocoding. At this point because the object's full address is considered to be present (ie `Site#full_address` returns `", , , ,"`) and both lat and long is `nil`, the geocoding job request is created.  

### Changes proposed in this pull request
Introduce new guard clauses so that geocoding only happens when it's supposed to.

1. Return `nil` for `#full_address` if a Site / Provider has no address whatsoever. 
2. Only call the Google Geocoding API if the object has a `full_address`
3. Only update the object of the Geocoding API returns a success response.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
