### PR TITLE
3033 setup benchmarking performance test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -184,9 +184,9 @@ group :test do
   gem "fakefs", require: "fakefs/safe"
   gem "faker"
   gem "jsonapi-rspec"
+  gem "rspec-benchmark"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.3"
   gem "simplecov", require: false
   gem "webmock"
-  gem "rspec-benchmark"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -188,4 +188,5 @@ group :test do
   gem "shoulda-matchers", "~> 4.3"
   gem "simplecov", require: false
   gem "webmock"
+  gem "rspec-benchmark"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,9 @@ GEM
     audited (4.9.0)
       activerecord (>= 4.2, < 6.1)
     awesome_print (1.8.0)
+    benchmark-malloc (0.2.0)
+    benchmark-perf (0.6.0)
+    benchmark-trend (0.4.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
     brakeman (4.8.0)
@@ -350,6 +353,11 @@ GEM
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
+    rspec-benchmark (0.6.0)
+      benchmark-malloc (~> 0.2)
+      benchmark-perf (~> 0.6)
+      benchmark-trend (~> 0.4)
+      rspec (>= 3.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
     rspec-expectations (3.9.1)
@@ -511,6 +519,7 @@ DEPENDENCIES
   rainbow
   rb-readline
   request_store
+  rspec-benchmark
   rspec-its
   rspec-rails
   rspec_junit_formatter

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -1,0 +1,32 @@
+#Performance Testing
+
+We run a performance regression test on the following endpoints in the Azure staging deploy pipeline.
+
+```
+/api/v3/recruitment_cycles/2020/providers/U80 (threshold 300ms)
+/api/v3/recruitment_cycles/2020/providers/U80/courses/2P3K (threshold 300ms)
+/api/v3/courses (threshold 4750ms)
+```
+
+These tests will warn if performance drops below the preset threshold. This should be reduced as we improve performance.
+
+NB They are not run as part of the normal `rspec` test run and must be run separately.
+
+The tests can also be run locally against a local or deployed environment. By default the tests run against localhost:3001.
+
+```
+bundle exec rspec spec/performance/pre_deploy_spec.rb
+```
+
+To specify an environment set the `CUSTOM_HOST_NAME` environment variable.
+
+```
+CUSTOM_HOST_NAME=https://api2.publish-teacher-training-courses.service.gov.uk bundle exec rspec spec/performance/pre_deploy_spec.rb
+```
+
+## Configuration ENV vars
+
+RECRUITMENT_CYCLE - set to 2020 by default
+PROVIDER_CODE - set to U80 by default
+COURSE_CODE - set to 2P3K by default
+

--- a/spec/performance/pre_deploy_spec.rb
+++ b/spec/performance/pre_deploy_spec.rb
@@ -1,0 +1,38 @@
+require "net/http"
+require "rspec-benchmark"
+
+TEST_SAMPLE_COUNT = 5
+
+RSpec.configure do |config|
+  config.include RSpec::Benchmark::Matchers
+end
+
+def get(path)
+  uri = URI(ENV.fetch("CUSTOM_HOST_NAME", "http://localhost:3001"))
+  uri.path = path
+  Net::HTTP.get(uri)
+end
+
+recruitment_cycle = ENV.fetch("RECRUITMENT_CYCLE", "2020")
+provider_code = ENV.fetch("PROVIDER_CODE", "U80")
+course_code = ENV.fetch("COURSE_CODE", "2P3K")
+
+tests = {
+  "/api/v3/recruitment_cycles/#{recruitment_cycle}/providers/#{provider_code}" => 300,
+  "/api/v3/recruitment_cycles/2020/providers/#{provider_code}/courses/#{course_code}" => 300,
+  "/api/v3/courses" => 4750,
+}
+
+describe "API performance" do
+  before do
+    WebMock.allow_net_connect!
+  end
+
+  tests.each do |url, time_in_ms|
+    it "#{url} responds under #{time_in_ms}ms" do
+      expect {
+        get url
+      }.to perform_under(time_in_ms).ms.sample(TEST_SAMPLE_COUNT).times
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -96,4 +96,7 @@ RSpec.configure do |config|
   config.include ActiveJob::TestHelper, type: :request
 
   ActiveJob::Base.queue_adapter = :test
+
+
+  config.filter_run_excluding type: :performance
 end


### PR DESCRIPTION
### Context

We have performance issues on some endpoints. As part of the work to address this we want to run performance regression tests as part of the staging deploy pipeline. The thresholds in theses tests will be reduced as we improve performance.

The tests are intended to warn (but not block) during deployment. They haven't been added to the pipeline yet as this will need to be merged before they can be added.

### Changes proposed in this pull request

Add spec/performance/pre_deploy_spec.rb that runs multiple requests against specified endpoints and compares their average response against a predefined threshold.

### Guidance to review

The tests can be run locally as per the docs.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
