### PR TITLE
[2893] Add Location to API docs

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -1,0 +1,8 @@
+module API
+  module Public
+    module V1
+      class ApplicationController < ActionController::API
+      end
+    end
+  end
+end

--- a/app/controllers/api/public/v1/locations_controller.rb
+++ b/app/controllers/api/public/v1/locations_controller.rb
@@ -1,0 +1,32 @@
+module API
+  module Public
+    module V1
+      class LocationsController < API::Public::V1::ApplicationController
+        def index
+          render json: {
+            data: [
+              {
+                id: "123",
+                type: "Location",
+                attributes: {
+                  code: "A",
+                  name: "some school",
+                  street_address_1: "some building",
+                  street_address_2: "some street",
+                  city: "some city",
+                  county: "some county",
+                  postcode: "NE1 6EE",
+                  region_code: "london",
+                  recruitment_cycle_year: "2020",
+                },
+              },
+            ],
+            jsonapi: {
+              version: "1.0",
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -99,6 +99,7 @@
 #                    api_v3_recruitment_cycle_provider GET    /api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                             api/v3/providers#show
 #                             api_v3_recruitment_cycle GET    /api/v3/recruitment_cycles/:year(.:format)                                                                                               api/v3/recruitment_cycles#show
 #                          api_v3_provider_suggestions GET    /api/v3/provider-suggestions(.:format)                                                                                                   api/v3/provider_suggestions#index
+#                       api_public_v1_course_locations GET    /api/public/v1/courses/:course_id/locations(.:format)                                                                                    api/public/v1/locations#index
 #                                            error_500 GET    /error_500(.:format)                                                                                                                     error#error_500
 #                                           error_nodb GET    /error_nodb(.:format)                                                                                                                    error#error_nodb
 #
@@ -191,6 +192,14 @@ Rails.application.routes.draw do
         end
       end
       get "provider-suggestions", to: "provider_suggestions#index"
+    end
+
+    namespace :public do
+      namespace :v1 do
+        resources :courses, only: [] do
+          resources :locations, only: [:index]
+        end
+      end
     end
   end
 

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -1,0 +1,23 @@
+require "swagger_helper"
+
+describe "API" do
+  path "/api/public/v1/courses/{course_code}/locations" do
+    get "Returns locations for the given course" do
+      operationId :public_api_v1_course_locations
+      tags "location"
+      produces "application/json"
+      parameter name: :course_code,
+        in: :path,
+        type: :string,
+        description: "The code of the course"
+
+      response "200", "The list of locations for the given course" do
+        let(:course_code) { 123 }
+
+        schema "$ref": "#/components/schemas/LocationsList"
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -441,6 +441,86 @@
           }
         }
       },
+      "LocationAttributes": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "example": "W"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of the location",
+            "example": "Henry Maynard Primary School"
+          },
+          "street_address_1": {
+            "type": "string",
+            "description": "Building or street line one",
+            "example": "The Rose Building"
+          },
+          "street_address_2": {
+            "type": "string",
+            "description": "Building or street line two",
+            "example": "Maynard Road"
+          },
+          "city": {
+            "type": "string",
+            "description": "Town or city",
+            "example": "London"
+          },
+          "county": {
+            "type": "string",
+            "description": "County",
+            "example": "London"
+          },
+          "postcode": {
+            "type": "string",
+            "description": "The postcode of the location",
+            "example": "E17 9JE"
+          },
+          "region_code": {
+            "type": "string",
+            "example": "london"
+          },
+          "recruitment_cycle_year": {
+            "type": "string",
+            "example": "2020"
+          }
+        }
+      },
+      "LocationResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "11214485"
+          },
+          "type": {
+            "type": "string",
+            "example": "sites"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/LocationAttributes"
+          }
+        }
+      },
+      "LocationsList": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocationResource"
+            }
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
       "Relationship": {
         "type": "object",
         "properties": {
@@ -473,6 +553,9 @@
           },
           {
             "$ref": "#/components/schemas/SubjectResource"
+          },
+          {
+            "$ref": "#/components/schemas/LocationResource"
           }
         ],
         "discriminator": {
@@ -607,6 +690,38 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/CourseSingleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/v1/courses/{course_code}/locations": {
+      "get": {
+        "summary": "Returns locations for the given course",
+        "operationId": "public_api_v1_course_locations",
+        "tags": [
+          "location"
+        ],
+        "parameters": [
+          {
+            "name": "course_code",
+            "in": "path",
+            "description": "The code of the course",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The list of locations for the given course",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocationsList"
                 }
               }
             }

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -372,6 +372,64 @@ components:
         version:
           type: string
           example: "1.0"
+    LocationAttributes:
+      type: object
+      properties:
+        code:
+          type: string
+          example: "W"
+        name:
+          type: string
+          description: "The name of the location"
+          example: "Henry Maynard Primary School"
+        street_address_1:
+          type: string
+          description: "Building or street line one"
+          example: "The Rose Building"
+        street_address_2:
+          type: string
+          description: "Building or street line two"
+          example: "Maynard Road"
+        city:
+          type: string
+          description: "Town or city"
+          example: "London"
+        county:
+          type: string
+          description: "County"
+          example: "London"
+        postcode:
+          type: string
+          description: "The postcode of the location"
+          example: "E17 9JE"
+        region_code:
+          type: string
+          example: "london"
+        recruitment_cycle_year:
+          type: string
+          example: "2020"
+    LocationResource:
+      type: object
+      properties:
+        id:
+          type: string
+          example: "11214485"
+        type:
+          type: string
+          example: "sites"
+        attributes:
+          $ref: "#/components/schemas/LocationAttributes"
+    LocationsList:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocationResource"
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPI"
     Relationship:
       type: object
       properties:
@@ -391,6 +449,7 @@ components:
         - $ref: '#/components/schemas/CourseResource'
         - $ref: '#/components/schemas/RecruitmentCycleResource'
         - $ref: '#/components/schemas/SubjectResource'
+        - $ref: '#/components/schemas/LocationResource'
       discriminator:
         propertyName: type
     ResourceIdentifier:


### PR DESCRIPTION
### Context

- https://trello.com/c/fdFc3kNR/2893-create-openapi-spec-for-locations
- Add Location to API documentation as it is does not exists

### Changes proposed in this pull request

- Add documentation

### Guidance to review

- run docs, see https://github.com/DFE-Digital/teacher-training-api#documentation
- visit http://localhost:3001
- see added Location documentation, compared to https://api2.qa.publish-teacher-training-courses.service.gov.uk/#about

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
