### PR TITLE
[3256] - Update AllocationsController#index

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -6,7 +6,9 @@ module API
       def index
         authorize Allocation
 
-        render jsonapi: policy_scope(Allocation.where(accredited_body_id: accredited_body.id)), status: :ok
+        render jsonapi: policy_scope(Allocation.where(accredited_body_id: accredited_body.id)),
+               include: params[:include],
+               status: :ok
       end
 
       def create

--- a/spec/requests/api/v2/allocations_spec.rb
+++ b/spec/requests/api/v2/allocations_spec.rb
@@ -127,7 +127,8 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
   end
 
   def when_i_get_the_allocations_index_endpoint
-    get "/api/v2/providers/#{@accredited_body.provider_code}/allocations", headers: { "HTTP_AUTHORIZATION" => @credentials }
+    get "/api/v2/providers/#{@accredited_body.provider_code}/allocations?include=provider%2Caccredited_body",
+        headers: { "HTTP_AUTHORIZATION" => @credentials }
   end
 
   def then_a_new_allocation_is_returned_with_zero_number_of_places
@@ -145,8 +146,16 @@ RSpec.describe "/api/v2/providers/<accredited_body_code>/allocations", type: :re
 
   def then_the_allocations_from_the_current_recruitment_cycle_are_returned
     expect(response).to have_http_status(:ok)
+
     parsed_response = JSON.parse(response.body)
+
     expect(parsed_response["data"].count).to eq(1)
     expect(parsed_response["data"].first["id"]).to eq(@current_allocation.id.to_s)
+
+    accredited_body_relationship = parsed_response["data"].first["relationships"]["accredited_body"]
+    provider_relationship = parsed_response["data"].first["relationships"]["provider"]
+
+    expect(accredited_body_relationship.count).to eq(1)
+    expect(provider_relationship.count).to eq(1)
   end
 end


### PR DESCRIPTION
### Context
Currently the AllocationsController index action does not return information about an allocation's relationships (provider and training provider).

### Changes proposed in this pull request
- process 'includes' params in order to return provider and accrediting provider relationship info.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
