### PR TITLE
3457 s add allocations information to reporting endpoint

### DIFF
--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -5,6 +5,7 @@ class RecruitmentCycle < ApplicationRecord
   # a site to a new recruitment_cycle
   has_many :courses, through: :providers
   has_many :sites, through: :providers
+  has_many :allocations
 
   validates :year, presence: true
 

--- a/app/services/allocation_reporting_service.rb
+++ b/app/services/allocation_reporting_service.rb
@@ -1,0 +1,36 @@
+class AllocationReportingService
+  def initialize(recruitment_cycle_scope: RecruitmentCycle)
+    @current = recruitment_cycle_scope
+    @previous = recruitment_cycle_scope.previous
+  end
+
+  class << self
+    def call(recruitment_cycle_scope:)
+      new(recruitment_cycle_scope: recruitment_cycle_scope).call
+    end
+  end
+
+  def call
+    {
+      previous: reporting(recruitment_cycle: @previous),
+      current: reporting(recruitment_cycle: @current),
+    }
+  end
+
+  private_class_method :new
+
+private
+
+  def reporting(recruitment_cycle: RecruitmentCycle)
+    requested_allocations = recruitment_cycle.allocations.not_declined
+    distinct_requested_allocations = requested_allocations.distinct
+    {
+      total: {
+        allocations: requested_allocations.count,
+        distinct_accredited_bodies: distinct_requested_allocations.select(:accredited_body_id).count,
+        distinct_providers: distinct_requested_allocations.select(:provider_id).count,
+        number_of_places: requested_allocations.sum(:number_of_places),
+      },
+    }
+  end
+end

--- a/app/services/statistic_service.rb
+++ b/app/services/statistic_service.rb
@@ -4,6 +4,7 @@ class StatisticService
       providers: ProviderReportingService.call(providers_scope: recruitment_cycle.providers),
       courses: CourseReportingService.call(courses_scope: recruitment_cycle.courses),
       publish: PublishReportingService.call(recruitment_cycle_scope: recruitment_cycle),
+      allocation: AllocationReportingService.call(recruitment_cycle_scope: recruitment_cycle),
     }
   end
 

--- a/app/services/statistic_service.rb
+++ b/app/services/statistic_service.rb
@@ -4,7 +4,7 @@ class StatisticService
       providers: ProviderReportingService.call(providers_scope: recruitment_cycle.providers),
       courses: CourseReportingService.call(courses_scope: recruitment_cycle.courses),
       publish: PublishReportingService.call(recruitment_cycle_scope: recruitment_cycle),
-      allocation: AllocationReportingService.call(recruitment_cycle_scope: recruitment_cycle),
+      allocations: AllocationReportingService.call(recruitment_cycle_scope: recruitment_cycle),
     }
   end
 

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -114,7 +114,7 @@ describe "GET /reporting" do
         },
         is_send: {
           open: { yes: 0, no: 0 },
-          closed:  { yes: 0, no: 0 },
+          closed: { yes: 0, no: 0 },
         },
         subject: {
           open: Subject.active.each_with_index.map { |sub, _i| x = {}; x[sub.subject_name] = 0; x }.reduce({}, :merge),
@@ -150,11 +150,35 @@ describe "GET /reporting" do
           updated_closed_courses_recently: 0,
           created_recently: 0,
         },
+
+        allocation: {
+          previous: {
+            total: {
+              allocations: 0,
+              distinct_accredited_bodies: 0,
+              distinct_providers: 0,
+              number_of_places:  0,
+            },
+          },
+          current: {
+            total: {
+              allocations: 0,
+              distinct_accredited_bodies: 0,
+              distinct_providers: 0,
+              number_of_places:  0,
+            },
+          },
+        },
       },
     }.with_indifferent_access
   end
 
+  let(:previous_recruitment_cycle) {
+    find_or_create(:recruitment_cycle, :previous)
+  }
+
   it "returns status success" do
+    previous_recruitment_cycle
     get "/reporting"
     expect(response.status).to eq(200)
     expect(JSON.parse(response.body)).to eq(expected)

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -150,23 +150,22 @@ describe "GET /reporting" do
           updated_closed_courses_recently: 0,
           created_recently: 0,
         },
