### PR TITLE
Update annotations after gem update

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -11,14 +11,14 @@
 #  discarded_at              :datetime
 #  english                   :integer
 #  id                        :integer          not null, primary key
-#  is_send                   :boolean          default("false")
+#  is_send                   :boolean          default(FALSE)
 #  level                     :string
 #  maths                     :integer
 #  modular                   :text
 #  name                      :text
 #  profpost_flag             :text
 #  program_type              :text
-#  provider_id               :integer          default("0"), not null
+#  provider_id               :integer          default(0), not null
 #  qualification             :integer          not null
 #  science                   :integer
 #  start_date                :datetime

--- a/app/models/financial_incentive.rb
+++ b/app/models/financial_incentive.rb
@@ -8,7 +8,7 @@
 #  id                                             :bigint           not null, primary key
 #  scholarship                                    :string
 #  subject_id                                     :bigint           not null
-#  subject_knowledge_enhancement_course_available :boolean          default("false"), not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
 #  updated_at                                     :datetime         not null
 #
 # Indexes

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -13,7 +13,7 @@
 #  location_name :text
 #  longitude     :float
 #  postcode      :text
-#  provider_id   :integer          default("0"), not null
+#  provider_id   :integer          default(0), not null
 #  region_code   :integer
 #  updated_at    :datetime         not null
 #

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@
 # Table name: user
 #
 #  accept_terms_date_utc  :datetime
-#  admin                  :boolean          default("false")
+#  admin                  :boolean          default(FALSE)
 #  email                  :text
 #  first_login_date_utc   :datetime
 #  first_name             :text

--- a/app/models/user_notification.rb
+++ b/app/models/user_notification.rb
@@ -2,8 +2,8 @@
 #
 # Table name: user_notification
 #
-#  course_create :boolean          default("false")
-#  course_update :boolean          default("false")
+#  course_create :boolean          default(FALSE)
+#  course_update :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  id            :bigint           not null, primary key
 #  provider_code :string           not null

--- a/app/serializers/course_serializer.rb
+++ b/app/serializers/course_serializer.rb
@@ -11,14 +11,14 @@
 #  discarded_at              :datetime
 #  english                   :integer
 #  id                        :integer          not null, primary key
-#  is_send                   :boolean          default("false")
+#  is_send                   :boolean          default(FALSE)
 #  level                     :string
 #  maths                     :integer
 #  modular                   :text
 #  name                      :text
 #  profpost_flag             :text
 #  program_type              :text
-#  provider_id               :integer          default("0"), not null
+#  provider_id               :integer          default(0), not null
 #  qualification             :integer          not null
 #  science                   :integer
 #  start_date                :datetime

--- a/app/serializers/site_serializer.rb
+++ b/app/serializers/site_serializer.rb
@@ -13,7 +13,7 @@
 #  location_name :text
 #  longitude     :float
 #  postcode      :text
-#  provider_id   :integer          default("0"), not null
+#  provider_id   :integer          default(0), not null
 #  region_code   :integer
 #  updated_at    :datetime         not null
 #

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -11,14 +11,14 @@
 #  discarded_at              :datetime
 #  english                   :integer
 #  id                        :integer          not null, primary key
-#  is_send                   :boolean          default("false")
+#  is_send                   :boolean          default(FALSE)
 #  level                     :string
 #  maths                     :integer
 #  modular                   :text
 #  name                      :text
 #  profpost_flag             :text
 #  program_type              :text
-#  provider_id               :integer          default("0"), not null
+#  provider_id               :integer          default(0), not null
 #  qualification             :integer          not null
 #  science                   :integer
 #  start_date                :datetime

--- a/spec/factories/financial_incentives.rb
+++ b/spec/factories/financial_incentives.rb
@@ -8,7 +8,7 @@
 #  id                                             :bigint           not null, primary key
 #  scholarship                                    :string
 #  subject_id                                     :bigint           not null
-#  subject_knowledge_enhancement_course_available :boolean          default("false"), not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
 #  updated_at                                     :datetime         not null
 #
 # Indexes

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -13,7 +13,7 @@
 #  location_name :text
 #  longitude     :float
 #  postcode      :text
