### PR TITLE
[3284] Add QueryNormalizerService 

### DIFF
--- a/app/services/api_service.rb
+++ b/app/services/api_service.rb
@@ -1,0 +1,20 @@
+module ApiService
+  def self.included(base)
+    base.extend ClassMethods
+    base.class_eval do
+      private_class_method :new
+    end
+  end
+
+  def call
+    raise NotImplementedError("#call must be implemented")
+  end
+
+  module ClassMethods
+    def call(**args)
+      return new.call if args.empty?
+
+      new(args).call
+    end
+  end
+end

--- a/app/services/query_normalizer_service.rb
+++ b/app/services/query_normalizer_service.rb
@@ -1,0 +1,17 @@
+class QueryNormalizerService
+  include ApiService
+
+  def initialize(query:)
+    @query = query
+  end
+
+  def call
+    return "" if query.blank?
+
+    CGI.unescape(query).downcase.gsub(/[^0-9a-z]/i, "")
+  end
+
+private
+
+  attr_reader :query
+end

--- a/spec/services/query_normalizer_service_spec.rb
+++ b/spec/services/query_normalizer_service_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe QueryNormalizerService do
+  describe ".call" do
+    subject { described_class.call(query: query) }
+
+    context "query contains spaces" do
+      let(:query) { "boo yah" }
+      it { is_expected.to eq("booyah") }
+    end
+
+    context "query contains upper case characters" do
+      let(:query) { "UpDown" }
+      it { is_expected.to eq("updown") }
+    end
+
+    context "query contains numbers" do
+      let(:query) { "123" }
+      it { is_expected.to eq("123") }
+    end
+
+    context "query contains unicode characters" do
+      let(:query) { "car’s" }
+      it { is_expected.to eq("cars") }
+    end
+
+    context "query contains URL encoded characters" do
+      let(:query) { "cars%20bikes%E2%80%99" }
+      it { is_expected.to eq("carsbikes") }
+    end
+
+    context "query is nil" do
+      let(:query) { nil }
+      it { is_expected.to eq("") }
+    end
+
+    context "query is ''" do
+      let(:query) { "" }
+      it { is_expected.to eq("") }
+    end
+
+    context "query is only special characters" do
+      let(:query) { "%20 ’ " }
+      it { is_expected.to eq("") }
+    end
+  end
+end


### PR DESCRIPTION
### Context

#1310 will be split into three smaller PR and deployed individually. This is the first of three.

Service to handle normalization of query terms for comparison against
normalised data columns. Currently, this is used for the provider
suggestions on the `Provider` model.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
