### PR TITLE
[3033] Remove .rspec file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,0 @@
---require spec_helper

--- a/spec/performance/pre_deploy_spec.rb
+++ b/spec/performance/pre_deploy_spec.rb
@@ -1,5 +1,6 @@
 require "net/http"
 require "rspec-benchmark"
+require "webmock"
 
 TEST_SAMPLE_COUNT = 5
 


### PR DESCRIPTION
### Context

We are running specs against live staging from a docker container which currently won't work without a DB available.

### Changes proposed in this pull request

Remove the .rspec file

This file was requiring spec_helper for all specs. This isn't necessary because:

a) spec_helper is required explicitly in all of the specs anyway
b) rails_helper is being required in some of the files that spec_helper requires so this ends up also requiring rails_helper which loads the app and this isn't what we want (we should fix that too)
c) this stops the pre_deploy_spec being run on a docker container without db access which we want to do.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
