### PR TITLE
[3218] Fix base url for api docs

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -1,0 +1,27 @@
+module API
+  module Public
+    module V1
+      class CoursesController < API::Public::V1::ApplicationController
+        def index
+          render json: {
+            data: [
+              {
+                id: 123,
+                type: "Course",
+                attributes: {
+                  code: "3GTY",
+                  provider_code: "6CL",
+                  age_minimum: 11,
+                  age_maximum: 14,
+                },
+              },
+            ],
+            jsonapi: {
+              version: "1.0",
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -100,6 +100,7 @@
 #                             api_v3_recruitment_cycle GET    /api/v3/recruitment_cycles/:year(.:format)                                                                                               api/v3/recruitment_cycles#show
 #                          api_v3_provider_suggestions GET    /api/v3/provider-suggestions(.:format)                                                                                                   api/v3/provider_suggestions#index
 #                       api_public_v1_course_locations GET    /api/public/v1/courses/:course_id/locations(.:format)                                                                                    api/public/v1/locations#index
+#                                api_public_v1_courses GET    /api/public/v1/courses(.:format)                                                                                                         api/public/v1/courses#index
 #                                            error_500 GET    /error_500(.:format)                                                                                                                     error#error_500
 #                                           error_nodb GET    /error_nodb(.:format)                                                                                                                    error#error_nodb
 #
@@ -196,7 +197,7 @@ Rails.application.routes.draw do
 
     namespace :public do
       namespace :v1 do
-        resources :courses, only: [] do
+        resources :courses, only: [:index] do
           resources :locations, only: [:index]
         end
       end

--- a/spec/api/courses_spec.rb
+++ b/spec/api/courses_spec.rb
@@ -1,8 +1,7 @@
 require "swagger_helper"
 
 describe "API" do
-  # http://localhost:3001/api/v3/courses
-  path "/api/v3/courses" do
+  path "/courses" do
     get "Returns courses for the current recruitment cycle" do
       operationId :public_api_v1_courses
       tags "course"

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -1,7 +1,7 @@
 require "swagger_helper"
 
 describe "API" do
-  path "/api/public/v1/courses/{course_code}/locations" do
+  path "/courses/{course_code}/locations" do
     get "Returns locations for the given course" do
       operationId :public_api_v1_course_locations
       tags "location"

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -1,6 +1,12 @@
 require "rails_helper"
 
 RSpec.configure do |config|
+  config.before :suite do
+    # Patch to ensure both rspec works and valid OpenAPI spec is generated
+    # see https://github.com/jdanielian/open-api-rswag#global-metadata
+    OpenApi::Rswag::Specs.config.swagger_docs["public_v1/api_spec.json"]["basePath"] = "/api/public/v1/"
+  end
+
   # Specify a root folder where Swagger JSON files are generated
   # NOTE: If you're using the rswag-api to serve API descriptions, you'll need
   # to ensure that it's configured to serve Swagger from the same folder

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -11,8 +11,16 @@
   },
   "servers": [
     {
+      "url": "https://api2.publish-teacher-training-courses.service.gov.uk/api/public/{version}",
       "description": "Production",
-      "url": "https://api2.publish-teacher-training-courses.service.gov.uk/api/public/v1"
+      "variables": {
+        "version": {
+          "enum": [
+            "v1"
+          ],
+          "default": "v1"
+        }
+      }
     }
   ],
   "components": {
@@ -656,7 +664,7 @@
     }
   },
   "paths": {
-    "/api/v3/courses": {
+    "/courses": {
       "get": {
         "summary": "Returns courses for the current recruitment cycle",
         "operationId": "public_api_v1_courses",
@@ -697,7 +705,7 @@
         }
       }
     },
-    "/api/public/v1/courses/{course_code}/locations": {
+    "/courses/{course_code}/locations": {
       "get": {
         "summary": "Returns locations for the given course",
         "operationId": "public_api_v1_course_locations",

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -8,8 +8,13 @@ info:
     email: becomingateacher@digital.education.gov.uk
   description: API for DfE's postgraduate teacher training course service
 servers:
-  - description: Production
-    url: https://api2.publish-teacher-training-courses.service.gov.uk/api/public/v1
+  - url: https://api2.publish-teacher-training-courses.service.gov.uk/api/public/{version}
+    description: Production
+    variables:
+      version:
+        enum:
+          - v1
+        default: v1
 components:
   schemas:
     CourseAttributes:


### PR DESCRIPTION
### Context

- https://trello.com/c/AEcOqa1a/3218-fix-api-docs-endpoint-paths
- api docs shows very long endpoint names with base url
- this change moves the endpoint prefix to the base suffix

### Changes proposed in this pull request

- api docs now use shortened endpoint urls
- the prefix is now server url
- add place holder endpoint for un-implemented courses endpoint

### Guidance to review

- setup api docs, see http://localhost:4567/api-reference.html#teacher-training-courses-api
- visit api docs: http://localhost:4567/api-reference.html#teacher-training-courses-api
- compare to https://api2.qa.publish-teacher-training-courses.service.gov.uk/api-reference.html#teacher-training-courses-api
- should no longer see long endpoint names on LHS

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
