### PR TITLE
3277 m add listing to allocations endpoint

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -1,6 +1,12 @@
 module API
   module V2
     class AllocationsController < API::V2::ApplicationController
+      def index
+        authorize Allocation
+
+        render jsonapi: policy_scope(Allocation.where(accredited_body_id: accredited_body.id)), status: :ok
+      end
+
       def create
         authorize @allocation = Allocation.new(allocation_params.merge(accredited_body_id: accredited_body.id))
 

--- a/app/policies/allocation_policy.rb
+++ b/app/policies/allocation_policy.rb
@@ -1,13 +1,35 @@
 class AllocationPolicy
   attr_reader :user, :allocation
 
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      if user.admin?
+        scope.all
+      else
+        scope
+          .where(accredited_body_id: user.providers.pluck(:id))
+      end
+    end
+  end
+
   def initialize(user, allocation);
     @allocation = allocation
     @user = user
   end
 
+  def index?
+    user.present?
+  end
+
   def create?
-    user_belongs_to_the_accredited_body?
+    user.admin? || user_belongs_to_the_accredited_body?
   end
 
 private

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,8 @@
 #                                               api_v2 GET    /api/v2/recruitment_cycles/:recruitment_cycle_year/providers/suggest(.:format)                                                           api/v2/providers#suggest
 #                                 api_v2_organisations GET    /api/v2/organisations(.:format)                                                                                                          api/v2/organisations#index
 #                   api_v2_provider_recruitment_cycles GET    /api/v2/providers/:provider_code/recruitment_cycles(.:format)                                                                            api/v2/recruitment_cycles#index
-#                          api_v2_provider_allocations POST   /api/v2/providers/:provider_code/allocations(.:format)                                                                                   api/v2/allocations#create
+#                          api_v2_provider_allocations GET    /api/v2/providers/:provider_code/allocations(.:format)                                                                                   api/v2/allocations#index
+#                                                      POST   /api/v2/providers/:provider_code/allocations(.:format)                                                                                   api/v2/allocations#create
 #                       publish_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publish(.:format)                                                                         api/v2/courses#publish
 #                   publishable_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/publishable(.:format)                                                                     api/v2/courses#publishable
 #                      withdraw_api_v2_provider_course POST   /api/v2/providers/:provider_code/courses/:code/withdraw(.:format)                                                                        api/v2/courses#withdraw
@@ -157,7 +158,7 @@ Rails.application.routes.draw do
                 param: :code,
                 concerns: :provider_routes do
         resources :recruitment_cycles, only: :index
-        resources :allocations, only: %i[create]
+        resources :allocations, only: %i[create index]
       end
 
       resources :recruitment_cycles,

--- a/spec/policies/allocation_policy_spec.rb
+++ b/spec/policies/allocation_policy_spec.rb
@@ -9,6 +9,17 @@ describe AllocationPolicy do
   let(:training_provider) { create(:provider) }
   let(:allocation) { build(:allocation, accredited_body: accredited_body, provider: training_provider) }
 
+  permissions :index? do
+    context "user is present" do
+      it { is_expected.to permit(user, Allocation) }
+    end
+
+    context "user is not present" do
+      let(:user) { nil }
+      it { is_expected.not_to permit(user, Allocation) }
+    end
+  end
+
   permissions :create? do
     context "a user that belongs to the allocation accredited body" do
       before do
@@ -28,6 +39,34 @@ describe AllocationPolicy do
 
     context "a user doesn't belong to the accredited body or the provider" do
       it { is_expected.not_to permit(user, allocation) }
