### PR TITLE
Add pg_search to Provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,8 @@ gem "geokit-rails"
 gem "open_api-rswag-api"
 gem "open_api-rswag-ui"
 
+gem "pg_search"
+
 group :development, :test do
   # add info about db structure to models and other files
   gem "annotate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,9 @@ GEM
     patience_diff (1.1.0)
       trollop (~> 1.16)
     pg (1.2.3)
+    pg_search (2.3.2)
+      activerecord (>= 5.2)
+      activesupport (>= 5.2)
     pkg-config (1.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -515,6 +518,7 @@ DEPENDENCIES
   open_api-rswag-ui
   parallel_tests
   pg
+  pg_search
   pkg-config (~> 1.4.1)
   pry
   pry-byebug

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -171,16 +171,6 @@ describe Provider, type: :model do
     end
   end
 
-  describe ".search_by_code_or_name" do
-    let(:provider1) { create(:provider, provider_name: "Zork") }
-    let(:provider2) { create(:provider, provider_name: "Acme") }
-
-    subject { Provider.search_by_code_or_name("zork") }
-
-    it { should include(provider1) }
-    it { should_not include(provider2) }
-  end
-
   describe "#update_changed_at" do
     let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 
@@ -729,6 +719,48 @@ describe Provider, type: :model do
           it { should be(true) }
         end
       end
+    end
+  end
+
+  describe "#search_by_code_or_name" do
+    let!(:matching_provider) { create(:provider, provider_code: "ABC", provider_name: "Dave's Searches") }
+    let!(:non_matching_provider) { create(:provider) }
+
+    subject { described_class.search_by_code_or_name(search_term) }
+
+    context "with an exactly matching code" do
+      let(:search_term) { "ABC" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with an exactly matching name" do
+      let(:search_term) { "Dave's Searches" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with unicode in the name" do
+      let(:search_term) { "Dave’s Searches" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with extra spaces in the name" do
+      let(:search_term) { "Dave's  Searches" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with non matching case code" do
+      let(:search_term) { "abc" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with non matching case name" do
+      let(:search_term) { "dave's searches" }
+      it { is_expected.to contain_exactly(matching_provider) }
+    end
+
+    context "with partial search term" do
+      let(:search_term) { "dave" }
+      it { is_expected.to contain_exactly(matching_provider) }
     end
   end
 end


### PR DESCRIPTION
### Context

The provider suggestions and search are being confounded by the inclusion of unicode characters, incorrect numbers of spaces etc. This introduces a more effective search that can handle that.

![image](https://user-images.githubusercontent.com/5216/80212895-3e4ce380-8630-11ea-98be-d88d0c149f4f.png)

^ note sexy apostrophe and extra spaces in the search term being correctly matched 🕺 

### Changes proposed in this pull request

* Bundle pg_search gem
* Switch search_by_code_or_name to use a combined scope on
`provider_code` and `provider_name`
 
### Guidance to review

Run find locally against this version of the API. Update a provider that has findable courses to 
have a name including a standard apostrophe. Enter the name but substitute a unicode apostrophe. The provider suggestion should now work.

This will need thorough product review on QA when it is merged as we may alter the expected search results. This introduces some fuzziness and partial-ness (😬) to the search.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
