### PR TITLE
[3416] change healthcheck to return service unavailable

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -13,11 +13,12 @@ class HeartbeatController < ActionController::API
       sidekiq_queue: sidekiq_queue_healthy?,
     }
 
-    status = :ok
-    status = :bad_gateway unless checks.values.all?
-    render status: status, json: {
-      checks: checks,
-    }
+    status = checks.values.all? ? :ok : :service_unavailable
+
+    render status: status,
+           json: {
+             checks: checks,
+           }
   end
 
 private

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -26,9 +26,9 @@ describe "heartbeat requests" do
         allow(Sidekiq::DeadSet).to receive(:new).and_return(dead_set)
       end
 
-      it "returns status bad gateway" do
+      it "returns status service unavailable" do
         get "/healthcheck"
-        expect(response.status).to eq(502)
+        expect(response.status).to eq(503)
       end
 
       it "returns the expected response report" do


### PR DESCRIPTION

### Context

Meant to fix the Sidekiq healthcheck, but can't currently find evidence of it being broken.

### Changes proposed in this pull request

Change `502 bad gateway` to `503 service unavailable`.

### Guidance to review

Another PR will be made if we can find anything to fix in the Sidekiq healthcheck.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
