### PR TITLE
[3253] - Filter training providers by subject and funding type

### DIFF
--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -6,7 +6,17 @@ module API
 
       def index
         authorize @provider, :can_list_training_providers?
-        providers = @provider.training_providers
+        providers = if params[:filter]
+                      course_scope = Course.where(provider: training_providers)
+
+                      eligible_training_provider_ids = CourseSearchService
+                                                         .call(filter: params[:filter], course_scope: course_scope)
+                                                         .pluck(:provider_id)
+
+                      training_providers.where(id: eligible_training_provider_ids)
+                    else
+                      training_providers
+                    end
 
         render jsonapi: providers, include: params[:include]
       end
@@ -23,6 +33,10 @@ module API
         @provider = @recruitment_cycle.providers.find_by!(
           provider_code: params[:provider_code].upcase,
         )
+      end
+
+      def training_providers
+        @provider.training_providers
       end
     end
   end

--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -16,7 +16,7 @@ module API
                                                          .call(filter: params[:filter], course_scope: course_scope)
                                                          .pluck(:provider_id)
 
-                      training_providers.where(id: eligible_training_provider_ids)
+                      training_providers.where(id: eligible_training_provider_ids).order(:provider_name)
                     else
                       training_providers
                     end

--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -7,7 +7,10 @@ module API
       def index
         authorize @provider, :can_list_training_providers?
         providers = if params[:filter]
-                      course_scope = Course.where(provider: training_providers)
+                      course_scope = Course.where(
+                        provider: training_providers,
+                        accrediting_provider_code: @provider.provider_code,
+                      )
 
                       eligible_training_provider_ids = CourseSearchService
                                                          .call(filter: params[:filter], course_scope: course_scope)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -239,19 +239,21 @@ class Course < ApplicationRecord
     program_types = []
 
     if funding_types.include?("salary")
-      program_types.push :school_direct_salaried_training_programme
+      program_types << :school_direct_salaried_training_programme
     end
 
     if funding_types.include?("apprenticeship")
-      program_types.push :pg_teaching_apprenticeship
+      program_types << :pg_teaching_apprenticeship
     end
 
     if funding_types.include?("fee")
-      program_types.push(
-        :higher_education_programme,
-        :scitt_programme,
-        :school_direct_training_programme,
-      )
+      %i[
+        higher_education_programme
+        scitt_programme
+        school_direct_training_programme
+      ].each do |program_type|
+        program_types << program_type
+      end
     end
 
     where(program_type: program_types)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -250,7 +250,7 @@ class Course < ApplicationRecord
       program_types.push(
         :higher_education_programme,
         :scitt_programme,
-        :school_direct_training_programme
+        :school_direct_training_programme,
       )
     end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -235,6 +235,28 @@ class Course < ApplicationRecord
     where(is_send: true)
   end
 
+  scope :with_funding_types, ->(funding_types) do
+    program_types = []
+
+    if funding_types.include?("salary")
+      program_types.push :school_direct_salaried_training_programme
+    end
+
+    if funding_types.include?("apprenticeship")
+      program_types.push :pg_teaching_apprenticeship
+    end
+
+    if funding_types.include?("fee")
+      program_types.push(
+        :higher_education_programme,
+        :scitt_programme,
+        :school_direct_training_programme
+      )
+    end
+
+    where(program_type: program_types)
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -34,6 +34,7 @@ class CourseSearchService
     scope = scope.with_provider_name(provider_name) if provider_name.present?
     scope = scope.with_send if send_courses_filter?
     scope = scope.within(filter[:radius], origin: origin) if locations_filter?
+    scope = scope.with_funding_types(funding_types) if funding_types.any?
 
     scope.distinct
   end
@@ -124,6 +125,12 @@ private
     return [] if filter[:study_type].blank?
 
     filter[:study_type].split(",")
+  end
+
+  def funding_types
+    return [] if filter[:funding_type].blank?
+
+    filter[:funding_type].split(",")
   end
 
   def subject_codes

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -772,6 +772,60 @@ describe Course, type: :model do
       end
     end
 
+    describe ".with_funding_types" do
+      let(:fee_course_higher_education) { create(:course, :with_higher_education) }
+      let(:fee_course_scitt) { create(:course, :with_scitt) }
+      let(:fee_course_school_direct) { create(:course, :with_school_direct) }
+      let(:salary_course) { create(:course, :with_salary) }
+      let(:apprenticeship_course) { create(:course, :with_apprenticeship) }
+
+      subject { described_class.with_funding_types(funding_types) }
+
+      context "fee courses" do
+        let(:funding_types) { %w[fee] }
+
+        before do
+          fee_course_higher_education
+          fee_course_scitt
+          fee_course_school_direct
+          salary_course
+          apprenticeship_course
+        end
+
+        it "returns fee courses" do
+          expect(subject).to contain_exactly(fee_course_higher_education, fee_course_school_direct, fee_course_scitt)
+        end
+      end
+
+      context "salary" do
+        let(:funding_types) { %w[salary] }
+
+        before do
+          salary_course
+          apprenticeship_course
+          fee_course_higher_education
+        end
+
+        it "returns fee courses" do
+          expect(subject).to contain_exactly(salary_course)
+        end
+      end
+
+      context "apprenticeship" do
+        let(:funding_types) { %w[apprenticeship] }
+
+        before do
+          apprenticeship_course
+          salary_course
+          fee_course_scitt
+        end
+
+        it "returns fee courses" do
+          expect(subject).to contain_exactly(apprenticeship_course)
+        end
+      end
+    end
+
     describe ".with_salary" do
       let(:course_higher_education_programme) do
         create(:course, program_type: :higher_education_programme)