-
-        allocation: {
-          previous: {
-            total: {
-              allocations: 0,
-              distinct_accredited_bodies: 0,
-              distinct_providers: 0,
-              number_of_places:  0,
-            },
+      },
+      allocations: {
+        previous: {
+          total: {
+            allocations: 0,
+            distinct_accredited_bodies: 0,
+            distinct_providers: 0,
+            number_of_places:  0,
           },
-          current: {
-            total: {
-              allocations: 0,
-              distinct_accredited_bodies: 0,
-              distinct_providers: 0,
-              number_of_places:  0,
-            },
+        },
+        current: {
+          total: {
+            allocations: 0,
+            distinct_accredited_bodies: 0,
+            distinct_providers: 0,
+            number_of_places:  0,
           },
         },
       },

--- a/spec/services/allocation_reporting_service_spec.rb
+++ b/spec/services/allocation_reporting_service_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+describe AllocationReportingService do
+  let(:previous) do
+    {
+      total: {
+        allocations: 666,
+        distinct_accredited_bodies: 321,
+        distinct_providers: 222,
+        number_of_places: 6666,
+      },
+    }
+  end
+
+  let(:current) do
+    {
+      total: {
+         allocations: 999,
+         distinct_accredited_bodies: 123,
+         distinct_providers: 333,
+         number_of_places: 9999,
+      },
+    }
+  end
+
+  let(:expected) do
+    {
+      previous: previous,
+      current: current,
+    }
+  end
+
+  let(:recruitment_cycle_scope) { instance_double(RecruitmentCycle) }
+
+  let(:current_recruitment_cycle_scope) { recruitment_cycle_scope }
+  let(:previous_recruitment_cycle_scope) { instance_double(RecruitmentCycle) }
+
+  let(:current_requested_allocations_scope) { class_double(Allocation) }
+  let(:previous_requested_allocations_scope) { class_double(Allocation) }
+
+  let(:current_distinct_requested_allocations_scope) { class_double(Allocation) }
+  let(:previous_distinct_requested_allocations_scope) { class_double(Allocation) }
+
+  let(:current_distinct_accredited_bodies_scope) { class_double(Allocation) }
+  let(:previous_distinct_accredited_bodies_scope) { class_double(Allocation) }
+
+  let(:current_distinct_providers_scope) { class_double(Allocation) }
+  let(:previous_distinct_providers_scope) { class_double(Allocation) }
+
+  describe ".call" do
+    describe "when scope is passed" do
+      subject { described_class.call(recruitment_cycle_scope: recruitment_cycle_scope) }
+
+      it "applies the scopes" do
+        expect(recruitment_cycle_scope).to receive_message_chain(:previous).and_return(previous_recruitment_cycle_scope)
+
+        expect(current_recruitment_cycle_scope).to receive_message_chain(:allocations, :not_declined).and_return(current_requested_allocations_scope)
+        expect(previous_recruitment_cycle_scope).to receive_message_chain(:allocations, :not_declined).and_return(previous_requested_allocations_scope)
+
+        expect(current_requested_allocations_scope).to receive_message_chain(:count).and_return(999)
+        expect(previous_requested_allocations_scope).to receive_message_chain(:count).and_return(666)
+
+        expect(current_requested_allocations_scope).to receive_message_chain(:distinct).and_return(current_distinct_requested_allocations_scope)
+        expect(previous_requested_allocations_scope).to receive_message_chain(:distinct).and_return(previous_distinct_requested_allocations_scope)
+
+        expect(current_distinct_requested_allocations_scope).to receive_message_chain(:select).with(:accredited_body_id).and_return(current_distinct_accredited_bodies_scope)
+        expect(previous_distinct_requested_allocations_scope).to receive_message_chain(:select).with(:accredited_body_id).and_return(previous_distinct_accredited_bodies_scope)
+
+        expect(current_distinct_accredited_bodies_scope).to receive_message_chain(:count).and_return(123)
+        expect(previous_distinct_accredited_bodies_scope).to receive_message_chain(:count).and_return(321)
+
+        expect(current_distinct_requested_allocations_scope).to receive_message_chain(:select).with(:provider_id).and_return(current_distinct_providers_scope)
+        expect(previous_distinct_requested_allocations_scope).to receive_message_chain(:select).with(:provider_id).and_return(previous_distinct_providers_scope)
+
+        expect(current_distinct_providers_scope).to receive_message_chain(:count).and_return(333)
+        expect(previous_distinct_providers_scope).to receive_message_chain(:count).and_return(222)
+
+        expect(current_requested_allocations_scope).to receive_message_chain(:sum).with(:number_of_places).and_return(9999)
+        expect(previous_requested_allocations_scope).to receive_message_chain(:sum).with(:number_of_places).and_return(6666)
+
+        expect(subject).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/services/statistic_service_spec.rb
+++ b/spec/services/statistic_service_spec.rb
@@ -1,7 +1,8 @@
 describe StatisticService do
-  describe "#reporting" do
-    let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
+  let!(:previous_recruitment_cycle) { find_or_create(:recruitment_cycle, :previous) }
 
+  describe "#reporting" do
     subject { described_class.reporting(recruitment_cycle: recruitment_cycle) }
 
     it "calls the provider reporting service" do

--- a/spec/services/statistic_service_spec.rb
+++ b/spec/services/statistic_service_spec.rb
@@ -18,6 +18,11 @@ describe StatisticService do
       expect(PublishReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
       subject
     end
+
+    it "calls the allocation reporting service" do
+      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      subject
+    end
   end
 
   describe "#save" do
@@ -41,6 +46,11 @@ describe StatisticService do
 
     it "calls the publish reporting service" do
       expect(PublishReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      subject
+    end
+
+    it "calls the allocation reporting service" do
+      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
       subject
     end
   end


### PR DESCRIPTION
### Context
Allocations informations

### Changes proposed in this pull request
Added allocations informations to reporting endpoint

### Guidance to review

http://localhost:3001/reporting

```json

{
  "providers": {...},
  "courses": {...},
  "publish": {...},
  "allocation": {
    "previous": {
      "total": {
        "allocations": 433,
        "distinct_accredited_bodies": 153,
        "distinct_providers": 397,
        "number_of_places": 1461
      }
    },
    "current": {
      "total": {
        "allocations": 0,
        "distinct_accredited_bodies": 0,
        "distinct_providers": 0,
        "number_of_places": 0
      }
    }
  }
}

```

These stats are only as accurate, if it remains the source of truth, as when an `allocation request` is made it will later be confirmed which results in the `number of places` subjected to amendments beyond current boundaries.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
