### PR TITLE
[3329] top level stats endpoint providers

### DIFF
--- a/app/controllers/reporting_controller.rb
+++ b/app/controllers/reporting_controller.rb
@@ -2,9 +2,11 @@ class ReportingController < ActionController::API
   before_action :build_recruitment_cycle
 
   def reporting
-    course_stats = CourseReportingService.call(courses_scope: @recruitment_cycle.courses)
+    stats = {
+      courses: CourseReportingService.call(courses_scope: @recruitment_cycle.courses),
+    }
 
-    render status: :ok, json: course_stats
+    render status: :ok, json: stats
   end
 
 private

--- a/app/controllers/reporting_controller.rb
+++ b/app/controllers/reporting_controller.rb
@@ -3,6 +3,7 @@ class ReportingController < ActionController::API
 
   def reporting
     stats = {
+      providers: ProviderReportingService.call(providers_scope: @recruitment_cycle.providers),
       courses: CourseReportingService.call(courses_scope: @recruitment_cycle.courses),
     }
 

--- a/app/services/provider_reporting_service.rb
+++ b/app/services/provider_reporting_service.rb
@@ -1,0 +1,45 @@
+class ProviderReportingService
+  def initialize(providers_scope: Provider)
+    @providers = providers_scope.distinct
+    @findable_providers = @providers.with_findable_courses
+    @open_providers = @findable_providers.where(id: Course.with_vacancies.select(:provider_id))
+    @closed_providers = @findable_providers.where.not(id: @open_providers)
+  end
+
+  class << self
+    def call(providers_scope:)
+      new(providers_scope: providers_scope).call
+    end
+  end
+
+  def call
+    {
+      total: {
+        all: @providers.count,
+        non_findable: @providers.count - @findable_providers.count,
+        all_findable: @findable_providers.count,
+      },
+      findable_total: {
+        open: @open_providers.count,
+        closed: @closed_providers.count,
+      },
+      accredited_body: { **group_by_count(:accrediting_provider) },
+      provider_type: { **group_by_count(:provider_type) },
+      region_code: { **group_by_count(:region_code) },
+    }
+  end
+
+  private_class_method :new
+
+private
+
+  def group_by_count(column)
+    open = @open_providers.group(column).count
+    closed = @closed_providers.group(column).count
+
+    {
+      open: Provider.send(column.to_s.pluralize).map { |key, _value| x = {}; x[key.to_sym] = open[key] || 0; x }.reduce({}, :merge),
+      closed: Provider.send(column.to_s.pluralize).map { |key, _value| x = {}; x[key.to_sym] = closed[key] || 0; x }.reduce({}, :merge),
+    }
+  end
+end

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 describe "GET /reporting" do
   let(:expected) do
     {
+      courses: {
       total: {
         all: 0,
         non_findable: 0,
@@ -51,6 +52,7 @@ describe "GET /reporting" do
       subject: {
         open: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
         closed: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
+      },
       },
     }.with_indifferent_access
   end

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -3,56 +3,123 @@ require "rails_helper"
 describe "GET /reporting" do
   let(:expected) do
     {
+      providers: {
+        total: {
+          all: 0,
+          non_findable: 0,
+          all_findable: 0,
+        },
+        findable_total: {
+          open: 0,
+          closed: 0,
+        },
+        accredited_body: {
+          open: {
+            accredited_body: 0,
+            not_an_accredited_body: 0,
+          },
+          closed: {
+            accredited_body: 0,
+            not_an_accredited_body: 0,
+          },
+        },
+        provider_type: {
+          open: {
+            scitt: 0,
+            lead_school: 0,
+            university: 0,
+            unknown: 0,
+            invalid_value: 0,
+          },
+          closed: {
+            scitt: 0,
+            lead_school: 0,
+            university: 0,
+            unknown: 0,
+            invalid_value: 0,
+          },
+        },
+        region_code: {
+          open: {
+            no_region: 0,
+            london: 0,
+            south_east: 0,
+            south_west: 0,
+            wales: 0,
+            west_midlands: 0,
+            east_midlands: 0,
+            eastern: 0,
+            north_west: 0,
+            yorkshire_and_the_humber: 0,
+            north_east: 0,
+            scotland: 0,
+          },
+          closed: {
+            no_region: 0,
+            london: 0,
+            south_east: 0,
+            south_west: 0,
+            wales: 0,
+            west_midlands: 0,
+            east_midlands: 0,
+            eastern: 0,
+            north_west: 0,
+            yorkshire_and_the_humber: 0,
+            north_east: 0,
+            scotland: 0,
+          },
+        },
+      },
       courses: {
-      total: {
-        all: 0,
-        non_findable: 0,
-        all_findable: 0,
-      },
-      findable_total: {
-        open: 0,
-        closed: 0,
-      },
-      provider_type: {
-        open: {
-          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        total: {
+          all: 0,
+          non_findable: 0,
+          all_findable: 0,
         },
-        closed: {
-          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        findable_total: {
+          open: 0,
+          closed: 0,
         },
-      },
-      program_type: {
-        open: {
-          higher_education_programme: 0, school_direct_training_programme: 0,
-          school_direct_salaried_training_programme: 0, scitt_programme: 0,
-          pg_teaching_apprenticeship: 0
+        provider_type: {
+          open: {
+            scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+          },
+          closed: {
+            scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+          },
         },
-        closed: {
-          higher_education_programme: 0, school_direct_training_programme: 0,
-          school_direct_salaried_training_programme: 0, scitt_programme: 0,
-          pg_teaching_apprenticeship: 0
+        program_type: {
+          open: {
+            higher_education_programme: 0, school_direct_training_programme: 0,
+            school_direct_salaried_training_programme: 0, scitt_programme: 0,
+            pg_teaching_apprenticeship: 0
+          },
+          closed: {
+            higher_education_programme: 0, school_direct_training_programme: 0,
+            school_direct_salaried_training_programme: 0, scitt_programme: 0,
+            pg_teaching_apprenticeship: 0
+          },
         },
-      },
-      study_mode: {
-        open: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
-        closed: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
-      },
-      qualification: {
-        open: {
-          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+        study_mode: {
+          open: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
+          closed: { full_time: 0, part_time: 0, full_time_or_part_time: 0 },
         },
-        closed: {
-          qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+        qualification: {
+          open: {
+            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+          },
+          closed: {
+            qts: 0, pgce_with_qts: 0, pgde_with_qts: 0, pgce: 0, pgde: 0
+          },
         },
-      },
-      is_send: {
-        open: { yes: 0, no: 0 },
-        closed:  { yes: 0, no: 0 },
-      },
-      subject: {
-        open: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
-        closed: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
-      },
+        is_send: {
+          open: { yes: 0, no: 0 },
+          closed:  { yes: 0, no: 0 },
+        },
+        subject: {
+          open: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
+          closed: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
+        },
       },
     }.with_indifferent_access
   end

--- a/spec/services/provider_reporting_service_spec.rb
+++ b/spec/services/provider_reporting_service_spec.rb
@@ -1,0 +1,155 @@
+require "rails_helper"
+
+describe ProviderReportingService do
+  let(:closed_providers_scope) { class_double(Provider) }
+  let(:closed_providers_accrediting_provider_scope) { class_double(Provider) }
+  let(:closed_providers_provider_type_scope) { class_double(Provider) }
+  let(:closed_providers_region_code_scope) { class_double(Provider) }
+
+  let(:providers_scope) { class_double(Provider) }
+  let(:findable_providers_scope) { class_double(Provider) }
+
+  let(:open_providers_scope) { class_double(Provider) }
+  let(:open_providers_accrediting_provider_scope) { class_double(Provider) }
+  let(:open_providers_provider_type_scope) { class_double(Provider) }
+  let(:open_providers_region_code_scope) { class_double(Provider) }
+
+  let(:distinct_providers_scope) { class_double(Provider) }
+
+  let(:providers_count) { 100 }
+  let(:findable_providers_count) { 60 }
+  let(:open_providers_count) { 40 }
+  let(:closed_providers_count) { 20 }
+
+  let(:expected) do
+    {
+      total: {
+        all: providers_count,
+        non_findable: providers_count - findable_providers_count,
+        all_findable: findable_providers_count,
+      },
+      findable_total: {
+        open: open_providers_count,
+        closed: closed_providers_count,
+      },
+      accredited_body: {
+        open: {
+          accredited_body: 1,
+          not_an_accredited_body: 2,
+        },
+        closed: {
+          accredited_body: 0,
+          not_an_accredited_body: 0,
+        },
+      },
+      provider_type: {
+        open: {
+          scitt: 1, lead_school: 2, university: 3, unknown: 4, invalid_value: 5
+        },
+        closed: {
+          scitt: 0, lead_school: 0, university: 0, unknown: 0, invalid_value: 0
+        },
+      },
+      region_code: {
+        open: {
+          no_region: 0,
+          london: 1,
+          south_east: 2,
+          south_west: 3,
+          wales: 4,
+          west_midlands: 5,
+          east_midlands: 6,
+          eastern: 7,
+          north_west: 8,
+          yorkshire_and_the_humber: 9,
+          north_east: 10,
+          scotland: 12,
+        },
+        closed: {
+          no_region: 0,
+          london: 0,
+          south_east: 0,
+          south_west: 0,
+          wales: 0,
+          west_midlands: 0,
+          east_midlands: 0,
+          eastern: 0,
+          north_west: 0,
+          yorkshire_and_the_humber: 0,
+          north_east: 0,
+          scotland: 0,
+        },
+      },
+    }
+  end
+
+  describe ".call" do
+    describe "when scope is passed" do
+      subject { described_class.call(providers_scope: providers_scope) }
+
+      it "applies the scopes" do
+        expect(providers_scope).to receive_message_chain(:distinct).and_return(distinct_providers_scope)
+        expect(distinct_providers_scope).to receive_message_chain(:count).and_return(providers_count)
+        expect(distinct_providers_scope).to receive_message_chain(:count).and_return(providers_count)
+        expect(distinct_providers_scope).to receive_message_chain(:with_findable_courses).and_return(findable_providers_scope)
+
+        expect(findable_providers_scope).to receive_message_chain(:where)
+          .with(id: Course.with_vacancies.select(:provider_id))
+          .and_return(open_providers_scope)
+
+        expect(findable_providers_scope).to receive_message_chain(:where, :not).and_return(closed_providers_scope)
+
+        expect(findable_providers_scope).to receive_message_chain(:count).and_return(findable_providers_count)
+        expect(findable_providers_scope).to receive_message_chain(:count).and_return(findable_providers_count)
+        expect(open_providers_scope).to receive_message_chain(:count).and_return(open_providers_count)
+
+        expect(open_providers_scope).to receive_message_chain(:group)
+          .with(:accrediting_provider)
+          .and_return(open_providers_accrediting_provider_scope)
+
+        expect(open_providers_accrediting_provider_scope).to receive_message_chain(:count)
+          .and_return(
+            { "accredited_body" => 1, "not_an_accredited_body" => 2 },
+          )
+
+        expect(open_providers_scope).to receive_message_chain(:group).with(:provider_type).and_return(open_providers_provider_type_scope)
+        expect(open_providers_provider_type_scope).to receive_message_chain(:count)
+          .and_return(
+            { "scitt" => 1, "lead_school" => 2, "university" => 3, "unknown" => 4, "invalid_value" => 5 },
+          )
+
+        expect(open_providers_scope).to receive_message_chain(:group).with(:region_code).and_return(open_providers_region_code_scope)
+        expect(open_providers_region_code_scope).to receive_message_chain(:count)
+          .and_return(
+            {
+              "no_region" => 0,
+              "london" => 1,
+              "south_east" => 2,
+              "south_west" => 3,
+              "wales" => 4,
+              "west_midlands" => 5,
+              "east_midlands" => 6,
+              "eastern" => 7,
+              "north_west" => 8,
+              "yorkshire_and_the_humber" => 9,
+              "north_east" => 10,
+              "scotland" => 12,
+            },
+          )
+
+        expect(closed_providers_scope).to receive_message_chain(:count).and_return(closed_providers_count)
+
+        expect(closed_providers_scope).to receive_message_chain(:group).with(:accrediting_provider).and_return(closed_providers_accrediting_provider_scope)
+        expect(closed_providers_accrediting_provider_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_providers_scope).to receive_message_chain(:group).with(:provider_type).and_return(closed_providers_provider_type_scope)
+        expect(closed_providers_provider_type_scope).to receive_message_chain(:count).and_return({})
+
+        expect(closed_providers_scope).to receive_message_chain(:group).with(:region_code).and_return(closed_providers_region_code_scope)
+        expect(closed_providers_region_code_scope).to receive_message_chain(:count).and_return({})
+
+        expect(subject).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
vital statistics

### Changes proposed in this pull request
Added providers stats

### Guidance to review
http://localhost:3001/reporting

```json
{
"providers": {
    "total": {
      "all": 1939,
      "non_findable": 850,
      "all_findable": 1089
    },
    "findable_total": {
      "open": 1022,
      "closed": 67
    },
    "accredited_body": {
      "open": {
        "accredited_body": 227,
        "not_an_accredited_body": 795
      },
      "closed": {
        "accredited_body": 27,
        "not_an_accredited_body": 40
      }
    },
    "provider_type": {
      "open": {
        "scitt": 138,
        "lead_school": 811,
        "university": 72,
        "unknown": 0,
        "invalid_value": 0
      },
      "closed": {
        "scitt": 3,
        "lead_school": 64,
        "university": 0,
        "unknown": 0,
        "invalid_value": 0
      }
    },
    "region_code": {
      "open": {
        "no_region": 0,
        "london": 162,
        "south_east": 150,
        "south_west": 80,
        "wales": 0,
        "west_midlands": 119,
        "east_midlands": 72,
        "eastern": 125,
        "north_west": 123,
        "yorkshire_and_the_humber": 127,
        "north_east": 60,
        "scotland": 0
      },
      "closed": {
        "no_region": 0,
        "london": 10,
        "south_east": 12,
        "south_west": 6,
        "wales": 0,
        "west_midlands": 9,
        "east_midlands": 3,
        "eastern": 9,
        "north_west": 9,
        "yorkshire_and_the_humber": 3,
        "north_east": 6,
        "scotland": 0
      }
    }
  },
  "courses": {...}
}
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
