### PR TITLE
Fix flakey organisation spec

### DIFF
--- a/spec/requests/api/v2/organisations_spec.rb
+++ b/spec/requests/api/v2/organisations_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe "Organisations API v2", type: :request do
-  describe "GET /organistaions" do
+  describe "GET /organisations" do
     let(:current_recruitment_cycle) { find_or_create(:recruitment_cycle) }
     let(:next_recruitment_cycle) { find_or_create(:recruitment_cycle, :next) }
     let(:user) { create(:user, :admin, organisations: [organisation]) }
@@ -68,53 +68,12 @@ describe "Organisations API v2", type: :request do
           perform_request
         end
 
-        it "has a JSON data section with the correct attributes" do
-          expect(json_response).to eq(
-            "data" =>
-                [{
-                  "id" => organisation.id.to_s,
-                  "type" => "organisations",
-                  "attributes" => {
-                    "name" => organisation.name,
-                    "nctl_ids" => organisation.nctl_organisations.map(&:nctl_id),
-                  },
-                  "relationships" => {
-                    "users" => {
-                      "meta" => {
-                        "included" => false,
-                        },
-                      },
-                    "providers" => {
-                      "meta" => {
-                        "included" => false,
-                       },
-                     },
-                    },
-                  },
-                 {
-                   "id" => organisation2.id.to_s,
-                   "type" => "organisations",
-                   "attributes" => {
-                     "name" => organisation2.name,
-                     "nctl_ids" => organisation2.nctl_organisations.map(&:nctl_id),
-                   },
-                 "relationships" => {
-                   "users" => {
-                     "meta" => {
-                       "included" => false,
-                       },
-                     },
-                     "providers" => {
-                       "meta" => {
-                         "included" => false,
-                       },
-                     },
-                   },
-                 }],
-                "jsonapi" => {
-                  "version" => "1.0",
-                },
-              )
+        it "returns the organisations" do
+          organisations = json_response["data"]
+
+          expect(organisations.count).to eq(2)
+          expect(organisations.first["id"]).to eq(organisation.id.to_s)
+          expect(organisations.second["id"]).to eq(organisation2.id.to_s)
         end
       end
 

--- a/spec/serializers/api/v2/serializable_organisation_spec.rb
+++ b/spec/serializers/api/v2/serializable_organisation_spec.rb
@@ -11,7 +11,15 @@ describe API::V2::SerializableOrganisation do
 
   subject { JSON.parse(resource.as_jsonapi.to_json) }
 
-  it { should have_type "organisations" }
-  it { should have_attribute(:name).with_value(organisation.name.to_s) }
-  it { should have_attribute(:nctl_ids).with_value([nctl_organisation.nctl_id]) }
+  it { is_expected.to have_type "organisations" }
+  it { is_expected.to have_attribute(:name).with_value(organisation.name.to_s) }
+  it { is_expected.to have_attribute(:nctl_ids).with_value([nctl_organisation.nctl_id]) }
+
+  it "has users" do
+    expect(subject.dig("relationships", "users")).to be_present
+  end
+
+  it "has providers" do
+    expect(subject.dig("relationships", "providers")).to be_present
+  end
 end


### PR DESCRIPTION
### Context

This spec fails quite regularly as the ordering is flakey within the
JSON. We have moved to not testing the entire JSON response in request
specs as this should be well covered in the serializer specs so removing
that here should make the tests more reliable.

### Changes proposed in this pull request

Don't test the whole JSON response in the v2 organisation request spec.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
