### PR TITLE
[3440] Allocations can now be filtered

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -7,7 +7,13 @@ module API
       def index
         authorize Allocation
 
-        render jsonapi: policy_scope(Allocation.where(accredited_body_id: accredited_body.id)),
+        scope = Allocation.where(accredited_body_id: accredited_body.id)
+
+        if params[:filter] && params[:filter][:training_provider_code]
+          scope = scope.where(provider_code: params[:filter][:training_provider_code])
+        end
+
+        render jsonapi: policy_scope(scope),
                include: params[:include],
                status: :ok
       end
@@ -15,9 +21,7 @@ module API
       def show
         authorize @allocation = Allocation.find(params[:id])
 
-        render jsonapi: @allocation,
-          include: params[:include],
-          status: :ok
+        render jsonapi: @allocation, include: params[:include], status: :ok
       end
 
       def create

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -4,6 +4,10 @@ FactoryBot.define do
     association :provider
     number_of_places { 0 }
     recruitment_cycle { RecruitmentCycle.current }
+
+    provider_code { provider.provider_code }
+    accredited_body_code { accredited_body.provider_code }
+
     trait :repeat do
       request_type { "repeat" }
     end


### PR DESCRIPTION
### Context

- https://trello.com/c/dtbw2raY/3440-stop-filtering-out-providers-from-provider-search-initial-allocation-request
- The frontend needs to to determine what to show the user depending on whether or not an allocation exists
- This change modifies the allocation endpoints so the results can be filtered

### Changes proposed in this pull request

- Can now pass training_provider_code to find allocations only
associated with the specified training provider
- allocations#show handles `include` to return associations

### Guidance to review

```ruby
Allocation.where(recruitment_cycle_year: recruitment_cycle.year)
  .where(provider_code: provider.provider_code, training_provider_code: training_provider[:provider_code])
   .first
```

- Using the above code in publish given an allocation exists for the training provider it should be returned otherwise should return nil

```
 Allocation.include(:provider).find(params[:id]).first
```

- This should now return the provider association

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
