### PR TITLE
[3422] Provider search can now include self

### DIFF
--- a/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
@@ -67,7 +67,7 @@ describe "AccreditedBody API v2", type: :request do
 
       let(:filters) { "" }
 
-      it "is returned" do
+      it "returns the accredited provider in the results" do
         get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
         json_response = JSON.parse(response.body)
         provider_hashes = json_response["data"]

--- a/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
@@ -60,7 +60,7 @@ describe "AccreditedBody API v2", type: :request do
       get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
     end
 
-    context "when accredited_provider has a course" do
+    context "when accredited_provider has a self-accredited course" do
       before do
         accredited_provider_course
       end

--- a/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_filter_providers_spec.rb
@@ -27,6 +27,15 @@ describe "AccreditedBody API v2", type: :request do
              accrediting_provider: accredited_provider)
     end
 
+    let(:accredited_provider_course) do
+      create(:course,
+             level: :secondary,
+             provider: accredited_provider,
+             subjects: [physical_education],
+             site_statuses: [build(:site_status, :findable, site: build(:site))],
+             accrediting_provider: nil) # important the course is not accredited
+    end
+
     let(:training_provider_1) { create(:provider, provider_name: "ABC Provider") }
 
     let(:accredited_provider) {
@@ -49,6 +58,21 @@ describe "AccreditedBody API v2", type: :request do
 
     def perform_request
       get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+    end
+
+    context "when accredited_provider has a course" do
+      before do
+        accredited_provider_course
+      end
+
+      let(:filters) { "" }
+
+      it "is returned" do
+        get request_path, headers: { "HTTP_AUTHORIZATION" => credentials }
+        json_response = JSON.parse(response.body)
+        provider_hashes = json_response["data"]
+        expect(provider_hashes.map { |h| h["id"].to_i }).to include(accredited_provider.id)
+      end
     end
 
     describe "funding type filter" do

--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -52,6 +52,57 @@ describe "AccreditedBody API v2", type: :request do
         expect(json_response).to eq(
           "data" => [
             {
+              "id" => accredited_provider.id.to_s,
+              "type" => "providers",
+              "attributes" => {
+                "provider_code" => accredited_provider.provider_code,
+                "provider_name" => accredited_provider.provider_name,
+                "accredited_body?" => false,
+                "can_add_more_sites?" => true,
+                "accredited_bodies" => [],
+                "train_with_us" => accredited_provider.train_with_us,
+                "train_with_disability" => accredited_provider.train_with_disability,
+                "latitude" => nil,
+                "longitude" => nil,
+                "address1" => accredited_provider.address1,
+                "address2" => accredited_provider.address2,
+                "address3" => accredited_provider.address3,
+                "address4" => accredited_provider.address4,
+                "postcode" => accredited_provider.postcode,
+                "region_code" => "london",
+                "telephone" => accredited_provider.telephone,
+                "email" => accredited_provider.email,
+                "website" => accredited_provider.website,
+                "recruitment_cycle_year" => "2020",
+                "admin_contact" => nil,
+                "utt_contact" => nil,
+                "web_link_contact" => nil,
+                "fraud_contact" => nil,
+                "finance_contact" => nil,
+                "gt12_contact" => nil,
+                "application_alert_contact" => nil,
+                "type_of_gt12" => nil,
+                "send_application_alerts" => nil,
+              },
+              "relationships" => {
+                "sites" => {
+                  "meta" => {
+                    "included" => false,
+                  },
+                },
+                "users" => {
+                  "meta" => {
+                    "included" => false,
+                  },
+                },
+                "courses" => {
+                  "meta" => {
+                    "count" => 0,
+                  },
+                },
+              },
+            },
+            {
               "id" => delivering_provider1.id.to_s,
               "type" => "providers",
               "attributes" => {
@@ -195,7 +246,7 @@ describe "AccreditedBody API v2", type: :request do
         it "only returns data for the next recruitment cycle" do
           perform_request
 
-          expect(json_response["data"].count).to eq 1
+          expect(json_response["data"].count).to eq 2
           expect(json_response["data"].first)
             .to have_attribute("recruitment_cycle_year")
             .with_value(next_recruitment_cycle.year)


### PR DESCRIPTION
### Context

- https://trello.com/c/Hwg5ZBqT/3422-accredited-bodies-should-be-able-to-request-pe-allocations
- For allocations we need to return accrediting providers if they also have a PR fee funded course

### Changes proposed in this pull request

- on accredited provider search if the accredited provider has a course
themselves that meets the criteria the accredited provider is returned
in the results
- previously only training providers would be considered

### Guidance to review

- Navigate to a provider with their own fee funded PE course eg `2AT`
- go to the index allocations page
- should see yet to request repeat allocation

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
