### PR TITLE
[2892] location status api docs

### DIFF
--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -237,6 +237,23 @@
           }
         }
       },
+      "LocationStatusResource": {
+        "type": "object",
+        "description": "Wrapper object for LocationStatusAttributes",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "22329867"
+          },
+          "type": {
+            "type": "string",
+            "example": "site_statuses"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/LocationStatusAttributes"
+          }
+        }
+      },
       "ProviderResource": {
         "type": "object",
         "required": [
@@ -335,6 +352,9 @@
           },
           {
             "$ref": "#/components/schemas/LocationResource"
+          },
+          {
+            "$ref": "#/components/schemas/LocationStatusResource"
           }
         ],
         "discriminator": {
@@ -392,6 +412,178 @@
           },
           "attributes": {
             "$ref": "#/components/schemas/SubjectAttributes"
+          }
+        }
+      },
+      "ProviderRelationships": {
+        "type": "object",
+        "properties": {
+          "locations": {
+            "$ref": "#/components/schemas/RelationshipList"
+          },
+          "recruitment_cycle": {
+            "$ref": "#/components/schemas/Relationship"
+          }
+        }
+      },
+      "LocationStatusAttributes": {
+        "type": "object",
+        "description": "Fields relating to the state of a location",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "discontinued",
+              "running",
+              "new_status",
+              "suspended"
+            ],
+            "example": "running"
+          },
+          "publish": {
+            "type": "string",
+            "enum": [
+              "published",
+              "unpublished"
+            ],
+            "example": "published"
+          },
+          "has_vacancies": {
+            "type": "boolean",
+            "description": "Are there any vacancies for this course",
+            "example": true
+          },
+          "vacancy_status": {
+            "type": "string",
+            "description": "What type of vacancies are available",
+            "enum": [
+              "full_time_vacancies",
+              "part_time_vacancies",
+              "both_full_time_and_part_time_vacancies"
+            ],
+            "example": "full_time_vacancies"
+          },
+          "relationships": {
+            "$ref": "#/components/schemas/LocationStatusRelationships"
+          }
+        }
+      },
+      "ProviderAttributes": {
+        "type": "object",
+        "required": [
+          "code",
+          "name"
+        ],
+        "properties": {
+          "accredited_body?": {
+            "type": "boolean",
+            "description": "Is this provider an accredited body for other provider's courses.",
+            "example": "true"
+          },
+          "city": {
+            "type": "string",
+            "description": "Town or city",
+            "example": "London"
+          },
+          "county": {
+            "type": "string",
+            "description": "County",
+            "example": "London"
+          },
+          "changed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Date-time timestamp of when this provider or any of its related data changed.",
+            "example": "2019-06-13T10:44:31Z"
+          },
+          "code": {
+            "type": "string",
+            "description": "Code that uniquely identifies this provider within a recruitment cycle.",
+            "maxLength": 3,
+            "minLength": 3,
+            "example": "X99"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of when this provider was created.",
+            "example": "2019-06-13T10:44:31Z"
+          },
+          "postcode": {
+            "type": "string",
+            "format": "uk-postcode",
+            "description": "The provider's postcode",
+            "maxLength": 8,
+            "example": "SK2 6AA"
+          },
+          "name": {
+            "type": "string",
+            "description": "The name of training provider.",
+            "example": "Long School"
+          },
+          "provider_type": {
+            "type": "string",
+            "description": "The type of provider.",
+            "example": "scitt",
+            "enum": [
+              "scitt",
+              "lead_school",
+              "university",
+              "unknown",
+              "invalid_value"
+            ]
+          },
+          "recruitment_cycle_year": {
+            "type": "integer",
+            "description": "The recruitment year this provider record is for.",
+            "example": 2020
+          },
+          "region_code": {
+            "type": "string",
+            "description": "The NUTS 1 region code for the provider's address.",
+            "example": "south_west",
+            "enum": [
+              "no_region",
+              "london",
+              "south_east",
+              "south_west",
+              "wales",
+              "west_midlands",
+              "east_midlands",
+              "eastern",
+              "north_west",
+              "yorkshire_and_the_humber",
+              "north_east",
+              "scotland"
+            ]
+          },
+          "street_address_1": {
+            "type": "string",
+            "description": "Building or street line one",
+            "example": "Long College"
+          },
+          "street_address_2": {
+            "type": "string",
+            "description": "Building or street line two",
+            "example": "1st floor, 86 Long Rd"
+          },
+          "train_with_disability": {
+            "type": "string",
+            "format": "markdown",
+            "description": "How candidates with disabilities and other needs will be supported.",
+            "example": "We are committed to supporting trainees with disabilities and other needs, so please let us and the accrediting provider know if you would like us to make any adjustments to support you."
+          },
+          "train_with_us": {
+            "type": "string",
+            "format": "markdown",
+            "description": "Information about the training provider.",
+            "example": "We offer both primary and secondary training in a wide range of subjects and work with a collection of schools in the local area. We offer diverse teaching placements, ensuring trainees have experience in different types of school environments."
+          },
+          "website": {
+            "type": "string",
+            "format": "url",
+            "description": "A link to the initial teacher training or course pages of your website",
+            "example": "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/"
           }
         }
       },