--- a/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
@@ -1,0 +1,202 @@
+require "rails_helper"
+
+describe "AccreditedBody API v2", type: :request do
+  describe "GET /providers" do
+    let(:user) { create(:user, organisations: [organisation]) }
+    let(:organisation) { create(:organisation) }
+    let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+    let(:payload) { { email: user.email } }
+    let(:token) do
+      JWT.encode payload,
+                 Settings.authentication.secret,
+                 Settings.authentication.algorithm
+    end
+    let(:credentials) do
+      ActionController::HttpAuthentication::Token.encode_credentials(token)
+    end
+
+    let(:physical_education) { find_or_create(:secondary_subject, :physical_education) }
+    let(:biology) { find_or_create(:secondary_subject, :biology) }
+
+    let(:unfunded_pe_course) do
+      create(:course,
+             level: :secondary,
+             provider: delivering_provider1,
+             subjects: [physical_education],
+             site_statuses: [build(:site_status, :findable, site: build(:site))],
+             accrediting_provider: accredited_provider)
+    end
+
+    let(:fee_funded_pe_course) do
+      create(:course,
+             level: :secondary,
+             program_type: :school_direct_training_programme,
+             provider: delivering_provider1,
+             subjects: [physical_education],
+             site_statuses: [build(:site_status, :findable, site: build(:site))],
+             accrediting_provider: accredited_provider)
+    end
+
+    let(:non_pe_course) do
+      create(:course,
+             level: :secondary,
+             provider: delivering_provider2,
+             subjects: [biology],
+             site_statuses: [build(:site_status, :findable, site: build(:site))],
+             accrediting_provider: accredited_provider)
+    end
+
+    let(:delivering_provider1) { create(:provider) }
+    let(:delivering_provider2) { create(:provider) }
+    let(:accredited_provider) {
+      create(:provider,
+             organisations: [organisation],
+             recruitment_cycle: recruitment_cycle)
+    }
+
+    let(:json_response) { JSON.parse(response.body) }
+
+    let(:request_path) {
+      "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/#{accredited_provider.provider_code}/training_providers#{filters}"
+    }
+
+    def perform_request
+      get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+    end
+
+    describe "funding type filter" do
+      let(:fee_funded_course) do
+        create(:course,
+               level: :secondary,
+               program_type: :school_direct_training_programme,
+               provider: delivering_provider1,
+               site_statuses: [build(:site_status, :findable, site: build(:site))],
+               accrediting_provider: accredited_provider)
+      end
+
+      context "with providers offering courses that match a single funding type" do
+        let(:filters) { "?filter[funding_type]=fee" }
+
+        before do
+          fee_funded_course
+        end
+
+        it "is returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(1)
+        end
+      end
+
+      context "with providers offering courses that match multiple funding types" do
+        let(:salary_funded_course) do
+          create(:course,
+                 level: :secondary,
+                 program_type: :school_direct_salaried_training_programme,
+                 provider: delivering_provider2,
+                 site_statuses: [build(:site_status, :findable, site: build(:site))],
+                 accrediting_provider: accredited_provider)
+        end
+
+        let(:filters) { "?filter[funding_type]=fee,salary" }
+
+        before do
+          fee_funded_course
+          salary_funded_course
+        end
+
+        it "is returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(2)
+        end
+      end
+
+      context "with providers offering courses that match no funding type" do
+        let(:filters) { "?filter[funding_type]=salary" }
+
+        before do
+          fee_funded_course
+        end
+
+        it "is not returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(0)
+        end
+      end
+    end
+
+    describe "subject type filter" do
+      let(:physical_education) { find_or_create(:secondary_subject, :physical_education) }
+      let(:biology) { find_or_create(:secondary_subject, :biology) }
+
+      let(:pe_course) do
+        create(:course,
+               level: :secondary,
+               provider: delivering_provider1,
+               subjects: [physical_education],
+               site_statuses: [build(:site_status, :findable, site: build(:site))],
+               accrediting_provider: accredited_provider)
+      end
+
+      context "with providers offering courses that match a single subject type" do
+        let(:filters) { "?filter[subjects]=#{physical_education.subject_code}" }
+
+        before do
+          pe_course
+        end
+
+        it "is returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(1)
+        end
+      end
+
+      context "with providers offering courses that match multiple subject" do
+        let(:biology_course) do
+          create(:course,
+                 level: :secondary,
+                 provider: delivering_provider2,
+                 subjects: [biology],
+                 site_statuses: [build(:site_status, :findable, site: build(:site))],
+                 accrediting_provider: accredited_provider)
+        end
+
+        let(:filters) { "?filter[subjects]=#{physical_education.subject_code},#{biology.subject_code}" }
+
+        before do
+          pe_course
+          biology_course
+        end
+
+        it "is returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(2)
+        end
+      end
+
+      context "with providers offering courses that match no subjects" do
+        let(:filters) { "?filter[subjects]=#{biology.subject_code}" }
+
+        before do
+          pe_course
+        end
+
+        it "is not returned" do
+          get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+          json_response = JSON.parse(response.body)
+          provider_hashes = json_response["data"]
+          expect(provider_hashes.count).to eq(0)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
@@ -27,7 +27,7 @@ describe "AccreditedBody API v2", type: :request do
              accrediting_provider: accredited_provider)
     end
 
