### PR TITLE
[3360] - Prioritise accredited body's own courses in search results

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -148,6 +148,10 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_name_descending).order("name desc")
   end
 
+  scope :accredited_body_order, ->(provider_name) do
+    joins(:provider).merge(Provider.by_provider_name(provider_name))
+  end
+
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
       changed_at_since(timestamp)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -75,6 +75,14 @@ class Provider < ApplicationRecord
   scope :by_name_ascending, -> { order(provider_name: :asc) }
   scope :by_name_descending, -> { order(provider_name: :desc) }
 
+  scope :by_provider_name, ->(provider_name) do
+    order(
+      Arel.sql(
+        "CASE WHEN provider.provider_name = #{connection.quote(provider_name)} THEN '1' END",
+      ),
+    )
+  end
+
   scope :with_findable_courses, -> do
     where(id: Course.findable.select(:provider_id))
       .or(self.where(provider_code: Course.findable.select(:accrediting_provider_code)))

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -182,6 +182,12 @@ describe Course, type: :model do
           expect(described_class.descending_canonical_order).to eq([course_d, course_c, course_b, course_a])
         end
       end
+
+      describe "#accredited_body_order" do
+        it "sorts in descending order of provider name" do
+          expect(described_class.accredited_body_order(course_c.provider.provider_name)).to eq([course_c, course_d, course_a, course_b])
+        end
+      end
     end
 
     context "by name" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -74,6 +74,14 @@ describe Provider, type: :model do
         expect(Provider.by_name_descending).to eq([provider_b, provider_a])
       end
     end
+
+    describe "#by_provider_name" do
+      it "orders the providers by name in descending order" do
+        provider_a
+        provider_b
+        expect(Provider.by_provider_name(provider_b.provider_name)).to eq([provider_b, provider_a])
+      end
+    end
   end
 
   describe "#changed_since" do


### PR DESCRIPTION
### Context
- When users search for an accredited body who delivers its own courses _and_ has partners who delivers courses on it's behalf, then the accredited body's courses should be prioritised in the results .

### Changes proposed in this pull request
- Scope added to prioritise university courses in results where appropriate.
- There appears to be a modest 30ms decrease in `db_runtime` (avg) as a result of the changes

<img width="1382" alt="warwick" src="https://user-images.githubusercontent.com/5256922/82214391-aaf48e80-990d-11ea-83c7-db33d334b41f.png">

### Guidance to review
- Do a provider search for 'University of Warwick' - you can see that its courses are now returned at the beginning of the results, other courses are returned thereafter alphabetically by provider name.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