@@ -751,122 +943,27 @@
           }
         }
       },
-      "ProviderAttributes": {
+      "LocationStatusRelationships": {
         "type": "object",
-        "required": [
-          "code",
-          "name"
-        ],
+        "description": "Associated data",
         "properties": {
-          "accredited_body?": {
-            "type": "boolean",
-            "description": "Is this provider an accredited body for other provider's courses.",
-            "example": "true"
-          },
-          "city": {
-            "type": "string",
-            "description": "Town or city",
-            "example": "London"
-          },
-          "county": {
-            "type": "string",
-            "description": "County",
-            "example": "London"
-          },
-          "changed_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Date-time timestamp of when this provider or any of its related data changed.",
-            "example": "2019-06-13T10:44:31Z"
-          },
-          "code": {
-            "type": "string",
-            "description": "Code that uniquely identifies this provider within a recruitment cycle.",
-            "maxLength": 3,
-            "minLength": 3,
-            "example": "X99"
-          },
-          "created_at": {
-            "type": "string",
-            "format": "date-time",
-            "description": "Timestamp of when this provider was created.",
-            "example": "2019-06-13T10:44:31Z"
-          },
-          "postcode": {
-            "type": "string",
-            "format": "uk-postcode",
-            "description": "The provider's postcode",
-            "maxLength": 8,
-            "example": "SK2 6AA"
-          },
-          "name": {
-            "type": "string",
-            "description": "The name of training provider.",
-            "example": "Long School"
-          },
-          "provider_type": {
-            "type": "string",
-            "description": "The type of provider.",
-            "example": "scitt",
-            "enum": [
-              "scitt",
-              "lead_school",
-              "university",
-              "unknown",
-              "invalid_value"
-            ]
-          },
-          "recruitment_cycle_year": {
-            "type": "integer",
-            "description": "The recruitment year this provider record is for.",
-            "example": 2020
-          },
-          "region_code": {
-            "type": "string",
-            "description": "The NUTS 1 region code for the provider's address.",
-            "example": "south_west",
-            "enum": [
-              "no_region",
-              "london",
-              "south_east",
-              "south_west",
-              "wales",
-              "west_midlands",
-              "east_midlands",
-              "eastern",
-              "north_west",
-              "yorkshire_and_the_humber",
-              "north_east",
-              "scotland"
-            ]
-          },
-          "street_address_1": {
-            "type": "string",
-            "description": "Building or street line one",
-            "example": "Long College"
-          },
-          "street_address_2": {
-            "type": "string",
-            "description": "Building or street line two",
-            "example": "1st floor, 86 Long Rd"
-          },
-          "train_with_disability": {
-            "type": "string",
-            "format": "markdown",
-            "description": "How candidates with disabilities and other needs will be supported.",
-            "example": "We are committed to supporting trainees with disabilities and other needs, so please let us and the accrediting provider know if you would like us to make any adjustments to support you."
-          },
-          "train_with_us": {
-            "type": "string",
-            "format": "markdown",
-            "description": "Information about the training provider.",
-            "example": "We offer both primary and secondary training in a wide range of subjects and work with a collection of schools in the local area. We offer diverse teaching placements, ensuring trainees have experience in different types of school environments."
-          },
-          "website": {
-            "type": "string",
-            "format": "url",
-            "description": "A link to the initial teacher training or course pages of your website",
-            "example": "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/"
+          "site": {
+            "type": "object",
+            "properties": {
+              "data": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "example": "11214483"
+                  },
+                  "type": {
+                    "type": "string",
+                    "example": "sites"
+                  }
+                }
+              }
+            }
           }
         }
       },
