### PR TITLE
[3466] Add extra endpoint to show a provider

### DIFF
--- a/app/controllers/api/v2/application_controller.rb
+++ b/app/controllers/api/v2/application_controller.rb
@@ -23,7 +23,7 @@ module API
     private
 
       def check_terms_accepted
-        return if @current_user&.accept_terms_date_utc.present?
+        return if current_user&.accept_terms_date_utc.present?
 
         error_body = {
           errors: [

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -3,7 +3,7 @@ module API
     class ProvidersController < API::V2::ApplicationController
       before_action :get_user, if: -> { params[:user_id].present? }
       before_action :build_recruitment_cycle
-      before_action :build_provider, except: %i[index suggest]
+      before_action :build_provider, except: %i[index suggest suggest_any]
 
       deserializable_resource :provider,
                               only: :update,
@@ -63,6 +63,23 @@ module API
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         found_providers = policy_scope(@recruitment_cycle.providers)
+          .search_by_code_or_name(params[:query])
+          .limit(5)
+
+        render(
+          jsonapi: found_providers,
+          class: { Provider: SerializableProviderSuggestion },
+        )
+      end
+
+      # Suggest any provider from the current recruitment cycle
+      def suggest_any
+        authorize Provider
+
+        return render(status: :bad_request) if params[:query].nil? || params[:query].length < 2
+        return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
+
+        found_providers = @recruitment_cycle.providers
           .search_by_code_or_name(params[:query])
           .limit(5)
 

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -33,6 +33,14 @@ module API
         render jsonapi: @provider, include: params[:include]
       end
 
+      # This endpoint ignores the policy and allows anyone to see the provider
+      # This used by allocations, as any training provider can be used
+      def show_any
+        authorize @provider, :show_any?
+
+        render jsonapi: @provider, include: params[:include]
+      end
+
       def update
         authorize @provider, :update?
 

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -31,6 +31,10 @@ class ProviderPolicy
     user.admin? || user.providers.include?(provider)
   end
 
+  def show_any?
+    user.present?
+  end
+
   def create?
     user.admin?
   end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -43,6 +43,10 @@ class ProviderPolicy
     user.present?
   end
 
+  def suggest_any?
+    user.present?
+  end
+
   alias_method :can_list_sites?, :show?
   alias_method :can_create_course?, :show?
   alias_method :update?, :show?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       end
 
       get "providers/suggest", to: "providers#suggest"
+      get "providers/suggest_any", to: "providers#suggest_any"
       get "/recruitment_cycles/:recruitment_cycle_year/providers/suggest", to: "providers#suggest"
 
       resources :organisations, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
         resources :allocations, only: %i[create index]
       end
 
-      resources :allocations, only: %i(show update destroy)
+      resources :allocations, only: %i[show update destroy]
 
       resources :recruitment_cycles,
                 only: %i[index show],
@@ -65,6 +65,9 @@ Rails.application.routes.draw do
                   only: %i[index show update],
                   param: :code,
                   concerns: :provider_routes do
+          member do
+            get :show_any
+          end
         end
 
         get "/courses", to: "courses#index"

--- a/spec/controllers/api/v2/providers_controller_spec.rb
+++ b/spec/controllers/api/v2/providers_controller_spec.rb
@@ -23,4 +23,18 @@ RSpec.describe API::V2::ProvidersController do
       end
     end
   end
+
+  describe "#suggest_any" do
+    context "when any provider uses endpoint" do
+      let(:user) { provider.users.first }
+      let!(:provider) { create(:provider) }
+      let(:course) { create(:course) }
+      let!(:other_provider) { course.provider }
+
+      it "returns the specified provider" do
+        get :suggest_any, params: { query: other_provider.provider_code }
+        expect(JSON.parse(response.body).dig("data").map { |p| p["id"] }).to eql([other_provider.id.to_s])
+      end
+    end
+  end
 end

--- a/spec/controllers/api/v2/providers_controller_spec.rb
+++ b/spec/controllers/api/v2/providers_controller_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe API::V2::ProvidersController do
+  before :each do
+    allow(controller).to receive(:authenticate).and_return(true)
+    allow(controller).to receive(:current_user).and_return(user)
+  end
+
+  describe "#show_any" do
+    context "when any provider uses endpoint" do
+      let(:user) { provider.users.first }
+      let(:provider) { create(:provider) }
+      let(:course) { create(:course) }
+      let(:other_provider) { course.provider }
+
+      it "returns the specified provider" do
+        get :show_any, params: {
+          code: other_provider.provider_code,
+          recruitment_cycle_year: other_provider.recruitment_cycle.year,
+        }
+
+        expect(JSON.parse(response.body).dig("data", "id").to_i).to eql(other_provider.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/QpRrdwxL/3466-pre-launch-task-make-accredited-bodies-able-to-see-allocation-pages
- We don't want accredited bodies to see training providers under normal circumstances but sometimes we do. This adds another endpoint to allow for this
- This is needed for the allocation work so accredited bodies can access any training provider
- There is also another endpoint for suggestions so allocations autocomplete can search for any provider

### Changes proposed in this pull request

- Additional endpoint for provider lookup
- This additional endpoint is identical to the show endpoint
- It uses a different policy
- The policy allows anyone to see any provider
- The additional endpoint was added instead of the policy of the #show
endpoint modified so on the client side a accredited body could not see
a training providers details under "normal" use cases which is desired
- This endpoint was added for the allocations work as it is possible for
an allocation to be associated with any provider

#### Suggestion endpoint

- Add endpoint for any provider suggestion
- This additional endpoint is identical to the suggest endpoint
- It uses a different policy
- The policy allows anyone to suggest any provider for the current cycle
- This endpoint was added for the allocations work so it is possible for
an allocation find any provider for autocomplete purposes

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