-    let(:training_provider_1) { create(:provider) }
+    let(:training_provider_1) { create(:provider, provider_name: "ABC Provider") }
 
     let(:accredited_provider) {
       create(:provider,
@@ -40,6 +40,12 @@ describe "AccreditedBody API v2", type: :request do
     let(:request_path) {
       "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/#{accredited_provider.provider_code}/training_providers#{filters}"
     }
+
+    def provider_names_in_response(provider_hashes)
+      provider_hashes.map { |provider|
+        provider["attributes"]["provider_name"]
+      }
+    end
 
     def perform_request
       get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
@@ -71,7 +77,7 @@ describe "AccreditedBody API v2", type: :request do
       end
 
       context "with training providers offering courses that match multiple funding types" do
-        let(:training_provider_2) { create(:provider) }
+        let(:training_provider_2) { create(:provider, provider_name: "BCD Provider") }
 
         let(:salary_funded_course) do
           create(:course,
@@ -94,6 +100,7 @@ describe "AccreditedBody API v2", type: :request do
           json_response = JSON.parse(response.body)
           provider_hashes = json_response["data"]
           expect(provider_hashes.count).to eq(2)
+          expect(provider_names_in_response(provider_hashes)).to eq(["ABC Provider", "BCD Provider"])
         end
       end
 
@@ -142,7 +149,7 @@ describe "AccreditedBody API v2", type: :request do
       end
 
       context "with training providers offering courses that match multiple subject" do
-        let(:training_provider_2) { create(:provider) }
+        let(:training_provider_2) { create(:provider, provider_name: "BCD Provider") }
 
         let(:biology_course) do
           create(:course,
@@ -165,6 +172,7 @@ describe "AccreditedBody API v2", type: :request do
           json_response = JSON.parse(response.body)
           provider_hashes = json_response["data"]
           expect(provider_hashes.count).to eq(2)
+          expect(provider_names_in_response(provider_hashes)).to eq(["ABC Provider", "BCD Provider"])
         end
       end
 

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -237,6 +237,62 @@ describe CourseSearchService do
       end
     end
 
+    describe "filter[funding_type]" do
+      context "when fee" do
+        let(:filter) { { funding_type: "fee" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_funding_types scope" do
+          expect(findable_scope).to receive(:with_funding_types).with(%w(fee)).and_return(distinct_scope)
+          expect(distinct_scope).to receive(:distinct).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when salary" do
+        let(:filter) { { funding_type: "salary" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_funding_types scope" do
+          expect(findable_scope).to receive(:with_funding_types).with(%w(salary)).and_return(distinct_scope)
+          expect(distinct_scope).to receive(:distinct).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when apprenticeship" do
+        let(:filter) { { funding_type: "apprenticeship" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_funding_types scope" do
+          expect(findable_scope).to receive(:with_funding_types).with(%w(apprenticeship)).and_return(distinct_scope)
+          expect(distinct_scope).to receive(:distinct).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when all" do
+        let(:filter) { { funding_type: "fee,salary,apprenticeship" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_funding_types scope" do
+          expect(findable_scope).to receive(:with_funding_types).with(%w(fee salary apprenticeship)).and_return(distinct_scope)
+          expect(distinct_scope).to receive(:distinct).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the scope" do
+          expect(findable_scope).not_to receive(:with_funding_types)
+          expect(findable_scope).to receive(:distinct).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+    end
+
     describe "filter[subjects]" do
       context "a single subject code" do
         let(:filter) { { subjects: "A1" } }


### PR DESCRIPTION
### Context
We want to filter training providers by what kind of courses they provide, for example, list providers that have fee-funded, physical education courses

### Changes proposed in this pull request
Adds `funding_type` and `subject` filters to the accredited body training providers endpoint 

Example request path:

```
      "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/#{accredited_provider.provider_code}/training_providers?filter[funding_type]=fee,salary&[subjects]=C6,A2"

```

### Out of scope
I suggest that _negative filters_ are tackled in another PR. Possibly we may end up handling client side.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
