### PR TITLE
XXXX cache api docs for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,16 @@ FROM ruby:2.6.5-alpine AS middleman
 
 RUN apk add --update --no-cache npm git build-base
 
-ADD . .
+COPY docs/Gemfile docs/Gemfile.lock /
 
-RUN cd docs && bundle install --jobs=4 && bundle exec middleman build --build-dir=../public && cd -
+RUN bundle install --jobs=4
+
+COPY docs /docs
+COPY public /public
+COPY swagger /swagger
+
+WORKDIR docs
+RUN bundle exec middleman build --build-dir=../public
 
 ###
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,11 +13,13 @@ variables:
   imageNameBgMailer: 'teacher-training-bg-mailer'
   dockerOverride: 'docker-compose -f docker-compose.yml'
 
+
 steps:
 - script: |
     set -x
     GIT_SHORT_SHA=$(echo $(Build.SourceVersion) | cut -c 1-7)
     docker_path=$(dockerHubUsername)/$(imageName)
+    docker_middleman_path=$(dockerHubUsername)/$(imageName)-middleman
     docker_bg_geocode_path=$(dockerHubUsername)/$(imageNameBgGeoCode)
     docker_bg_mailer_path=$(dockerHubUsername)/$(imageNameBgMailer)
     set +x # We confuse VSTS if we trace these commands
@@ -30,22 +32,40 @@ steps:
 
 - script: |
     set -x
-    docker pull $(docker_path):latest || true
-  displayName: "Pull latest docker image to cache"
+    docker pull $(docker_path):$GIT_BRANCH || true
+    docker pull $(docker_path)-middleman:master || true
+  displayName: "Pull any existing images for this branch to cache"
+  # When this branch is first created, there won't be any images to cache, even though master
+  # would probably be an acceptable cache. We could improve build times by pulling master, and
+  # tagging it with the branch, locally.
+  env:
+    GIT_BRANCH: $(Build.SourceBranchName)
 - script: |
     set -x
+    $DOCKER_OVERRIDE build middleman
     $DOCKER_OVERRIDE build
-    $DOCKER_OVERRIDE up --no-build -d
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rails db:setup"
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "apk --no-cache add curl"
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake cc:setup"
-  displayName: 'Build & setup'
+  displayName: Build Docker Images
   env:
     DOCKER_OVERRIDE: $(dockerOverride)
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
+    GIT_BRANCH: $(Build.SourceBranchName)
+
+- script: |
+    set -x
+    $DOCKER_OVERRIDE up --no-build -d
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rails db:setup"
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "apk --no-cache add curl"
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake cc:setup"
+  displayName: Setup for Tests
+  env:
+    DOCKER_OVERRIDE: $(dockerOverride)
+    dockerHubUsername: $(dockerHubUsername)
+    dockerHubImageName: $(imageName)
+    CC_TEST_REPORTER_ID: $(ccReporterID)
+    GIT_BRANCH: $(Build.SourceBranchName)
 - script: |
     set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
@@ -58,6 +78,7 @@ steps:
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
+    GIT_BRANCH: $(Build.SourceBranchName)
 - task: PublishTestResults@2
   condition: succeededOrFailed()
   inputs:
@@ -73,6 +94,7 @@ steps:
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
+    GIT_BRANCH: $(Build.SourceBranchName)
 - script: |
     set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake cc:report"
@@ -83,6 +105,7 @@ steps:
     dockerHubImageName: $(imageName)
     CC_TEST_REPORTER_ID: $(ccReporterID)
     AGENT_JOBSTATUS: $(Agent.JobStatus)
+    GIT_BRANCH: $(Build.SourceBranchName)
 - script: |
     set -x
     $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake brakeman"
@@ -92,38 +115,50 @@ steps:
     dockerHubUsername: $(dockerHubUsername)
     dockerHubImageName: $(imageName)
     AGENT_JOBSTATUS: $(Agent.JobStatus)
-- task: Docker@1
-  displayName: Tag image with current build number $(Build.BuildNumber)
-  inputs:
-    command: Tag image
-    imageName: "$(docker_path):latest"
-    arguments: "$(docker_path):$(Build.BuildNumber)"
+    GIT_BRANCH: $(Build.SourceBranchName)
+
 - task: Docker@1
   displayName: Docker Hub login
   inputs:
     command: "login"
     containerregistrytype: Container Registry
     dockerRegistryEndpoint: DfE Docker Hub
+
 - task: Docker@1
-  displayName: Push tagged image
+  displayName: Push image $(dockerHubUsername)/$(imageName):$(Build.SourceBranchName)
   inputs:
     command: Push an image
-    imageName: "$(docker_path):$(Build.BuildNumber)"
+    imageName: "$(docker_path):$(Build.SourceBranchName)"
+
 - task: Docker@1
-  displayName: Push tagged image (latest) if master
+  displayName: Push image $(dockerHubUsername)/$(imageName)-middleman:$(Build.SourceBranchName)
   condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
   inputs:
     command: Push an image
