### PR TITLE
3308 Refactor training provider search

### DIFF
--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -22,8 +22,8 @@ describe "AccreditedBody API v2", type: :request do
       create(:course, provider: delivering_provider2, accrediting_provider: accredited_provider)
     end
 
-    let(:delivering_provider1) { create(:provider) }
-    let(:delivering_provider2) { create(:provider) }
+    let(:delivering_provider1) { create(:provider, provider_name: "a") }
+    let(:delivering_provider2) { create(:provider, provider_name: "b") }
     let(:accredited_provider) {
       create(:provider,
              organisations: [organisation],


### PR DESCRIPTION
### Context

- https://trello.com/c/XSJooptJ/3308-m-6a-api-add-negated-subject-filtering-support-to-providers-endpoint
- Original PR name `3308 negate subject provider search`
- ~~Enables searching of training providers that do not offer specified subjects~~
- The original task is no longer required and this PR only contains a refactor

### Changes proposed in this pull request

- Refactor `AccreditedProviderTrainingProvidersController` with internal service class
- Results now ordered by `provider_name`

### Guidance to review

- only change is now results are always sorted `provider_name`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
