### PR TITLE
[3338] Added basic top level course stats

### DIFF
--- a/app/controllers/reporting_controller.rb
+++ b/app/controllers/reporting_controller.rb
@@ -1,52 +1,13 @@
 class ReportingController < ActionController::API
   before_action :build_recruitment_cycle
-  before_action :build_courses
 
   def reporting
-    status = :ok
+    course_stats = CourseReportingService.call(courses_scope: @recruitment_cycle.courses)
 
-    render status: status, json: course_stats
+    render status: :ok, json: course_stats
   end
 
 private
-
-  def course_stats
-    {
-      total: {
-        all: @courses.count,
-        non_findable: @courses.count - @findable_courses.count,
-        all_findable: @findable_courses.count,
-      },
-      findable_total: {
-        open: @open_courses.count,
-        closed: @closed_courses.count,
-      },
-      provider_type: { **group_by_count(:provider_type) },
-      program_type: { **group_by_count(:program_type) },
-
-      study_mode: { **group_by_count(:study_mode) },
-      qualification: { **group_by_count(:qualification) },
-      is_send: { **group_by_count(:is_send) },
-    }
-  end
-
-  def group_by_count(column)
-    open = @open_courses.group(column).count
-
-    closed = @closed_courses.group(column).count
-
-    {
-      open: column == :provider_type ? open.transform_keys { |key| Provider.provider_types.key(key || "") } : open,
-      closed: column == :provider_type ? closed.transform_keys { |key| Provider.provider_types.key(key || "") } : closed,
-    }
-  end
-
-  def build_courses
-    @courses = @recruitment_cycle.courses
-    @findable_courses = @courses.findable.distinct
-    @open_courses = @findable_courses.with_vacancies
-    @closed_courses = @findable_courses.where.not id: @open_courses
-  end
 
   def build_recruitment_cycle
     @recruitment_cycle = RecruitmentCycle.find_by(

--- a/app/controllers/reporting_controller.rb
+++ b/app/controllers/reporting_controller.rb
@@ -1,0 +1,56 @@
+class ReportingController < ActionController::API
+  before_action :build_recruitment_cycle
+  before_action :build_courses
+
+  def reporting
+    status = :ok
+
+    render status: status, json: course_stats
+  end
+
+private
+
+  def course_stats
+    {
+      total: {
+        all: @courses.count,
+        non_findable: @courses.count - @findable_courses.count,
+        all_findable: @findable_courses.count,
+      },
+      findable_total: {
+        open: @open_courses.count,
+        closed: @closed_courses.count,
+      },
+      provider_type: { **group_by_count(:provider_type) },
+      program_type: { **group_by_count(:program_type) },
+
+      study_mode: { **group_by_count(:study_mode) },
+      qualification: { **group_by_count(:qualification) },
+      is_send: { **group_by_count(:is_send) },
+    }
+  end
+
+  def group_by_count(column)
+    open = @open_courses.group(column).count
+
+    closed = @closed_courses.group(column).count
+
+    {
+      open: column == :provider_type ? open.transform_keys { |key| Provider.provider_types.key(key || "") } : open,
+      closed: column == :provider_type ? closed.transform_keys { |key| Provider.provider_types.key(key || "") } : closed,
+    }
+  end
+
+  def build_courses
+    @courses = @recruitment_cycle.courses
+    @findable_courses = @courses.findable.distinct
+    @open_courses = @findable_courses.with_vacancies
+    @closed_courses = @findable_courses.where.not id: @open_courses
+  end
+
+  def build_recruitment_cycle
+    @recruitment_cycle = RecruitmentCycle.find_by(
+      year: params[:recruitment_cycle_year],
+    ) || RecruitmentCycle.current_recruitment_cycle
+  end
+end

--- a/app/services/course_reporting_service.rb
+++ b/app/services/course_reporting_service.rb
@@ -29,12 +29,24 @@ class CourseReportingService
       study_mode: { **group_by_count(:study_mode) },
       qualification: { **group_by_count(:qualification) },
       is_send: { **group_by_count(:is_send) },
+
+      subject: { **group_by_subject_count },
     }
   end
 
   private_class_method :new
 
 private
