### PR TITLE
[3224] Make v2 course endpoint return courses correctly

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -59,7 +59,7 @@ module API
           authorize @provider, :can_list_courses?
           scope = @provider.courses
         else
-          scope = policy_scope(Course)
+          scope = policy_scope(Course).kept
           scope = scope.with_accredited_bodies(accredited_bodies) if accredited_bodies.present?
         end
         render jsonapi: scope, include: params[:include], class: CourseSerializersService.new.execute

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -60,6 +60,7 @@ module API
           scope = @provider.courses
         else
           scope = policy_scope(Course).kept
+          scope = scope.with_recruitment_cycle(@recruitment_cycle.year)
           scope = scope.with_accredited_bodies(accredited_bodies) if accredited_bodies.present?
         end
         render jsonapi: scope, include: params[:include], class: CourseSerializersService.new.execute

--- a/spec/requests/api/v2/courses_spec.rb
+++ b/spec/requests/api/v2/courses_spec.rb
@@ -20,6 +20,9 @@ describe "Courses API v2", type: :request do
   let(:course3) { create(:course) }
   let(:course4) { create(:course, provider: provider1, accrediting_provider: accredited_body) }
 
+  let(:provider3) { create :provider, :previous_recruitment_cycle, organisations: [organisation] }
+  let(:previous_cycle_course) { create(:course, provider: provider3) }
+
   describe "GET index" do
     subject { perform_request(request_path) }
 
@@ -28,6 +31,7 @@ describe "Courses API v2", type: :request do
       course2
       course3
       course4
+      previous_cycle_course
       get path,
           headers: { "HTTP_AUTHORIZATION" => credentials }
       response
@@ -44,7 +48,7 @@ describe "Courses API v2", type: :request do
 
         expect(response).to have_http_status(:success)
         expect(json_response["data"].count).to eq(3)
-        expect(json_response["data"].pluck("id")).not_to include(course3.id.to_s)
+        expect(json_response["data"].pluck("id")).not_to include(course3.id.to_s, previous_cycle_course.id.to_s)
         expect(json_response["included"].first["type"]).to eq("subjects")
       end
 

--- a/spec/requests/api/v2/courses_spec.rb
+++ b/spec/requests/api/v2/courses_spec.rb
@@ -9,10 +9,6 @@ describe "Courses API v2", type: :request do
     ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
   let(:current_cycle) { find_or_create :recruitment_cycle }
-  let(:next_cycle)    { find_or_create :recruitment_cycle, :next }
-  let(:current_year)  { current_cycle.year.to_i }
-  let(:previous_year) { current_year - 1 }
-  let(:next_year)     { current_year + 1 }
   let(:subjects) { [course_subject_mathematics] }
 
   let(:provider1)       { create :provider, organisations: [organisation] }

--- a/spec/requests/api/v2/courses_spec.rb
+++ b/spec/requests/api/v2/courses_spec.rb
@@ -47,6 +47,18 @@ describe "Courses API v2", type: :request do
         expect(json_response["data"].pluck("id")).not_to include(course3.id.to_s)
         expect(json_response["included"].first["type"]).to eq("subjects")
       end
+
+      context "when a course is discarded" do
+        before do
+          course1.discard!
+        end
+
+        it "doesn't return it" do
+          json_response = JSON.parse subject.body
+
+          expect(json_response["data"].pluck("id")).to match_array([course2.id.to_s, course4.id.to_s])
+        end
+      end
     end
 
     context "request with accrediting_provider filter" do


### PR DESCRIPTION
### Context
The new courses endpoint was returning courses for all recruitment cycles as well as discarded courses. 

### Changes proposed in this pull request
Stop the endpoint doing this, so it behaves like the `provider/:id/courses` endpoint

### Guidance to review

- Checkout this branch and run the server
- Open console in Publish  run `Course.where(recruitment_cycle_year: "2020", accrediting_provider_code: "B20").count` 
- It should return 36 (not 84)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
