### PR TITLE
3459 Course updated emails not being sent

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,11 +19,6 @@ class User < ApplicationRecord
   scope :admins, -> { where(admin: true) }
   scope :non_admins, -> { where.not(admin: true) }
   scope :active, -> { where.not(accept_terms_date_utc: nil) }
-  scope :notifiable_users, ->(provider_code) do
-    joins(:user_notifications).merge(
-      UserNotification.course_update_notification_requests(provider_code),
-    )
-  end
   scope :last_login_since, ->(timestamp) do
     where("last_login_date_utc > ?", timestamp)
   end

--- a/app/services/courses/update_notification_service.rb
+++ b/app/services/courses/update_notification_service.rb
@@ -22,7 +22,9 @@ module Courses
     end
 
     def users_to_notify(course)
-      User.notifiable_users(course.provider.provider_code)
+      User.joins(:user_notifications).merge(
+        UserNotification.course_update_notification_requests(course.accrediting_provider_code),
+      )
     end
 
     def course_needs_to_notify?(course)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,25 +3,6 @@ require "rails_helper"
 describe User, type: :model do
   subject { create(:user, first_name: "Jane", last_name: "Smith", email: "jsmith@scitt.org") }
 
-  context "#notifiable_users" do
-    let(:user2) { create(:user, first_name: "Richard", last_name: "Brent", email: "rbrent@scitt.org") }
-    let(:user3) { create(:user, first_name: "John", last_name: "Pollard", email: "jpoll@scitt.org") }
-
-    let(:provider) { create(:provider) }
-    let(:course) { create(:course, provider: provider) }
-    let(:user_notification) do
-      create(:user_notification, user: subject, provider: provider, course_update: true)
-      create(:user_notification, user: user2, provider: provider, course_update: true)
-      create(:user_notification, user: user3, provider: provider, course_update: false)
-    end
-
-    it "returns users with notifications for a course" do
-      user_notification
-
-      expect(User.notifiable_users(provider.provider_code)).to match_array([subject, user2])
-    end
-  end
-
   describe "associations" do
     it { should have_many(:organisation_users) }
     it { should have_many(:organisations).through(:organisation_users) }

--- a/spec/requests/api/v2/providers/courses/update_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_spec.rb
@@ -645,6 +645,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     let(:mailer_spy) { spy(course_update_email: mail_spy) }
     let(:findable) { build(:site_status, :findable) }
     let(:new) { build(:site_status, :new) }
+    let(:accredited_body) { create(:provider, :accredited_body) }
 
     let(:permitted_params) do
       [:age_range_in_years]
@@ -657,7 +658,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     end
 
     let(:user_notifications) do
-      create(:user_notification, user: user, provider: provider, course_update: true)
+      create(:user_notification, user: user, provider: accredited_body, course_update: true)
     end
 
     let(:update_course) do
@@ -680,6 +681,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
             age_range_in_years: "3_to_7",
             site_statuses: [findable],
             provider: provider,
+            accrediting_provider: accredited_body,
           )
         end
 

--- a/spec/services/courses/update_notification_service_spec.rb
+++ b/spec/services/courses/update_notification_service_spec.rb
@@ -17,7 +17,7 @@ describe Courses::UpdateNotificationService do
     create(
       :course,
       age_range_in_years: "3_to_7",
-      provider: provider,
+      accrediting_provider: provider,
     )
   end
   let(:findable) { build(:site_status, :findable) }
@@ -35,7 +35,7 @@ describe Courses::UpdateNotificationService do
         :course,
         age_range_in_years: "3_to_7",
         site_statuses: [findable],
-        provider: provider,
+        accrediting_provider: provider,
       )
     end
 
@@ -75,6 +75,14 @@ describe Courses::UpdateNotificationService do
                :accredited_body,
                organisations: [organisation],
                recruitment_cycle: recruitment_cycle)
+      end
+
+      let(:course) do
+        create(
+          :course,
+          age_range_in_years: "3_to_7",
+          provider: provider,
+        )
       end
 
       it "does not send a notification" do


### PR DESCRIPTION
### Context

Course updated emails don't appear to be being sent when a course is updated. Turns out we were checking notifiable users using the provider code rather than the accredited body code on the course so what was actually happening is that there would have been emails sent in some cases, just not to the correct users. This wasn't clear as we don't have many subscriptions and may explain why we didn't see this in user research when the same code was used.

### Changes proposed in this pull request

* Update the `UserNotificationService` to use the correct provider code when querying the users to be notified
* Remove the `User.notifiable_users` as the `User` model has enough to worry about. Move that logic into the service as it seems like the service that should be concerned with this relationship. This also makes it consistent with the `PublishService`. 

### Guidance to review

This fixes the bug that is blocking the feature being launched. There is a bit of tidy up needed of this code to get it consistent and sort all of the naming inconsistencies etc. There's a card for that so be gentle https://trello.com/c/zxFwsm2N/3458-rename-create-to-publish-throughout-the-notifications-code

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