+
+  def group_by_subject_count
+    open = CourseSubject.where(course_id: @open_courses).group(:subject_id).count
+    closed = CourseSubject.where(course_id: @closed_courses).group(:subject_id).count
+
+    {
+      open: Subject.active.map { |sub| x = {}; x[sub.subject_name] = open[sub.id] || 0; x }.reduce({}, :merge),
+      closed: Subject.active.map { |sub| x = {}; x[sub.subject_name] = closed[sub.id] || 0; x }.reduce({}, :merge),
+    }
+  end
 
   def group_by_count(column)
     open = @open_courses.group(column).count

--- a/app/services/course_reporting_service.rb
+++ b/app/services/course_reporting_service.rb
@@ -1,0 +1,61 @@
+class CourseReportingService
+  def initialize(courses_scope: Course)
+    @courses = courses_scope.distinct
+    @findable_courses = @courses.findable
+    @open_courses = @findable_courses.with_vacancies
+    @closed_courses = @findable_courses.where.not(id: @open_courses)
+  end
+
+  class << self
+    def call(courses_scope:)
+      new(courses_scope: courses_scope).call
+    end
+  end
+
+  def call
+    {
+      total: {
+        all: @courses.count,
+        non_findable: @courses.count - @findable_courses.count,
+        all_findable: @findable_courses.count,
+      },
+      findable_total: {
+        open: @open_courses.count,
+        closed: @closed_courses.count,
+      },
+      provider_type: { **group_by_count(:provider_type) },
+      program_type: { **group_by_count(:program_type) },
+
+      study_mode: { **group_by_count(:study_mode) },
+      qualification: { **group_by_count(:qualification) },
+      is_send: { **group_by_count(:is_send) },
+    }
+  end
+
+  private_class_method :new
+
+private
+
+  def group_by_count(column)
+    open = @open_courses.group(column).count
+    closed = @closed_courses.group(column).count
+
+    case column
+    when :provider_type
+      {
+        open: Provider.provider_types.map { |key, value| x = {}; x[key.to_sym] = open[value] || 0; x }.reduce({}, :merge),
+        closed: Provider.provider_types.map { |key, value| x = {}; x[key.to_sym] = closed[value] || 0; x }.reduce({}, :merge),
+      }
+    when :program_type, :study_mode, :qualification
+      {
+        open: Course.send(column.to_s.pluralize).map { |key, _value| x = {}; x[key.to_sym] = open[key] || 0; x }.reduce({}, :merge),
+        closed: Course.send(column.to_s.pluralize).map { |key, _value| x = {}; x[key.to_sym] = closed[key] || 0; x }.reduce({}, :merge),
+      }
+    when :is_send
+      {
+        open: { yes: open[true] || 0, no: open[false] || 0 },
+        closed: { yes: closed[true] || 0, no: closed[false] || 0 },
+      }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@
 #                                               Prefix Verb   URI Pattern                                                                                                                              Controller#Action
 #                                                 ping GET    /ping(.:format)                                                                                                                          heartbeat#ping
 #                                          healthcheck GET    /healthcheck(.:format)                                                                                                                   heartbeat#healthcheck
+#                                            reporting GET    /reporting(.:format)                                                                                                                     reporting#reporting
 #                                    open_api_rswag_ui        /api-docs                                                                                                                                OpenApi::Rswag::Ui::Engine
 #                                   open_api_rswag_api        /api-docs                                                                                                                                OpenApi::Rswag::Api::Engine
 #                                     api_v1_providers GET    /api/v1(/:recruitment_year)/providers(.:format)                                                                                          api/v1/providers#index {:recruitment_year=>/2020|2021/}
@@ -122,6 +123,7 @@
 Rails.application.routes.draw do
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
+  get :reporting, controller: :reporting
 
   mount OpenApi::Rswag::Ui::Engine => "/api-docs"
   mount OpenApi::Rswag::Api::Engine => "/api-docs"

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -48,6 +48,10 @@ describe "GET /reporting" do
         open: { yes: 0, no: 0 },
         closed:  { yes: 0, no: 0 },
       },
+      subject: {
+        open: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
+        closed: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
+      },
     }.with_indifferent_access
   end
 

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -1,8 +1,59 @@
 require "rails_helper"
 
 describe "GET /reporting" do
