### PR TITLE
[3256] - Add attributes to the AllocationSerializer

### DIFF
--- a/app/serializers/api/v2/serializable_allocation.rb
+++ b/app/serializers/api/v2/serializable_allocation.rb
@@ -3,6 +3,8 @@ module API
     class SerializableAllocation < JSONAPI::Serializable::Resource
       type "allocations"
       attributes :number_of_places
+      attributes :provider_id
+      attributes :accredited_body_id
 
       belongs_to :accredited_body
       belongs_to :provider

--- a/spec/serializers/api/v2/serializable_allocation_spec.rb
+++ b/spec/serializers/api/v2/serializable_allocation_spec.rb
@@ -36,4 +36,12 @@ describe API::V2::SerializableAllocation do
   it "has a number_of_places attribute" do
     expect(subject.dig(:data, :attributes, :number_of_places)).to eq(10)
   end
+
+  it "has a provider_id attribute" do
+    expect(subject.dig(:data, :attributes, :provider_id)).to eq(allocation.provider.id)
+  end
+
+  it "has an accredited_body_id attribute" do
+    expect(subject.dig(:data, :attributes, :accredited_body_id)).to eq(allocation.accredited_body.id)
+  end
 end


### PR DESCRIPTION
### Context
This is so that we can display allocation statuses on Publish.

Following attributes have been added to `AllocationSerializer`

- provider_id
- accrediting_body_id

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
