### PR TITLE
[3417] don't validate courses when rolling over

### DIFF
--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -17,7 +17,7 @@ module Courses
         new_course.applications_open_from = course.applications_open_from + year_differential.year
         new_course.start_date = course.start_date + year_differential.year
         new_course.subjects = course.subjects
-        new_course.save!
+        new_course.save!(validate: false)
 
         copy_latest_enrichment_to_course(course, new_course)
 

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -47,7 +47,7 @@ module Providers
       provider.courses.each do |course|
         new_course = @copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
         courses_count += 1 if new_course.present?
-      rescue
+      rescue Exception # rubocop: disable Lint/RescueException
         logger.fatal "error trying to copy course #{course.course_code}" if logger
         raise
       end

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -5,7 +5,7 @@ module Providers
     def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
-      @logger = logger
+      @logger = logger || Logger.new("/dev/null")
     end
 
     def execute(provider:, new_recruitment_cycle:)

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -1,8 +1,11 @@
 module Providers
   class CopyToRecruitmentCycleService
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:)
+    attr :logger
+
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
+      @logger = logger
     end
 
     def execute(provider:, new_recruitment_cycle:)
@@ -44,6 +47,9 @@ module Providers
       provider.courses.each do |course|
         new_course = @copy_course_to_provider_service.execute(course: course, new_provider: new_provider)
         courses_count += 1 if new_course.present?
+      rescue
+        logger.fatal "error trying to copy course #{course.course_code}" if logger
+        raise
       end
 
       courses_count

--- a/lib/mcb/commands/providers/rollover.rb
+++ b/lib/mcb/commands/providers/rollover.rb
@@ -27,6 +27,7 @@ run do |opts, args, _cmd| # rubocop:disable Metrics/BlockLength
           copy_provider_to_recruitment_cycle = Providers::CopyToRecruitmentCycleService.new(
             copy_course_to_provider_service: copy_courses_to_provider_service,
             copy_site_to_provider_service: Sites::CopyToProviderService.new,
+            logger: Logger.new(STDOUT),
           )
 
           counts = copy_provider_to_recruitment_cycle.execute(

--- a/spec/mcb_helper.rb
+++ b/spec/mcb_helper.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 load "bin/mcb"
 
 def audit_user_tag(example)

--- a/spec/mcb_helper.rb
+++ b/spec/mcb_helper.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require "spec_helper"
 
 load "bin/mcb"
 

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe Courses::CopyToProviderService do
     expect(mocked_enrichments_copy_to_course_service).to_not have_received(:execute)
   end
 
+  it "saves without doing validations" do
+    course_dup = instance_spy(Course, recruitment_cycle: recruitment_cycle)
+    allow(course).to receive(:dup).and_return(course_dup)
+
+    service.execute(course: course, new_provider: new_provider)
+
+    expect(course_dup).to have_received(:save!).with(validate: false)
+  end
+
   context "when a published enrichment exists" do
     let!(:old_published_enrichment) do
       create :course_enrichment, :published, last_published_timestamp_utc: 10.days.ago, course: course

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -59,6 +59,25 @@ describe Providers::CopyToRecruitmentCycleService do
       expect(recruitment_cycle.reload.providers).to eq [provider]
     end
 
+    context "an error occurs when copying the course" do
+      it "logs a useful message to the provided logger" do
+        log_output = StringIO.new
+        logger = Logger.new(log_output)
+        service = described_class.new(
+          copy_course_to_provider_service: mocked_copy_course_service,
+          copy_site_to_provider_service: mocked_copy_site_service,
+          logger: logger,
+        )
+        allow(mocked_copy_course_service).to receive(:execute).and_raise("Nope")
+
+        expect {
+          service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+        }.to raise_error("Nope")
+
+        expect(log_output.string).to include "error trying to copy course #{course.course_code}"
+      end
+    end
+
     context "the provider already exists in the new recruitment cycle" do
       let(:new_provider) {
         build :provider, provider_code: provider.provider_code


### PR DESCRIPTION
This may seem counter-intuitive, but it seems that our courses aren't all valid
at the current time, for example the "age_range_in_years" is nil on a bunch of
courses, but is validated as being present on new/create. We should fix this,
but for the time being we just need to duplicate the broken-ness.

This change also adds a little extra info when an error is raised to know which
course code was being processed at the time of the error.

### Context

When testing rollover locally, we got the error that a course was invalid pretty early on in the process.

### Changes proposed in this pull request

Be messy and don't validate a course before saving. It seems that last year's rollover also didn't validate courses, and that the `save!` was added as part of the refactoring later in PR #726.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