+  let(:expected) do
+    {
+      total: {
+        all: 0,
+        non_findable: 0,
+        all_findable: 0,
+      },
+      findable_total: {
+        open: 0,
+        closed: 0,
+      },
+      provider_type: {
+        open: {
+          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        },
+        closed: {
+          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        },
+      },
+      program_type: {
+        open: {
+          higher_education_programme: 0, school_direct_training_programme: 0,
+          school_direct_salaried_training_programme: 0, scitt_programme: 0,
+          pg_teaching_apprenticeship: 0
+        },
+        closed: {
+          higher_education_programme: 0, school_direct_training_programme: 0,
+          school_direct_salaried_training_programme: 0, scitt_programme: 0,
+          pg_teaching_apprenticeship: 0
+        },
+      },
+      study_mode: {
+        open: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
+        closed: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
+      },
+      qualification: {
+        open: {
+          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+        },
+        closed: {
+          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+        },
+      },
+      is_send: {
+        open: { yes: 0, no: 0 },
+        closed:  { yes: 0, no: 0 },
+      },
+    }.with_indifferent_access
+  end
+
   it "returns status success" do
     get "/reporting"
     expect(response.status).to eq(200)
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+describe "GET /reporting" do
+  it "returns status success" do
+    get "/reporting"
+    expect(response.status).to eq(200)
+  end
+end

