### PR TITLE
[3364] User getting 403 errors when viewing their training providers on the courses as an accredited body page

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -55,14 +55,12 @@ module API
 
       def index
         authorize Course
-        if @provider.present?
-          authorize @provider, :can_list_courses?
-          scope = @provider.courses
-        else
-          scope = policy_scope(Course).kept
-          scope = scope.with_recruitment_cycle(@recruitment_cycle.year)
-          scope = scope.with_accredited_bodies(accredited_bodies) if accredited_bodies.present?
-        end
+
+        scope = policy_scope(Course).kept
+        scope = scope.where(provider_id: @provider.id) if @provider.present?
+        scope = scope.with_recruitment_cycle(@recruitment_cycle.year)
+        scope = scope.with_accredited_bodies(accredited_bodies) if accredited_bodies.present?
+
         render jsonapi: scope, include: params[:include], class: CourseSerializersService.new.execute
       end
 

--- a/app/controllers/api/v2/sites_controller.rb
+++ b/app/controllers/api/v2/sites_controller.rb
@@ -10,7 +10,7 @@ module API
       before_action :build_site, except: %i[index create]
 
       def index
-        authorize @provider, :can_list_courses?
+        authorize @provider, :can_list_sites?
         authorize Site
 
         render jsonapi: @provider.sites

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -39,7 +39,6 @@ class ProviderPolicy
     user.present?
   end
 
-  alias_method :can_list_courses?, :show?
   alias_method :can_list_sites?, :show?
   alias_method :can_create_course?, :show?
   alias_method :update?, :show?

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -634,18 +634,6 @@ describe "Courses API v2", type: :request do
       it { should have_http_status(:unauthorized) }
     end
 
-    context "when unauthorised" do
-      let(:unauthorised_user) { create(:user) }
-      let(:payload) { { email: unauthorised_user.email } }
-
-      it "raises an error" do
-        expect {
-          get "/api/v2/providers/#{provider.provider_code}/courses",
-              headers: { "HTTP_AUTHORIZATION" => credentials }
-        }.to raise_error Pundit::NotAuthorizedError
-      end
-    end
-
     def perform_request
       findable_open_course
       get request_path,
@@ -700,7 +688,7 @@ describe "Courses API v2", type: :request do
               "about_accrediting_body" => nil,
               "english" => "must_have_qualification_at_application_time",
               "maths" => "must_have_qualification_at_application_time",
-                "science" => "must_have_qualification_at_application_time",
+              "science" => "must_have_qualification_at_application_time",
               "provider_code" => provider.provider_code,
               "recruitment_cycle_year" => current_year.to_s,
               "gcse_subjects_required" => %w[maths english science],


### PR DESCRIPTION
### Context

When an accredited body user tries to list courses for a provider that they are not directly associated with but that does deliver courses on behalf of the accredited body they are getting a 403 response in publish.

Publish currently calls the `ProvidersController#show` endpoint and includes the courses and the `ProviderPolicy#show?` policy does not allow this. Updating that policy will have undesirable side effects and will require complex coupling of with `Course`. So, we're going to switch `Publish` to use the `CourseController#index` endpoint to retrieve these courses. Unfortunately that also uses the `ProviderPolicy#show?` (via an alias) when the courses are scoped by provider. It also disregards any other filter params in that case.

### Changes proposed in this pull request

* Don't use `ProviderPolicy` in the `CoursesController#index`
* Rely on the `CoursePolicy::Scope` to restrict access appropriately
* Remove the `can_list_courses?` policy from `ProviderPolicy'

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