@@ -883,17 +980,6 @@
           "code": {
             "type": "string",
             "description": "Unique subject code."
-          }
-        }
-      },
-      "ProviderRelationships": {
-        "type": "object",
-        "properties": {
-          "locations": {
-            "$ref": "#/components/schemas/RelationshipList"
-          },
-          "recruitment_cycle": {
-            "$ref": "#/components/schemas/Relationship"
           }
         }
       },

--- a/swagger/public_v1/component_schemas/LocationStatusAttributes.yml
+++ b/swagger/public_v1/component_schemas/LocationStatusAttributes.yml
@@ -1,0 +1,32 @@
+---
+type: object
+description: Fields relating to the state of a location
+properties:
+  status:
+    type: string
+    enum:
+      - discontinued
+      - running
+      - new_status
+      - suspended
+    example: "running"
+  publish:
+    type: string
+    enum:
+      - published
+      - unpublished
+    example: "published"
+  has_vacancies:
+    type: boolean
+    description: "Are there any vacancies for this course"
+    example: true
+  vacancy_status:
+    type: string
+    description: "What type of vacancies are available"
+    enum:
+     - full_time_vacancies
+     - part_time_vacancies
+     - both_full_time_and_part_time_vacancies
+    example: full_time_vacancies
+  relationships:
+    $ref: "#/components/schemas/LocationStatusRelationships"

--- a/swagger/public_v1/component_schemas/LocationStatusRelationships.yml
+++ b/swagger/public_v1/component_schemas/LocationStatusRelationships.yml
@@ -1,0 +1,16 @@
+---
+type: object
+description: "Associated data"
+properties:
+  site:
+    type: object
+    properties:
+      data:
+        type: object
+        properties:
+          id:
+            type: string
+            example: "11214483"
+          type:
+            type: string
+            example: sites

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -171,6 +171,18 @@ components:
             $ref: "#/components/schemas/LocationResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
+    LocationStatusResource:
+      type: object
+      description: Wrapper object for LocationStatusAttributes
+      properties:
+        id:
+          type: string
+          example: "22329867"
+        type:
+          type: string
+          example: site_statuses
+        attributes:
+          $ref: "#/components/schemas/LocationStatusAttributes"
     ProviderResource:
       type: object
       required:
@@ -234,6 +246,7 @@ components:
         - $ref: '#/components/schemas/RecruitmentCycleResource'
         - $ref: '#/components/schemas/SubjectResource'
         - $ref: '#/components/schemas/LocationResource'
+        - $ref: '#/components/schemas/LocationStatusResource'
       discriminator:
         propertyName: type
     ResourceIdentifier:


### PR DESCRIPTION
### Context

- https://trello.com/c/9fqUlf8O/2892-s-create-openapi-spec-for-courselocations
- Add LocationStatus to API docs as it does not exists

### Changes proposed in this pull request

- Add documentation for LocationStatus

### Guidance to review

- fire up docs, see https://github.com/DFE-Digital/teacher-training-api#documentation
- Should see new documentation
- this depends on https://github.com/DFE-Digital/teacher-training-api/pull/1287/files which should be merged first

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
