### PR TITLE
[3172] Fix dupe site_statuses on course create

### DIFF
--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -19,8 +19,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code with sites" do
   let(:existing_site) { create :site, provider: provider }
 
   before do
-    course.add_site!(site: existing_site)
-    course.add_site!(site: unwanted_site)
+    course.sites = [site_status.site, existing_site, unwanted_site]
   end
 
   let(:sites_payload) {


### PR DESCRIPTION
### Context

- https://trello.com/c/vElWfWcT/3172-prevent-duplicate-site-statuses-being-created-on-course-creation
- duplicate site_statuses were being generated on course creation

### Changes proposed in this pull request

- this would occur for unpersisted records
- as hand creating site_statuses
- then calling super which is default activerecord
- default activerecord creates the join on has_many through
- hence dupe joins
- now the handcrafting only happens for persisted records
- non persisted uses default rails behaviour

### Guidance to review

- checkout branch
- take a note of `SiteStatus.count`
- in publisher create a course
- after creation of course `SiteStatus.count` should increase by the number of sites you selected and not double as it was previously

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
