### PR TITLE
[3429] Import missed allocations

### DIFF
--- a/app/services/allocation_importer_service.rb
+++ b/app/services/allocation_importer_service.rb
@@ -1,0 +1,46 @@
+require "csv"
+
+class AllocationImporterService
+  attr_reader :path_to_csv
+
+  def initialize(path_to_csv:)
+    @path_to_csv = path_to_csv
+  end
+
+  def execute
+    rows.each do |row|
+      training_provider = Provider.where(recruitment_cycle_id: 1).find_by(provider_code: row["provider_code"])
+      accredited_body_provider = Provider.where(recruitment_cycle_id: 1).find_by(provider_code: row["accredited_body_code"])
+
+      if training_provider.blank?
+        raise "Training Provider with code: #{row['provider_code']} not found"
+      end
+
+      if accredited_body_provider.blank?
+        raise "Accredited Body Provider with code: #{row['accredited_body_code']} not found"
+      end
+
+      puts "Importing training_provider: #{training_provider.provider_code} and accredited_body: #{accredited_body_provider.provider_code}"
+
+      allocation = Allocation.find_or_initialize_by(
+        provider: training_provider,
+        accredited_body: accredited_body_provider,
+        recruitment_cycle_id: 1,
+        provider_code: training_provider.provider_code,
+        accredited_body_code: accredited_body_provider.provider_code,
+      )
+
+      allocation.number_of_places = row["number_of_places"]
+
+      if allocation.changed?
+        allocation.save!
+      end
+    end
+  end
+
+private
+
+  def rows
+    @rows ||= CSV.read(path_to_csv, headers: :first_row)
+  end
+end

--- a/config/data/itt_allocations_2020_to_2021/missed_physical_education.csv
+++ b/config/data/itt_allocations_2020_to_2021/missed_physical_education.csv
@@ -1,0 +1,57 @@
+provider,provider_code,accredited_body,accredited_body_code,number_of_places
+Bingley Grammar School,2BP,Bradford Birth to 19 SCITT,259,2
+Moor End Academy,1A1,Huddersfield Horizon SCITT,2EX,2
+Liverpool College,L43,Liverpool Hope University,L46,2
+St John Bosco Arts College,1FU,Liverpool Hope University,L46,1
+St Patrick's RC High School and Arts College,18A,Liverpool Hope University,L46,1
+St James's CE High School,18J,Liverpool Hope University,L46,1
+"St Edmund Arrowsmith Catholic High School, Ashton-in-Makerfield",27Q,Liverpool Hope University,L46,1
+Hope Academy,1LA,Liverpool Hope University,L46,1
+The Oldham Academy North,2KG,Liverpool Hope,L46,1
+Durrington High School,2GH,The South Downs SCITT,2AZ,1
+Bitterne Park School,1F6,University of Southampton,S27,2
+Bishop Wordsworth's Grammar School,1FZ,University of Southampton,S27,1
+Noadswood School,2BH,University of Southampton,S27,1
+North Essex Teacher Training (NETT),N46,North Essex Teacher Training (NETT),N46,2
+Greenwood Academies Trust,1EX,The Cambridge Partnership,C03,1
+CMAT Nene Park Academy,263,The Cambridge Partnership,C03,1
+Springwood High School,1U4,The Cambridge Partnership,C03,3
+Bridgewater High School,2H4,Endeavour Learning SCITT,M70,2
+Leeds Beckett University,L27,The Manchester Metropolitan University,M40,2
+Bishop Grosseteste University,B38,Bishop Grosseteste University,B38,7
+Mascalls Academy,1GR,Kent and Medway Training,K30,1
+Landau Forte College Derby SCITT,186,Landau Forte College Derby SCITT,25E,1
+University of Chichester,C58,St. Mary’s University Twickenham,S64,1
+St Mary's Catholic High School,1WA,The Sheffield SCITT,S97,1
+Hungerhill School,298,The Sheffield SCITT,S97,2
+St Bernard's Catholic High School,S97,The Sheffield SCITT,S97,1
+North Wiltshire SCITT,1T9,North Wiltshire SCITT,24U,1
+Lincolnshire Teaching School Alliance SCITT,25G,Lincolnshire Teaching School Alliance SCITT,25G,1
+EborHope Teaching School Alliance /York St John University,1DH,York St John University,Y75,3
+The Cherwell School,24T,The Cherwell OTSA SCITT,24T,3
+Our Lady’s Catholic High School,1GB,University of Cumbria,C99,3
+Broughton High School,12V,University of Cumbria,C99,5
+Denbigh School,1QK,The Tommy Flowers SCITT,1YK,1
+Lozells Primary,139,Birmingham City University,B25,2
+Platt Bridge Communtiy School,K51,Kingsbridge Teacher Training,K51,1
+The Piggott School,152,University of Reading,R12,3
+Lydiard Park Academy,2KD,The University of the West of England,B80,1
+Davenant Foundation School,H40,TES Institute,H40,1
+Thomas Telford School,1K7,West Midlands Consortium,W53,3
+Bromley Schools' Collegiate,B91,Bromley Schools' Collegiate,B91,2
+Chiltern Training Group,C59,Chiltern Training Group,C59,2
+Chiltern Training Group,15N,Chiltern Training Group,C59,1
+GLF Schools' Teacher Training,2B4,GLF Schools' Teacher Training,2B4,3
+Huddersfield Horizon SCITT,2EX,Huddersfield Horizon SCITT,2EX,2
+Liverpool Hope University,L46,Liverpool Hope University,L46,6
+The South Downs SCITT,2AZ,The South Downs SCITT,2AZ,1
+University of Southampton,S27,University of Southampton,S27,13
+The Tommy Flowers SCITT,1YK,The Tommy Flowers SCITT,1YK,1
+Redcar and Cleveland Teacher Training Partnership,R16,Redcar and Cleveland Teacher Training Partnership,R16,1
+University of Cumbria,C99,University of Cumbria,C99,10
+North Lincolnshire SCITT Partnership,N66,North Lincolnshire SCITT Partnership,N66,1
+Manchester Nexus SCITT,2EU,Manchester Nexus SCITT,2EU,1
+NELTA/Beal HIgh School,1NA,NELTA (North East London Teaching Alliance),251,1
+Consilium SCITT,1MS,Buile Hill VA College SCITT,1WT,1
+Cranford Community College,265,Teaching London: LDBS SCITT,L59,1
+Grand Union Training Partnership ,G60,Grand Union Training Partnership ,G60,1

