### PR TITLE
[3462] add /sha endpoint to see the commit SHA in deployed env

### DIFF
--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -20,6 +20,12 @@ class HeartbeatController < ActionController::API
            }
   end
 
+  def sha
+    commit_sha_path = Rails.root.join(Settings.commit_sha_file)
+    sha = File.read(commit_sha_path).strip
+    render json: { sha: sha }
+  end
+
 private
 
   def database_alive?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@
 Rails.application.routes.draw do
   get :ping, controller: :heartbeat
   get :healthcheck, controller: :heartbeat
+  get :sha, controller: :heartbeat
   get :reporting, controller: :reporting
 
   mount OpenApi::Rswag::Ui::Engine => "/api-docs"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,4 @@ logstash:
 log_level: info
 magic_link:
   max_token_age: <%= 1.hour %>
+commit_sha_file: COMMIT_SHA

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -110,4 +110,16 @@ describe "heartbeat requests" do
       end
     end
   end
+
+  describe "GET /sha" do
+    it "returns the sha from the file COMMIT_SHA" do
+      allow(File).to receive(:read)
+                       .with(Rails.root.join("COMMIT_SHA"))
+                       .and_return("deadbeef\n")
+
+      get "/sha"
+
+      expect(response.body).to eq '{"sha":"deadbeef"}'
+    end
+  end
 end


### PR DESCRIPTION
### Context

Sometimes it's important to be able to see what version of the code is actually running for debugging issues.

### Changes proposed in this pull request

Add an endpoint that exposes the git commit SHA at `/sha`.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