--- a/spec/services/course_reporting_service_spec.rb
+++ b/spec/services/course_reporting_service_spec.rb
@@ -1,0 +1,146 @@
+require "rails_helper"
+
+describe CourseReportingService do
+  let(:closed_courses_scope) { class_double(Course) }
+  let(:closed_courses_provider_type_scope) { class_double(Course) }
+  let(:closed_courses_program_type_scope) { class_double(Course) }
+  let(:closed_courses_study_mode_scope) { class_double(Course) }
+  let(:closed_courses_qualification_scope) { class_double(Course) }
+  let(:closed_courses_is_send_scope) { class_double(Course) }
+
+  let(:courses_scope) { class_double(Course) }
+  let(:findable_courses_scope) { class_double(Course) }
+
+  let(:open_courses_scope) { class_double(Course) }
+  let(:open_courses_provider_type_scope) { class_double(Course) }
+  let(:open_courses_program_type_scope) { class_double(Course) }
+  let(:open_courses_study_mode_scope) { class_double(Course) }
+  let(:open_courses_qualification_scope) { class_double(Course) }
+  let(:open_courses_is_send_scope) { class_double(Course) }
+
+  let(:distinct_courses_scope) { class_double(Course) }
+
+  let(:courses_count) { 100 }
+  let(:findable_courses_count) { 60 }
+  let(:open_courses_count) { 40 }
+  let(:closed_courses_count) { 20 }
+
+  let(:expected) do
+    {
+      total: {
+        all: courses_count,
+        non_findable: courses_count - findable_courses_count,
+        all_findable: findable_courses_count,
+      },
+      findable_total: {
+        open: open_courses_count,
+        closed: closed_courses_count,
+      },
+      provider_type: {
+        open: {
+          scitt: 1, lead_school: 2, university: 3, unknown: 4, invalid_value: 5
+        },
+        closed: {
+          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        },
+      },
+      program_type: {
+        open: {
+          higher_education_programme: 1, school_direct_training_programme: 2,
+          school_direct_salaried_training_programme: 3, scitt_programme: 4,
+          pg_teaching_apprenticeship: 5
+        },
+        closed: {
+          higher_education_programme: 0, school_direct_training_programme: 0,
+          school_direct_salaried_training_programme: 0, scitt_programme: 0,
+          pg_teaching_apprenticeship: 0
+        },
+      },
+      study_mode: {
+        open: { full_time: 1, part_time: 2, full_time_or_part_time: 3 },
+        closed: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
+      },
+      qualification: {
+        open: {
+          qts: 1, pgce_with_qts: 2, pgde_with_qts: 3, pgce: 4, pgde: 5
+        },
+        closed: {
+          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+        },
+      },
+      is_send: {
+        open: { yes: 1, no: 2 },
+        closed:  { yes: 0, no: 0 },
+      },
+    }
+  end
+
+  describe ".call" do
+    describe "when scope is passed" do
+      subject { described_class.call(courses_scope: courses_scope) }
+
+      it "applies the scopes" do
+        expect(courses_scope).to receive_message_chain(:distinct).and_return(distinct_courses_scope)
+        expect(distinct_courses_scope).to receive_message_chain(:count).and_return(courses_count)
+        expect(distinct_courses_scope).to receive_message_chain(:count).and_return(courses_count)
+        expect(distinct_courses_scope).to receive_message_chain(:findable).and_return(findable_courses_scope)
+
+        expect(findable_courses_scope).to receive_message_chain(:with_vacancies).and_return(open_courses_scope)
+        expect(findable_courses_scope).to receive_message_chain(:where, :not).and_return(closed_courses_scope)
+
+        expect(findable_courses_scope).to receive_message_chain(:count).and_return(findable_courses_count)
+        expect(findable_courses_scope).to receive_message_chain(:count).and_return(findable_courses_count)
+        expect(open_courses_scope).to receive_message_chain(:count).and_return(open_courses_count)
+
+        expect(open_courses_scope).to receive_message_chain(:group).with(:provider_type).and_return(open_courses_provider_type_scope)
+        expect(open_courses_provider_type_scope).to receive_message_chain(:count)
+          .and_return(
+            { "B" => 1, "Y" => 2, "O" => 3, "" => 4, "0" => 5 },
+          )
+
+        expect(open_courses_scope).to receive_message_chain(:group).with(:program_type).and_return(open_courses_program_type_scope)
+        expect(open_courses_program_type_scope).to receive_message_chain(:count)
+          .and_return(
+            { "higher_education_programme" => 1, "school_direct_training_programme" => 2,
+            "school_direct_salaried_training_programme" => 3, "scitt_programme" => 4,
+            "pg_teaching_apprenticeship" => 5 },
+          )
+
+        expect(open_courses_scope).to receive_message_chain(:group).with(:study_mode).and_return(open_courses_study_mode_scope)
+        expect(open_courses_study_mode_scope).to receive_message_chain(:count)
+          .and_return(
+            { "full_time" => 1, "part_time" => 2, "full_time_or_part_time" => 3 },
+          )
+
+        expect(open_courses_scope).to receive_message_chain(:group).with(:qualification).and_return(open_courses_qualification_scope)
+        expect(open_courses_qualification_scope).to receive_message_chain(:count)
+          .and_return(
+            { "qts" => 1, "pgce_with_qts" => 2, "pgde_with_qts" => 3, "pgce" => 4, "pgde" => 5 },
+          )
+
+        expect(open_courses_scope).to receive_message_chain(:group).with(:is_send).and_return(open_courses_is_send_scope)
+        expect(open_courses_is_send_scope).to receive_message_chain(:count)
+          .and_return({ true => 1, false => 2 })
+
+        expect(closed_courses_scope).to receive_message_chain(:count).and_return(closed_courses_count)
+
+        expect(closed_courses_scope).to receive_message_chain(:group).with(:provider_type).and_return(closed_courses_provider_type_scope)
+        expect(closed_courses_provider_type_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_courses_scope).to receive_message_chain(:group).with(:program_type).and_return(closed_courses_program_type_scope)
+        expect(closed_courses_program_type_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_courses_scope).to receive_message_chain(:group).with(:study_mode).and_return(closed_courses_study_mode_scope)
+        expect(closed_courses_study_mode_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_courses_scope).to receive_message_chain(:group).with(:qualification).and_return(closed_courses_qualification_scope)
+        expect(closed_courses_qualification_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_courses_scope).to receive_message_chain(:group).with(:is_send).and_return(closed_courses_is_send_scope)
+        expect(closed_courses_is_send_scope).to receive_message_chain(:count).and_return({})
+
+        expect(subject).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Vital statistics
 
### Changes proposed in this pull request
Add basic course stats

### Guidance to review
Subject stats will have dupes as a course can be associated to one or more subjects
http://localhost:3001/reporting

