### PR TITLE
Don't run annotate in the default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ Rake::Task["default"].clear
 
 task lint: ["lint:ruby"]
 task parallel: ["parallel:spec"]
-task default: %i[parallel annotate lint brakeman]
+task default: %i[parallel lint brakeman]


### PR DESCRIPTION
Annotate gem was removed in a previous PR #1371 