### PR TITLE
[3194] Add commit sha to deploy artifact

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ steps:
     echo "##vso[task.setvariable variable=docker_path;]$docker_path"
     echo "##vso[task.setvariable variable=docker_bg_geocode_path;]$docker_bg_geocode_path"
     echo "##vso[task.setvariable variable=docker_bg_mailer_path;]$docker_bg_mailer_path"
+    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: |


### PR DESCRIPTION
### Context

In order to send the commit sha of the release to Sentry/Logit - we need to store it in the build artifact to be accessible.

### Changes proposed in this pull request

- Store the commit sha in a file to be later accessed.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
