### PR TITLE
[3459] Move email notification

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -98,6 +98,8 @@ module API
 
         @course.ensure_site_statuses_match_study_mode if @course.study_mode_previously_changed?
 
+        Courses::UpdateNotificationService.new.call(course: @course)
+
         if @course.errors.empty? && @course.valid?
           @course.save
           @course.course_subjects.each(&:save)
@@ -149,8 +151,6 @@ module API
 
         @course.assign_attributes(course_params)
         @course.save
-
-        Courses::UpdateNotificationService.new.call(course: @course)
       end
 
       def update_sites


### PR DESCRIPTION
### Context

We are launching the email notifications feature. On testing, updating a course doesn't seem to trigger the emails.

### Changes proposed in this pull request

Move the call to `Courses::UpdateNotificationService` to ensure that it is always called when a course is updated.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