```json
{
  "total": {
    "all": 17575,
    "non_findable": 4626,
    "all_findable": 12949
  },
  "findable_total": {
    "open": 9886,
    "closed": 3063
  },
  "provider_type": {
    "open": {
      "scitt": 1641,
      "lead_school": 7257,
      "university": 987,
      "unknown": 0,
      "invalid_value": 0
    },
    "closed": {
      "scitt": 332,
      "lead_school": 2637,
      "university": 94,
      "unknown": 0,
      "invalid_value": 0
    }
  },
  "program_type": {
    "open": {
      "higher_education_programme": 1035,
      "school_direct_training_programme": 6213,
      "school_direct_salaried_training_programme": 1068,
      "scitt_programme": 1493,
      "pg_teaching_apprenticeship": 77
    },
    "closed": {
      "higher_education_programme": 101,
      "school_direct_training_programme": 1784,
      "school_direct_salaried_training_programme": 807,
      "scitt_programme": 305,
      "pg_teaching_apprenticeship": 66
    }
  },
  "study_mode": {
    "open": {
      "full_time": 9304,
      "part_time": 178,
      "full_time_or_part_time": 404
    },
    "closed": {
      "full_time": 2960,
      "part_time": 32,
      "full_time_or_part_time": 71
    }
  },
  "qualification": {
    "open": {
      "qts": 1890,
      "pgce_with_qts": 7842,
      "pgde_with_qts": 118,
      "pgce": 30,
      "pgde": 6
    },
    "closed": {
      "qts": 653,
      "pgce_with_qts": 2391,
      "pgde_with_qts": 18,
      "pgce": 0,
      "pgde": 1
    }
  },
  "is_send": {
    "open": {
      "yes": 95,
      "no": 9791
    },
    "closed": {
      "yes": 50,
      "no": 3013
    }
  },
  "subject": {
    "open": {
      "Primary": 1281,
      "Primary with English": 14,
      "Primary with geography and history": 11,
      "Primary with mathematics": 133,
      "Primary with modern languages": 20,
      "Primary with physical education": 35,
      "Primary with science": 13,
      "Art and design": 325,
      "Science": 15,
      "Biology": 627,
      "Business studies": 164,
      "Chemistry": 693,
      "Citizenship": 21,
      "Classics": 12,
      "Communication and media studies": 25,
      "Computing": 475,
      "Dance": 51,
      "Design and technology": 440,
      "Drama": 266,
      "Economics": 30,
      "English": 725,
      "Geography": 609,
      "Health and social care": 26,
      "History": 508,
      "Mathematics": 843,
      "Music": 314,
      "Philosophy": 0,
      "Physical education": 215,
      "Physics": 750,
      "Psychology": 62,
      "Religious education": 406,
      "Social sciences": 58,
      "French": 331,
      "English as a second or other language": 1,
      "German": 161,
      "Italian": 4,
      "Japanese": 5,
      "Mandarin": 13,
      "Russian": 3,
      "Spanish": 279,
      "Further education": 36,
      "Modern Languages": 781,
      "Modern languages (other)": 305
    },
    "closed": {
      "Primary": 421,
      "Primary with English": 1,
      "Primary with geography and history": 1,
      "Primary with mathematics": 28,
      "Primary with modern languages": 1,
      "Primary with physical education": 5,
      "Primary with science": 1,
      "Art and design": 140,
      "Science": 4,
      "Biology": 178,
      "Business studies": 84,
      "Chemistry": 149,
      "Citizenship": 0,
      "Classics": 12,
      "Communication and media studies": 11,
      "Computing": 113,
      "Dance": 28,
      "Design and technology": 124,
      "Drama": 67,
      "Economics": 5,
      "English": 226,
      "Geography": 138,
      "Health and social care": 13,
      "History": 185,
      "Mathematics": 152,
      "Music": 95,
      "Philosophy": 0,
      "Physical education": 323,
      "Physics": 142,
      "Psychology": 33,
      "Religious education": 89,
      "Social sciences": 47,
      "French": 114,
      "English as a second or other language": 1,
      "German": 70,
      "Italian": 2,
      "Japanese": 0,
      "Mandarin": 4,
      "Russian": 1,
      "Spanish": 100,
      "Further education": 1,
      "Modern Languages": 254,
      "Modern languages (other)": 75
    }
  }
}
```

shamelessly borrowed #1345 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
