### PR TITLE
[3195] Add the commit sha to logging and sentry

### DIFF
--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,6 +1,8 @@
 LogStashLogger.configure do |config|
+  commit_sha = File.read(Rails.root.join("COMMIT_SHA")).strip
   config.customize_event do |event|
     event["application"] = Settings.application
     event["environment"] = Rails.env
+    event["release"] = commit_sha
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -7,4 +7,7 @@ Raven.configure do |config|
     ["ActiveRecord::RecordNotFound"]
 
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+
+  commit_sha = File.read(Rails.root.join("COMMIT_SHA")).strip
+  config.release = commit_sha
 end


### PR DESCRIPTION
### Context

We want to see the version of the code that is deployed in both logging and when we get errors reported

### Changes proposed in this pull request

- Add the `COMMIT_SHA` to both Sentry and Logstash

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
