### PR TITLE
[3318] - V2 API User Notifications index endpoint

### DIFF
--- a/app/controllers/api/v2/notifications_controller.rb
+++ b/app/controllers/api/v2/notifications_controller.rb
@@ -3,6 +3,15 @@ module API
     class NotificationsController < API::V2::ApplicationController
       deserializable_resource :user_notification,
                               class: API::V2::DeserializableNotification
+
+      def index
+        authorize @notifications = @current_user.user_notifications
+
+        render jsonapi: @notifications,
+               include: JSONAPI::IncludeDirective.new(params[:include]).to_hash,
+               status: :ok
+      end
+
       def create
         @current_user.providers.accredited_body.map do |provider|
           authorize @notification = @current_user.user_notifications.find_or_initialize(provider.provider_code)

--- a/app/policies/user_notification_policy.rb
+++ b/app/policies/user_notification_policy.rb
@@ -24,6 +24,10 @@ class UserNotificationPolicy
     @user_notification = user_notification
   end
 
+  def index?
+    user.present?
+  end
+
   def create?
     user_is_admin_or_belongs_to_accredited_body?
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@
 #                                     api_v1_providers GET    /api/v1(/:recruitment_year)/providers(.:format)                                                                                          api/v1/providers#index {:recruitment_year=>/2020|2021/}
 #                                      api_v1_subjects GET    /api/v1(/:recruitment_year)/subjects(.:format)                                                                                           api/v1/subjects#index {:recruitment_year=>/2020|2021/}
 #                                       api_v1_courses GET    /api/v1(/:recruitment_year)/courses(.:format)                                                                                            api/v1/courses#index {:recruitment_year=>/2020|2021/}
-#                            api_v2_user_notifications POST   /api/v2/users/:user_id/notifications(.:format)                                                                                           api/v2/notifications#create
+#                            api_v2_user_notifications GET    /api/v2/users/:user_id/notifications(.:format)                                                                                           api/v2/notifications#index
+#                                                      POST   /api/v2/users/:user_id/notifications(.:format)                                                                                           api/v2/notifications#create
 #                                api_v2_user_providers GET    /api/v2/users/:user_id/providers(.:format)                                                                                               api/v2/providers#index
 #                                                      POST   /api/v2/users/:user_id/providers(.:format)                                                                                               api/v2/providers#create
 #                                 api_v2_user_provider GET    /api/v2/users/:user_id/providers/:id(.:format)                                                                                           api/v2/providers#show
@@ -134,7 +135,7 @@ Rails.application.routes.draw do
 
     namespace :v2 do
       resources :users, only: %i[update show] do
-        resources :notifications, only: %i[create]
+        resources :notifications, only: %i[create index]
         resources :providers
 
         patch :accept_transition_screen, on: :member

--- a/spec/policies/user_notification_policy_spec.rb
+++ b/spec/policies/user_notification_policy_spec.rb
@@ -9,6 +9,17 @@ describe UserNotificationPolicy do
   let(:accredited_body) { create(:provider, :accredited_body) }
   let(:notification) { build(:user_notification, user: user, provider: accredited_body) }
 
+  permissions :index? do
+    context "user is present" do
+      it { is_expected.to permit(user, UserNotification) }
+    end
+
+    context "user is not present" do
+      let(:user) { nil }
+      it { is_expected.not_to permit(user, UserNotification) }
+    end
+  end
+
   permissions :create? do
     context "a user that belongs to the notification accredited body" do
       before do


### PR DESCRIPTION
### Context
In order to allow users to opt in and opt out of receiving course update notifications we need to add some new end points to V2.

### Changes proposed in this pull request
- Adds index endpoint for user notifications

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
