### PR TITLE
[3216] Remove vnet config from template

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -847,7 +847,7 @@
       "properties": {
         "mode": "Incremental",
         "templateLink": {
-          "uri": "[concat(variables('deploymentUrlBase'), 'container-instance-network-profile-subnet-delg.json')]",
+          "uri": "[concat(variables('deploymentUrlBase'), 'container-instance-network-profile.json')]",
           "contentVersion": "1.0.0.0"
         },
         "parameters": {
@@ -857,14 +857,8 @@
           "vnetName": {
             "value": "[parameters('vnetName')]"
           },
-          "vnetAddressSpaceCIDR": {
-            "value": "[parameters('vnetAddressSpaceCIDR')]"
-          },
           "subnetName": {
             "value": "[parameters('vnetSubnetName')]"
-          },
-          "subnetAddressPrefix": {
-            "value": "[parameters('vnetSubnetAddressPrefix')]"
           },
           "resourceTags":{
             "value": "[parameters('resourceTags')]"


### PR DESCRIPTION
### Context
When we deploy, the route table added by CIP is removed. It is required to use the Internet Access Service (IAS). This is because our Azure template also configures vnet and subnet, but without route table.

### Changes proposed in this pull request
Use a simpler network template which does not try to recreate the network config, but only references the existing.

### Guidance to review
It was deployed here: https://dev.azure.com/dfe-ssp/Become-A-Teacher/_releaseProgress?_a=release-environment-logs&releaseId=5843&environmentId=23304
And the route table has not been removed: https://portal.azure.com/#@platform.education.gov.uk/resource/subscriptions/f013afaf-9685-4a48-91ae-155e77aa42fc/resourceGroups/s121d01-core/providers/Microsoft.Network/virtualNetworks/s121d01-core-vn-01/subnets

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
