### PR TITLE
[3246] paginate v2 providers endpoint

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -11,13 +11,19 @@ module API
 
       def index
         authorize Provider
+
         providers = policy_scope(@recruitment_cycle.providers)
                       .include_courses_counts
                       .includes(:recruitment_cycle)
+                      .by_name_ascending
+
         providers = providers.where(id: @user.providers) if @user.present?
 
-        render jsonapi: providers.by_name_ascending,
-               fields: { providers: %i[provider_code provider_name courses
+        render jsonapi: paginate(providers, per_page: 10),
+               meta: { count: providers.count(:provider_code) },
+               fields: { providers: %i[provider_code
+                                       provider_name
+                                       courses
                                        recruitment_cycle_year] }
       end
 

--- a/spec/requests/api/v2/providers/providers_spec.rb
+++ b/spec/requests/api/v2/providers/providers_spec.rb
@@ -41,7 +41,7 @@ describe "Providers API v2", type: :request do
       it { should have_http_status(:unauthorized) }
     end
 
-    describe "JSON generated for a providers" do
+    describe "JSON generated for providers" do
       let(:request_path) { "/api/v2/providers" }
 
       it "has a data section with the correct attributes" do
@@ -65,6 +65,12 @@ describe "Providers API v2", type: :request do
               },
             },
           }],
+          "links" => {
+            "last" => "/api/v2/providers?page%5Bpage%5D=1",
+          },
+          "meta" => {
+            "count" => 1,
+          },
           "jsonapi" => {
             "version" => "1.0",
           },
@@ -95,6 +101,12 @@ describe "Providers API v2", type: :request do
               },
             },
           }],
+          "links" => {
+            "last" => "/api/v2/users/#{user.id}/providers?page%5Bpage%5D=1",
+          },
+          "meta" => {
+            "count" => 1,
+          },
           "jsonapi" => {
             "version" => "1.0",
           },
@@ -111,6 +123,12 @@ describe "Providers API v2", type: :request do
 
         expect(json_response).to eq(
           "data" => [],
+          "links" => {
+            "last" => "/api/v2/users/#{different_user.id}/providers?page%5Bpage%5D=1",
+          },
+          "meta" => {
+            "count" => 0,
+          },
           "jsonapi" => {
             "version" => "1.0",
           },


### PR DESCRIPTION
### Context

- https://trello.com/c/xM3j6Ohd/3246-paginate-providers-in-publish-and-api
- Server side pagination has not been implemented of v2 providers endpoint
- This is consumed by publish and is slow
- We implement server side pagination to improve performance

### Changes proposed in this pull request

- add pagination to v2 providers endpoint
- hard coded to 10 providers per page
- adds meta count to response

### Guidance to review

```
curl -H "Authorization: Bearer bats" "http://localhost:3001/api/v2/recruitment_cycles/2020/providers" | ruby -e "require 'json'; puts JSON.parse(gets)['data'].size"
```

- the above should return 10

```
curl -H "Authorization: Bearer bats" "http://localhost:3001/api/v2/recruitment_cycles/2020/providers?page[page]=1" |  ruby -e "require 'json'; puts JSON.parse(gets)['data']"
```

- should return page 1

```
curl -H "Authorization: Bearer bats" "http://localhost:3001/api/v2/recruitment_cycles/2020/providers?page[page]=2" |  ruby -e "require 'json'; puts JSON.parse(gets)['data']"
```

- should return page 2

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