-#  provider_id   :integer          default("0"), not null
+#  provider_id   :integer          default(0), not null
 #  region_code   :integer
 #  updated_at    :datetime         not null
 #

--- a/spec/factories/user_notifications.rb
+++ b/spec/factories/user_notifications.rb
@@ -2,8 +2,8 @@
 #
 # Table name: user_notification
 #
-#  course_create :boolean          default("false")
-#  course_update :boolean          default("false")
+#  course_create :boolean          default(FALSE)
+#  course_update :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  id            :bigint           not null, primary key
 #  provider_code :string           not null

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@
 # Table name: user
 #
 #  accept_terms_date_utc  :datetime
-#  admin                  :boolean          default("false")
+#  admin                  :boolean          default(FALSE)
 #  email                  :text
 #  first_login_date_utc   :datetime
 #  first_name             :text

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -11,14 +11,14 @@
 #  discarded_at              :datetime
 #  english                   :integer
 #  id                        :integer          not null, primary key
-#  is_send                   :boolean          default("false")
+#  is_send                   :boolean          default(FALSE)
 #  level                     :string
 #  maths                     :integer
 #  modular                   :text
 #  name                      :text
 #  profpost_flag             :text
 #  program_type              :text
-#  provider_id               :integer          default("0"), not null
+#  provider_id               :integer          default(0), not null
 #  qualification             :integer          not null
 #  science                   :integer
 #  start_date                :datetime

--- a/spec/models/financial_incentive_spec.rb
+++ b/spec/models/financial_incentive_spec.rb
@@ -8,7 +8,7 @@
 #  id                                             :bigint           not null, primary key
 #  scholarship                                    :string
 #  subject_id                                     :bigint           not null
-#  subject_knowledge_enhancement_course_available :boolean          default("false"), not null
+#  subject_knowledge_enhancement_course_available :boolean          default(FALSE), not null
 #  updated_at                                     :datetime         not null
 #
 # Indexes

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -13,7 +13,7 @@
 #  location_name :text
 #  longitude     :float
 #  postcode      :text
-#  provider_id   :integer          default("0"), not null
+#  provider_id   :integer          default(0), not null
 #  region_code   :integer
 #  updated_at    :datetime         not null
 #

--- a/spec/models/user_notification_spec.rb
+++ b/spec/models/user_notification_spec.rb
@@ -2,8 +2,8 @@
 #
 # Table name: user_notification
 #
-#  course_create :boolean          default("false")
-#  course_update :boolean          default("false")
+#  course_create :boolean          default(FALSE)
+#  course_update :boolean          default(FALSE)
 #  created_at    :datetime         not null
 #  id            :bigint           not null, primary key
 #  provider_code :string           not null

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,7 +3,7 @@
 # Table name: user
 #
 #  accept_terms_date_utc  :datetime
-#  admin                  :boolean          default("false")
+#  admin                  :boolean          default(FALSE)
 #  email                  :text
 #  first_login_date_utc   :datetime
 #  first_name             :text

--- a/spec/serializers/course_serializer_spec.rb
+++ b/spec/serializers/course_serializer_spec.rb
@@ -11,14 +11,14 @@
 #  discarded_at              :datetime
 #  english                   :integer
 #  id                        :integer          not null, primary key
-#  is_send                   :boolean          default("false")
+#  is_send                   :boolean          default(FALSE)
 #  level                     :string
 #  maths                     :integer
 #  modular                   :text
 #  name                      :text
 #  profpost_flag             :text
 #  program_type              :text
-#  provider_id               :integer          default("0"), not null
+#  provider_id               :integer          default(0), not null
 #  qualification             :integer          not null
 #  science                   :integer
 #  start_date                :datetime

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -13,7 +13,7 @@
 #  location_name :text
 #  longitude     :float
 #  postcode      :text
-#  provider_id   :integer          default("0"), not null
+#  provider_id   :integer          default(0), not null
 #  region_code   :integer
 #  updated_at    :datetime         not null
 #


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/teacher-training-api/pull/1270
Merged in daf1e293c46b978e9fd89db681e3ee10aa25fb92
> Bumps annotate from 3.1.0 to 3.1.1.


### Changes proposed in this pull request

Update annotations after gem update

### Guidance to review

:eyes:

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally