### PR TITLE
[3298] Create allocations

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -4,6 +4,9 @@ module API
       def create
         authorize @allocation = Allocation.new(allocation_params.merge(accredited_body_id: accredited_body.id))
 
+        # hardcoded till back filling of data is implemented
+        @allocation.number_of_places ||= 42
+
         if @allocation.save
           render jsonapi: @allocation, status: :created
         else

--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -1,6 +1,9 @@
 module API
   module V2
     class AllocationsController < API::V2::ApplicationController
+      deserializable_resource :allocation,
+                              class: API::V2::DeserializableAllocation
+
       def create
         authorize @allocation = Allocation.new(allocation_params.merge(accredited_body_id: accredited_body.id))
 

--- a/app/deserializers/api/v2/deserializable_allocation.rb
+++ b/app/deserializers/api/v2/deserializable_allocation.rb
@@ -1,0 +1,8 @@
+module API
+  module V2
+    class DeserializableAllocation < JSONAPI::Deserializable::Resource
+      attributes :provider_id,
+                 :number_of_places
+    end
+  end
+end

--- a/app/policies/allocation_policy.rb
+++ b/app/policies/allocation_policy.rb
@@ -7,7 +7,7 @@ class AllocationPolicy
   end
 
   def create?
-    user_belongs_to_the_accredited_body?
+    user_belongs_to_the_accredited_body? || user.admin?
   end
 
 private

--- a/spec/policies/allocation_policy_spec.rb
+++ b/spec/policies/allocation_policy_spec.rb
@@ -4,6 +4,7 @@ describe AllocationPolicy do
   subject { described_class }
 
   let(:user) { create(:user) }
+  let(:admin) { create(:user, :admin) }
   let(:organisation) { create(:organisation, users: [user]) }
   let(:accredited_body) { create(:provider, :accredited_body) }
   let(:training_provider) { create(:provider) }
@@ -28,6 +29,10 @@ describe AllocationPolicy do
 
     context "a user doesn't belong to the accredited body or the provider" do
       it { is_expected.not_to permit(user, allocation) }
+    end
+
+    context "a user that is an admin" do
+      it { is_expected.to permit(admin, allocation) }
     end
   end
 end

--- a/spec/requests/api/v2/allocations_spec.rb
+++ b/spec/requests/api/v2/allocations_spec.rb
@@ -3,12 +3,24 @@ require "rails_helper"
 RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :request do
   describe "POST" do
     context "with valid parameters" do
-      it "returns 201" do
-        given_an_accredited_body_exists
-        given_the_accredited_body_has_a_training_provider
-        given_i_am_an_authenticated_user_from_the_accredited_body
-        when_valid_parameters_are_posted_to_the_allocations_endpoint
-        then_a_new_allocation_is_returned
+      context "when no number_of_places specified" do
+        it "returns 201" do
+          given_an_accredited_body_exists
+          given_the_accredited_body_has_a_training_provider
+          given_i_am_an_authenticated_user_from_the_accredited_body
+          when_valid_parameters_are_posted_with_unspecified_number_of_places
+          then_a_new_allocation_is_returned_with_backfilled_number_of_places
+        end
+      end
+
+      context "when zero number_of_places specified" do
+        it "returns 201" do
+          given_an_accredited_body_exists
+          given_the_accredited_body_has_a_training_provider
+          given_i_am_an_authenticated_user_from_the_accredited_body
+          when_valid_parameters_are_posted_with_zero_number_of_places
+          then_a_new_allocation_is_returned_with_zero_number_of_places
+        end
       end
     end
 
@@ -41,8 +53,16 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
     @credentials = ActionController::HttpAuthentication::Token.encode_credentials(token)
   end
 
-  def when_valid_parameters_are_posted_to_the_allocations_endpoint
-    post "/api/v2/providers/#{@accredited_body.provider_code}/allocations", params: { allocation: { provider_id: @training_provider.id } }, headers: { "HTTP_AUTHORIZATION" => @credentials }
+  def when_valid_parameters_are_posted_with_unspecified_number_of_places
+    post "/api/v2/providers/#{@accredited_body.provider_code}/allocations",
+         params: { allocation: { provider_id: @training_provider.id } },
+         headers: { "HTTP_AUTHORIZATION" => @credentials }
+  end
+
+  def when_valid_parameters_are_posted_with_zero_number_of_places
+    post "/api/v2/providers/#{@accredited_body.provider_code}/allocations",
+         params: { allocation: { provider_id: @training_provider.id, number_of_places: 0 } },
+         headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 
   def when_invalid_parameters_are_posted_to_the_allocations_endpoint
@@ -50,10 +70,18 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
     post "/api/v2/providers/#{@accredited_body.provider_code}/allocations", params: { allocation: { provider_id: invalid_provider_id } }, headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 
-  def then_a_new_allocation_is_returned
+  def then_a_new_allocation_is_returned_with_backfilled_number_of_places
     expect(response).to have_http_status(:created)
     parsed_response = JSON.parse(response.body)
     expect(parsed_response["data"]["type"]).to eq("allocations")
+    expect(parsed_response["data"]["attributes"]["number_of_places"]).to eq(42)
+  end
+
+  def then_a_new_allocation_is_returned_with_zero_number_of_places
+    expect(response).to have_http_status(:created)
+    parsed_response = JSON.parse(response.body)
+    expect(parsed_response["data"]["type"]).to eq("allocations")
+    expect(parsed_response["data"]["attributes"]["number_of_places"]).to eq(0)
   end
 
   def then_the_allocation_errors_are_returned

--- a/spec/requests/api/v2/allocations_spec.rb
+++ b/spec/requests/api/v2/allocations_spec.rb
@@ -54,14 +54,37 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
   end
 
   def when_valid_parameters_are_posted_with_unspecified_number_of_places
+    params = {
+      "_jsonapi" => {
+        "data" => {
+          "type" => "allocations",
+          "attributes" => {
+            "provider_id" => @training_provider.id.to_s,
+          },
+        },
+      },
+    }
+
     post "/api/v2/providers/#{@accredited_body.provider_code}/allocations",
-         params: { allocation: { provider_id: @training_provider.id } },
+         params: params,
          headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 
   def when_valid_parameters_are_posted_with_zero_number_of_places
+    params = {
+      "_jsonapi" => {
+        "data" => {
+          "type" => "allocations",
+          "attributes" => {
+            "provider_id" => @training_provider.id.to_s,
+            number_of_places: "0",
+          },
+        },
+      },
+    }
+
     post "/api/v2/providers/#{@accredited_body.provider_code}/allocations",
-         params: { allocation: { provider_id: @training_provider.id, number_of_places: 0 } },
+         params: params,
          headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/xZDgo5YV/3298-m-4d-create-allocation-request-action
- Selecting yes/no will now talk to the API and create an allocation
- Allocation will be 42 `number_of_places` if yes
- Allocation will be with 0 `number_of_places` if no

### Changes proposed in this pull request

- admins can create allocations otherwise review apps and QA will not work
- add placeholder backfilling mechanism so flows journey from publish will work by hard coding to 42 `number_of_places`
- add deserialiser to handle json api client requests

### Developer comments

- I foresee bugs occurring as the create endpoint is not idempotent. It is possible for multiple allocations to exist because of this

### Guidance to review

- wire up with publish from this PR https://github.com/DFE-Digital/publish-teacher-training/pull/1037
- go thru yes journey
- should end up with allocation with 42 `number_of_places`
- go thru no journey
- should end up with allocation with 0 `number_of_places`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
