### PR TITLE
[3190] Add course resource to v2

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -216,6 +216,10 @@ class Course < ApplicationRecord
     where(qualification: qualifications)
   end
 
+  scope :with_accredited_bodies, ->(accredited_body_codes) do
+    where(accrediting_provider_code: accredited_body_codes)
+  end
+
   scope :with_provider_name, ->(provider_name) do
     where(
       provider_id: Provider.where(provider_name: provider_name),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@
 #                    api_v2_recruitment_cycle_provider GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                             api/v2/providers#show
 #                                                      PATCH  /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                             api/v2/providers#update
 #                                                      PUT    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:code(.:format)                                                             api/v2/providers#update
+#                     api_v2_recruitment_cycle_courses GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/courses(.:format)                                                                     api/v2/courses#index
 #                            api_v2_recruitment_cycles GET    /api/v2/recruitment_cycles(.:format)                                                                                                     api/v2/recruitment_cycles#index
 #                             api_v2_recruitment_cycle GET    /api/v2/recruitment_cycles/:year(.:format)                                                                                               api/v2/recruitment_cycles#show
 #                                      api_v2_sessions GET    /api/v2/sessions(.:format)                                                                                                               api/v2/sessions#show
@@ -163,6 +164,8 @@ Rails.application.routes.draw do
                   param: :code,
                   concerns: :provider_routes do
         end
+
+        get "/courses", to: "courses#index"
       end
 
       resource :sessions

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -902,6 +902,21 @@ describe Course, type: :model do
         it { is_expected.to contain_exactly(accredited_course) }
       end
     end
+
+    describe ".with_accredited_bodies" do
+      context "course with an accredited body" do
+        let!(:provider) { create(:provider) }
+        let!(:course) { create(:course, provider: provider) }
+        let!(:accredited_provider) { create(:provider, :accredited_body) }
+        let!(:accredited_course) { create(:course, accrediting_provider: accredited_provider) }
+
+        subject { described_class.with_accredited_bodies(accredited_provider.provider_code) }
+
+        it "returns courses for which the provider is the accredited body" do
+          expect(subject).to contain_exactly(accredited_course)
+        end
+      end
+    end
   end
 
   describe "changed_at" do

--- a/spec/requests/api/v2/courses_spec.rb
+++ b/spec/requests/api/v2/courses_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+describe "Courses API v2", type: :request do
+  let(:user)         { create(:user) }
+  let(:organisation) { create(:organisation, users: [user]) }
+  let(:payload)      { { email: user.email } }
+  let(:token)        { build_jwt :apiv2, payload: payload }
+  let(:credentials) do
+    ActionController::HttpAuthentication::Token.encode_credentials(token)
+  end
+  let(:current_cycle) { find_or_create :recruitment_cycle }
+  let(:next_cycle)    { find_or_create :recruitment_cycle, :next }
+  let(:current_year)  { current_cycle.year.to_i }
+  let(:previous_year) { current_year - 1 }
+  let(:next_year)     { current_year + 1 }
+  let(:subjects) { [course_subject_mathematics] }
+
+  let(:provider1)       { create :provider, organisations: [organisation] }
+  let(:provider2)       { create :provider, organisations: [organisation] }
+  let(:accredited_body) { create :provider, :accredited_body }
+
+  let(:course1) { create(:course, provider: provider1) }
+  let(:course2) { create(:course, provider: provider2) }
+  let(:course3) { create(:course) }
+  let(:course4) { create(:course, provider: provider1, accrediting_provider: accredited_body) }
+
+  describe "GET index" do
+    subject { perform_request(request_path) }
+
+    def perform_request(path)
+      course1
+      course2
+      course3
+      course4
+      get path,
+          headers: { "HTTP_AUTHORIZATION" => credentials }
+      response
+    end
+
+    context "request without filters" do
+      let(:request_path) do
+        api_v2_recruitment_cycle_courses_path(current_cycle.year) +
+          "?include=subjects"
+      end
+
+      it "returns user related courses" do
+        json_response = JSON.parse subject.body
+
+        expect(response).to have_http_status(:success)
+        expect(json_response["data"].count).to eq(3)
+        expect(json_response["data"].pluck("id")).not_to include(course3.id.to_s)
+        expect(json_response["included"].first["type"]).to eq("subjects")
+      end
+    end
+
+    context "request with accrediting_provider filter" do
+      let(:request_path) do
+        api_v2_recruitment_cycle_courses_path(current_cycle.year) +
+          "?include=subjects&filter[accrediting_provider_code]=#{accredited_body.provider_code}"
+      end
+
+      it "returns user related courses filtered by accredited body" do
+        json_response = JSON.parse subject.body
+        expect(json_response["data"].pluck("id")).to eq([course4.id.to_s])
+        expect(json_response["included"].first["type"]).to eq("subjects")
+      end
+
+      context "for multiple codes" do
+        let(:request_path) do
+          api_v2_recruitment_cycle_courses_path(current_cycle.year) +
+            "?filter[accrediting_provider_code][]=#{accredited_body.provider_code}" +
+            "&filter[accrediting_provider_code][]=#{accredited_body2.provider_code}"
+        end
+
+        let(:accredited_body2) { create :provider, :accredited_body }
+        let!(:course5) { create(:course, provider: provider1, accrediting_provider: accredited_body2) }
+
+        it "returns user related courses filtered by accredited body" do
+          json_response = JSON.parse subject.body
+          expect(json_response["data"].pluck("id")).to match_array([course4.id.to_s, course5.id.to_s])
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Changes are required for the Accredited body feature in Publish.

### Changes proposed in this pull request

Allow retrieving courses across multiple training providers in one
hit. Specifically for accredited bodies to be able to see the courses of
their training providers.

Having this as a new resource-style endpoint with the ability to apply
filters will allow us to consolidate all the other course endpoints.

### Guidance to review
- Generate a token: TOKEN=`bin/mcb apiv2 token generate -S secret user@example.com`
- `curl -H 'Accept: application/json' -H "Authorization: Bearer ${TOKEN}" 'http://localhost:3001/api/v2/recruitment_cycles/2020/courses?filter%5Baccrediting_provider_code%5D%3DE69%27’`
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
