### PR TITLE
[3399] - Allow provider searches with queries containing 2 characters

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -51,7 +51,7 @@ module API
       def suggest
         authorize Provider
 
-        return render(status: :bad_request) if params[:query].nil? || params[:query].length < 3
+        return render(status: :bad_request) if params[:query].nil? || params[:query].length < 2
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         found_providers = policy_scope(@recruitment_cycle.providers)

--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -7,6 +7,8 @@ module API
         build_fields_for_index
 
         @providers = if params[:search].present?
+                       return render(status: :bad_request) if params[:search].length < 2
+
                        @recruitment_cycle.providers.search_by_code_or_name(params[:search])
                      else
                        @recruitment_cycle.providers

--- a/spec/requests/api/v2/providers/suggest_provider_spec.rb
+++ b/spec/requests/api/v2/providers/suggest_provider_spec.rb
@@ -95,7 +95,7 @@ describe "GET /suggest" do
   it "returns bad request if query is too short" do
     provider
 
-    get "/api/v2/providers/suggest?query=#{provider.provider_name[0, 2]}",
+    get "/api/v2/providers/suggest?query=#{provider.provider_name[0, 1]}",
         headers: { "HTTP_AUTHORIZATION" => credentials }
 
     expect(response.status).to eq(400)

--- a/spec/requests/api/v3/providers/index_spec.rb
+++ b/spec/requests/api/v3/providers/index_spec.rb
@@ -131,7 +131,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       provider_two
     end
 
-    context "Seaching for a provider by its full name" do
+    context "Searching for a provider by its full name" do
       let(:request_path) { "#{base_provider_path}?search=Second provider" }
 
       it "Only returns data for the provider" do
@@ -142,7 +142,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
 
-    context "Seaching for a provider by its lower case full name" do
+    context "Searching for a provider by its lower case full name" do
       let(:request_path) { "#{base_provider_path}?search=second provider" }
 
       it "Only returns data for the provider" do
@@ -153,7 +153,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
 
-    context "Seaching for a provider by part of its name" do
+    context "Searching for a provider by part of its name" do
       let(:request_path) { "#{base_provider_path}?search=provider" }
 
       it "Returns data for the matching providers" do
@@ -165,7 +165,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
 
-    context "Seaching for a provider by its provider code" do
+    context "Searching for a provider by its provider code" do
       let(:request_path) { "#{base_provider_path}?search=2AT" }
 
       it "Only returns data for the provider" do
@@ -176,7 +176,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
     end
 
-    context "Seaching for a provider by a lower case provider code" do
+    context "Searching for a provider by a lower case provider code" do
       let(:request_path) { "#{base_provider_path}?search=2at" }
 
       it "Only returns data for the provider" do
@@ -184,6 +184,28 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers" do
 
         expect(json_response["data"].count).to eq(1)
         expect(json_response["data"].first).to have_attribute("provider_code").with_value("2AT")
+      end
+    end
+
+    context "Searching for a provider with an invalid query" do
+      context "query is empty" do
+        let(:request_path) { "#{base_provider_path}?search=" }
+
+        it "returns all providers" do
+          perform_request
+
+          expect(json_response["data"].count).to eq(2)
+        end
+      end
+
+      context "query is less than 2 characters" do
+        let(:request_path) { "#{base_provider_path}?search=a" }
+
+        it "returns Bad Request" do
+          perform_request
+
+          expect(response.status).to eq(400)
+        end
       end
     end
   end


### PR DESCRIPTION
### Context
On Publish and Find we now want to allow users to run provider searches containing 2 characters. 
NB: Hold fire on merging until front ends are updated

### Changes proposed in this pull request
- Changes the provider search query minimum character limit to  1
- Adds missing test coverage

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
