### PR TITLE
Source 'govuk_tech_docs' gem via RubyGems

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -3,7 +3,7 @@
 source "https://rubygems.org"
 
 # Include the tech docs gem
-gem "govuk_tech_docs", git: "https://github.com/DFE-Digital/tech-docs-gem", branch: "any-of-api-renderer"
+gem "govuk_tech_docs", git: "https://github.com/DFE-Digital/tech-docs-gem"
 
 group :test do
   gem "rspec"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/DFE-Digital/tech-docs-gem
-  revision: 2fbdf0e50644603d22f1a66b798f0c0641c2b90b
-  branch: any-of-api-renderer
+  revision: 73d658e5f60eaae1ea5579b9550d5d3a0c35d070
   specs:
     govuk_tech_docs (2.0.11)
       activesupport
@@ -32,7 +31,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (6.7.7.2)
       execjs
-    backports (3.17.0)
+    backports (3.17.1)
     capybara (3.31.0)
       addressable
       mini_mime (>= 0.1.3)
@@ -156,7 +155,7 @@ GEM
     padrino-support (0.13.3.4)
       activesupport (>= 3.1)
     parallel (1.19.1)
-    pry (0.13.0)
+    pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.3)
@@ -184,10 +183,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    ruby-enum (0.7.2)
+    ruby-enum (0.8.0)
       i18n
     sass (3.4.25)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     servolux (0.13.0)
     sprockets (4.0.0.beta10)
@@ -197,7 +196,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)


### PR DESCRIPTION
### Context
`govuk_tech_docs` gem is pointing to a repository branch, however install of the docs fails. 

### Changes proposed in this pull request
Source `govuk_tech_docs` gem via RubyGems

### Guidance to review
Reinstall as per the docs guidance

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
