### PR TITLE
[3234] Expose `provider_id` in v2 Allocation

### DIFF
--- a/app/serializers/api/v2/serializable_allocation.rb
+++ b/app/serializers/api/v2/serializable_allocation.rb
@@ -2,7 +2,7 @@ module API
   module V2
     class SerializableAllocation < JSONAPI::Serializable::Resource
       type "allocations"
-      attributes :number_of_places, :request_type
+      attributes :number_of_places, :request_type, :provider_id
 
       belongs_to :accredited_body
       belongs_to :provider

--- a/spec/serializers/api/v2/serializable_allocation_spec.rb
+++ b/spec/serializers/api/v2/serializable_allocation_spec.rb
@@ -40,4 +40,8 @@ describe API::V2::SerializableAllocation do
   it "has a request_type attribute" do
     expect(subject.dig(:data, :attributes, :request_type)).to eq("initial")
   end
+
+  it "has a provider_id attribute" do
+    expect(subject.dig(:data, :attributes, :provider_id)).to eq(provider.id)
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/DsJjDa09/3234-s-6b-pick-a-provider-page-searching-for-an-organisation-that-i-dont-already-accredit-no-js-autofill

### Changes proposed in this pull request

- So clients can marry up allocations with their training providers

### Guidance to review

- create an allocation
- hit endpoint to grab all allocations
- json should include correct `provider_id`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
