### PR TITLE
[3243] Add terraform StatusCake alert directory 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,6 +146,7 @@ steps:
   inputs:
     Contents: |
      azure/**
+     terraform/**
     TargetFolder: '$(build.artifactstagingdirectory)'
     OverWrite: true
 - task: PublishBuildArtifacts@1

--- a/terraform/backend.tf
+++ b/terraform/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "azurerm" {
+    container_name       = "tfstatestr"
+  }
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,0 +1,4 @@
+provider statuscake {
+  username = var.sc_username
+  apikey   = var.sc_api_key
+}

--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -1,0 +1,12 @@
+resource statuscake_test alert {
+  for_each =  var.alerts
+    
+  website_name  = each.value.website_name
+  website_url   = each.value.website_url
+  test_type     = each.value.test_type
+  check_rate    = each.value.check_rate
+  contact_group = each.value.contact_group
+  trigger_rate  = each.value.trigger_rate
+  custom_header = each.value.custom_header
+  status_codes  = each.value.status_codes
+}

--- a/terraform/terraform_prod.tfvars
+++ b/terraform/terraform_prod.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+ttapi = {
+    website_name = "prod-teacher-training-api"
+    website_url   = "https://api2.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    test_type     = "HTTP"
+    check_rate    = 300
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/terraform_qa.tfvars
+++ b/terraform/terraform_qa.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+ttapi = {
+    website_name = "qa-teacher-training-api"
+    website_url   = "https://api2.qa.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    test_type     = "HTTP"
+    check_rate    = 300
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/terraform_staging.tfvars
+++ b/terraform/terraform_staging.tfvars
@@ -1,0 +1,12 @@
+alerts =  {
+ttapi = {
+    website_name = "staging-teacher-training-api"
+    website_url   = "https://api2.staging.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    test_type     = "HTTP"
+    check_rate    = 300
+    contact_group = [151103]
+    trigger_rate  = 0
+    custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"
+    status_codes  = "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, 408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, 504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, 598, 599"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,5 @@
+variable "sc_username" {}
+variable "sc_api_key" {}
+variable "alerts" {
+  type = "map"
+}


### PR DESCRIPTION
### Context

Emit an alert from health-check endpoints on any of the services going down.

### Changes proposed in this pull request

Add terraform StatusCake alerts directory to the repo.

### Guidance to review

Example: https://dfe-ssp.visualstudio.com/Become-A-Teacher/_releaseProgress?_a=release-environment-logs&releaseId=6121&environmentId=25474

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