+    end
+
+    context "an admin" do
+      let(:user) { create(:user, :admin) }
+
+      it { is_expected.to permit(user, allocation) }
+    end
+  end
+
+  describe AllocationPolicy::Scope do
+    let(:allocation) { create(:allocation, accredited_body: accredited_body, provider: training_provider) }
+
+    subject { described_class.new(user, Allocation).resolve }
+
+    context "a user that belongs to the allocation accredited body" do
+      before { organisation.providers << accredited_body }
+
+      it { is_expected.to contain_exactly(allocation) }
+    end
+
+    context "a user that doesn't belong to the allocation accredited body" do
+      it { is_expected.not_to contain_exactly(allocation) }
+    end
+
+    context "an admin" do
+      let(:user) { create(:user, :admin) }
+
+      it { is_expected.to contain_exactly(allocation) }
     end
   end
 end

--- a/spec/requests/api/v2/allocations_spec.rb
+++ b/spec/requests/api/v2/allocations_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
     end
   end
 
+  describe "GET" do
+    it "returns the allocations for the accredited body from the current recruitment cycle" do
+      given_an_accredited_body_exists
+      given_the_accredited_body_has_a_training_provider
+      given_the_accredited_body_has_allocations_for_the_current_recruitment_cycle
+      given_the_accredited_body_has_allocations_from_the_previous_recruitment_cycle
+      given_i_am_an_authenticated_user_from_the_accredited_body
+      when_i_get_the_allocations_index_endpoint
+      then_the_allocations_from_the_current_recruitment_cycle_are_returned
+    end
+  end
+
   def given_an_accredited_body_exists
     @accredited_body = create(:provider, :accredited_body)
   end
@@ -41,6 +53,16 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
     @credentials = ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
+  def given_the_accredited_body_has_allocations_for_the_current_recruitment_cycle
+    @current_allocation = create(:allocation, accredited_body_id: @accredited_body.id, provider_id: @training_provider.id, number_of_places: 10)
+  end
+
+  def given_the_accredited_body_has_allocations_from_the_previous_recruitment_cycle
+    previous_accredited_body = create(:provider, :previous_recruitment_cycle, :accredited_body, provider_code: @accredited_body.provider_code)
+    previous_training_provider = create(:provider, :previous_recruitment_cycle, provider_code: @training_provider.provider_code)
+    @previous_allocation = create(:allocation, accredited_body_id: previous_accredited_body.id, provider_id: previous_training_provider.id, number_of_places: 10)
+  end
+
   def when_valid_parameters_are_posted_to_the_allocations_endpoint
     post "/api/v2/providers/#{@accredited_body.provider_code}/allocations", params: { allocation: { provider_id: @training_provider.id } }, headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
@@ -48,6 +70,10 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
   def when_invalid_parameters_are_posted_to_the_allocations_endpoint
     invalid_provider_id = 0
     post "/api/v2/providers/#{@accredited_body.provider_code}/allocations", params: { allocation: { provider_id: invalid_provider_id } }, headers: { "HTTP_AUTHORIZATION" => @credentials }
+  end
+
+  def when_i_get_the_allocations_index_endpoint
+    get "/api/v2/providers/#{@accredited_body.provider_code}/allocations", headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 
   def then_a_new_allocation_is_returned
@@ -60,5 +86,12 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
     expect(response).to have_http_status(:unprocessable_entity)
     parsed_response = JSON.parse(response.body)
     expect(parsed_response["errors"]).to be_present
+  end
+
+  def then_the_allocations_from_the_current_recruitment_cycle_are_returned
+    expect(response).to have_http_status(:ok)
+    parsed_response = JSON.parse(response.body)
+    expect(parsed_response["data"].count).to eq(1)
+    expect(parsed_response["data"].first["id"]).to eq(@current_allocation.id.to_s)
   end
 end


### PR DESCRIPTION
### Context

Add an endpoint to the allocations API to allow allocations for an accredited body to be retreived.

### Changes proposed in this pull request

Add `GET /api/v2/providers/:accredited_body_code/allocations`
Update the `AllocationPolicy` with a scope and allow admins

### Guidance to review

This is on top of #1321. There is discussion in the description there about the relationship of allocations with the recruitment cycle. This PR carries on relating through the provider ids (which are recruitment cycle specific). I wonder if it would be useful to associate `Allocation` with recruitment cycle directly? 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