-    imageName: "$(docker_path):latest"
+    imageName: "$(docker_path)-middleman:$(Build.SourceBranchName)"
+
+- task: Docker@1
+  displayName: Tag image with current build number $(Build.BuildNumber)
+  inputs:
+    command: Tag image
+    imageName: "$(docker_path):$(Build.SourceBranchName)"
+    arguments: "$(docker_path):$(Build.BuildNumber)"
+
+- task: Docker@1
+  displayName: Push api image for build number $(Build.BuildNumber)
+  inputs:
+    command: Push an image
+    imageName: "$(docker_path):$(Build.BuildNumber)"
+
 - task: Docker@1
   displayName: Tag bg_geocode image with current build number $(Build.BuildNumber)
   inputs:
     command: Tag image
-    imageName: "$(docker_bg_geocode_path):latest"
+    imageName: "$(docker_bg_geocode_path):$(Build.SourceBranchName)"
     arguments: "$(docker_bg_geocode_path):$(Build.BuildNumber)"
 
 - task: Docker@1
-  displayName: Push tagged image
+  displayName: Push bg_geocode image with current build number $(Build.BuildNumber)
   inputs:
     command: Push an image
     imageName: "$(docker_bg_geocode_path):$(Build.BuildNumber)"
@@ -132,11 +167,11 @@ steps:
   displayName: Tag bg_mailer image with current build number $(Build.BuildNumber)
   inputs:
     command: Tag image
-    imageName: "$(docker_bg_mailer_path):latest"
+    imageName: "$(docker_bg_mailer_path):$(Build.SourceBranchName)"
     arguments: "$(docker_bg_mailer_path):$(Build.BuildNumber)"
 
 - task: Docker@1
-  displayName: Push tagged image
+  displayName: Push bg_mailer image with current build number $(Build.BuildNumber)
   inputs:
     command: Push an image
     imageName: "$(docker_bg_mailer_path):$(Build.BuildNumber)"
@@ -149,6 +184,7 @@ steps:
      terraform/**
     TargetFolder: '$(build.artifactstagingdirectory)'
     OverWrite: true
+
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'
   inputs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.2'
+version: '3.4'
 volumes:
   dbdata:
 services:
@@ -9,12 +9,20 @@ services:
      - dbdata:/var/lib/postgresql/data
     environment:
     - POSTGRES_PASSWORD=developmentpassword
+  middleman:
+    build:
+      context: .
+      target: middleman
+      cache_from:
+        - ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:master
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:${GIT_BRANCH:-latest}
   web:
     build:
       context: .
       cache_from:
-        - ${dockerHubUsername:-dfedigital}/teacher-training-api:latest
-    image: ${dockerHubUsername:-dfedigital}/teacher-training-api:latest
+        - ${dockerHubUsername:-dfedigital}/teacher-training-api:${GIT_BRANCH:-latest}
+        - ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:${GIT_BRANCH:-latest}
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-api:${GIT_BRANCH:-latest}
     command: ash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3001 -b '0.0.0.0'"
     volumes:
       - .:/app
@@ -22,6 +30,7 @@ services:
       - "3001:3001"
     depends_on:
       - db
+      - middleman
     environment:
       - DB_HOSTNAME=db
       - DB_USERNAME=postgres
@@ -35,8 +44,8 @@ services:
         - TEACHER_TRAINING_API=${dockerHubImageName:-teacher-training-api}
       context: bg-geocode
       cache_from:
-        - ${dockerHubUsername:-dfedigital}/teacher-training-bg-geocode:latest
-    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-geocode:latest
+        - ${dockerHubUsername:-dfedigital}/teacher-training-bg-geocode:${GIT_BRANCH:-latest}
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-geocode:${GIT_BRANCH:-latest}
     volumes:
       - .:/app
     depends_on:
@@ -55,8 +64,8 @@ services:
         - TEACHER_TRAINING_API=${dockerHubImageName:-teacher-training-api}
       context: bg-mailer
       cache_from:
-        - ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:latest
-    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:latest
+        - ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:${GIT_BRANCH:-latest}
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-mailer:${GIT_BRANCH:-latest}
     volumes:
       - .:/app
     depends_on:


### PR DESCRIPTION
### Context

Teacher training API builds are slow.

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/15608/83316359-4e527700-a21d-11ea-82e6-7987365be3a9.png">

### Changes proposed in this pull request

Make builds faster by building branch-specific images and ensuring we use them in the docker cache.

A few more details about what's changed:

- We build an image for the `middleman` stage separately and push it up to docker-hub.
- We pull down the `middleman` image before each build and try to cache from it it.
- Don't tag either images, `api` or `middleman`, as `latest` anymore, but instead:
- Tag `api` and `middleman` images with the branch name and push/pull them to dockerhub so we're more likely to be able to reuse them next build.

### Guidance to review

Makes builds faster.

<img width="1227" alt="image" src="https://user-images.githubusercontent.com/15608/83316378-60341a00-a21d-11ea-90b7-67dbf5dbab70.png">

Oh, and ya, I'll squash this mess back together.