### PR TITLE
[3290] Vacancies only consider findable courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -202,8 +202,8 @@ class Course < ApplicationRecord
   end
 
   scope :with_recruitment_cycle, ->(year) { joins(provider: :recruitment_cycle).where(recruitment_cycle: { year: year }) }
-  scope :findable, -> { where(id: SiteStatus.findable.select(:course_id)) }
-  scope :with_vacancies, -> { where(id: SiteStatus.with_vacancies.select(:course_id)) }
+  scope :findable, -> { joins(:site_statuses).merge(SiteStatus.findable) }
+  scope :with_vacancies, -> { joins(:site_statuses).merge(SiteStatus.with_vacancies) }
   scope :with_salary, -> { where(program_type: :school_direct_salaried_training_programme) }
   scope :with_study_modes, ->(study_modes) do
     where(study_mode: Array(study_modes) << "full_time_or_part_time")

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -971,6 +971,21 @@ describe Course, type: :model do
         end
       end
     end
+
+    context "::findable && ::with_vacancies" do
+      let(:course_in_scope) { create(:course) }
+      let(:course_not_in_scope) { create(:course) }
+
+      before do
+        create(:site_status, :published, :running, :full_time_vacancies, course: course_in_scope)
+        create(:site_status, :unpublished, :running, :full_time_vacancies, course: course_not_in_scope)
+        create(:site_status, :published, :running, :with_no_vacancies, course: course_not_in_scope)
+      end
+
+      it "scopes are combined with AND and not OR" do
+        expect(described_class.findable.with_vacancies.to_a).to eql([course_in_scope])
+      end
+    end
   end
 
   describe "changed_at" do


### PR DESCRIPTION
### Context

- https://trello.com/c/5CqPh7eV/3290-bug-course-still-showing-on-find-even-though-no-vacancies
- Search would return courses that had no vacancies despite user searching for courses with vacancies

### Changes proposed in this pull request

- When combining scopes #findable and #with_vacancies
- These would be combined with OR instead of AND
- This would introduce bugs where a course could be return that should
not be because it was unfindable with vacancies AND findable with no
vacancies
- This fixes scopes so activerecord can combine these scopes correctly

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