--- a/db/migrate/20200522114747_add_uniq_index_on_allocations.rb
+++ b/db/migrate/20200522114747_add_uniq_index_on_allocations.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexOnAllocations < ActiveRecord::Migration[6.0]
+  def change
+    add_index :allocation, %i[provider_id accredited_body_id provider_code accredited_body_code recruitment_cycle_id], unique: true, name: "index_allocations_on_uniqueness_of_codes_and_ids"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_18_101459) do
+ActiveRecord::Schema.define(version: 2020_05_22_114747) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_buffercache"
@@ -47,6 +47,7 @@ ActiveRecord::Schema.define(version: 2020_05_18_101459) do
     t.text "provider_code"
     t.integer "recruitment_cycle_id"
     t.index ["accredited_body_id"], name: "index_allocation_on_accredited_body_id"
+    t.index ["provider_id", "accredited_body_id", "provider_code", "accredited_body_code", "recruitment_cycle_id"], name: "index_allocations_on_uniqueness_of_codes_and_ids", unique: true
     t.index ["provider_id"], name: "index_allocation_on_provider_id"
     t.index ["recruitment_cycle_id", "accredited_body_code", "provider_code"], name: "index_allocation_recruitment_and_codes"
     t.index ["request_type"], name: "index_allocation_on_request_type"

--- a/spec/services/allocation_importer_service_spec.rb
+++ b/spec/services/allocation_importer_service_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+RSpec.describe AllocationImporterService do
+  # disable stdout
+  around do |example|
+    original_stdout = $stdout
+    $stdout = File.open(File::NULL, "w")
+    example.run
+    $stdout = original_stdout
+  end
+
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle, id: 1) }
+  let(:path_to_csv) { Rails.root.join("tmp/physical_education.csv") }
+  let(:training_provider) { create(:provider, recruitment_cycle: recruitment_cycle) }
+  let(:accredited_body_provider) { create(:provider, :accredited_body, recruitment_cycle: recruitment_cycle) }
+
+  subject do
+    described_class.new(path_to_csv: path_to_csv)
+  end
+
+  describe "#execute" do
+    context "happy path" do
+      before do
+        File.open(path_to_csv, "w") do |f|
+          f.write "provider,provider_code,accredited_body,accredited_body_code,number_of_places\n"
+          f.write "#{training_provider.provider_name},#{training_provider.provider_code},#{accredited_body_provider.provider_name},#{accredited_body_provider.provider_code},3\n"
+        end
+      end
+
+      it "creates correct allocation" do
+        expect { subject.execute }.to change(Allocation, :count).by(1)
+
+        allocation = Allocation.last
+
+        expect(allocation.provider_id).to eql(training_provider.id)
+        expect(allocation.accredited_body_id).to eql(accredited_body_provider.id)
+        expect(allocation.number_of_places).to eql(3)
+        expect(allocation.provider_code).to eql(training_provider.provider_code)
+        expect(allocation.accredited_body_code).to eql(accredited_body_provider.provider_code)
+      end
+
+      it "is idempotent" do
+        expect {
+          subject.execute
+          subject.execute
+        }.to change(Allocation, :count).by(1)
+      end
+    end
+
+    context "when training provider not found" do
+      before do
+        File.open(path_to_csv, "w") do |f|
+          f.write "allocation,training_provider_code,accredited_body_provider_code\n"
+          f.write "3,no-provider,#{accredited_body_provider.provider_code}\n"
+        end
+      end
+
+      it "raises an error" do
+        expect { subject.execute }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "when accredited body provider not found" do
+      before do
+        File.open(path_to_csv, "w") do |f|
+          f.write "allocation,training_provider_code,accredited_body_provider_code\n"
+          f.write "3,#{training_provider.provider_code},no-provider\n"
+        end
+      end
+
+      it "raises an error" do
+        expect { subject.execute }.to raise_error(RuntimeError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/x2El42cz/3429-import-additional-allocations
- There were missed allocations that were submitted after the deadline and were not in the published spreadsheet

### Changes proposed in this pull request

- Reintroduce allocation import script
- Add missed allocation data for import
- Introduce uniqueness index to prevent duplicate allocations from being created

### Guidance to review

- Test against most recent db dump
- Run the following in a rails console
- `service = AllocationImporterService.new(path_to_csv: Rails.root.join('config/data/itt_allocations_2020_to_2021/missed_physical_education.csv')); service.execute`
- New or updated allocations should be present

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
