### PR TITLE
[3456] Update user notifications when accredited body changes

### DIFF
--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -1,0 +1,38 @@
+module UserAssociationsService
+  class Create
+    attr_reader :organisation, :user
+
+    class << self
+      def call(**args)
+        new(args).call
+      end
+    end
+
+    def initialize(organisation:, user:)
+      @organisation = organisation
+      @user = user
+    end
+
+    def call
+      add_user_to_organistation
+      update_user_notification_preferences
+    end
+
+    private_class_method :new
+
+  private
+
+    def add_user_to_organistation
+      organisation.add_user(user)
+    end
+
+    def update_user_notification_preferences
+      user_notification_preferences = UserNotificationPreferences.new(user_id: user.id)
+      return if user_notification_preferences.updated_at.nil?
+
+      user_notification_preferences.update(
+        enable_notifications: user_notification_preferences.enabled,
+      )
+    end
+  end
+end

--- a/app/services/user_associations_service/create.rb
+++ b/app/services/user_associations_service/create.rb
@@ -1,6 +1,6 @@
 module UserAssociationsService
   class Create
-    attr_reader :organisation, :user
+    attr_reader :organisation, :user, :all_organisations
 
     class << self
       def call(**args)
@@ -8,13 +8,14 @@ module UserAssociationsService
       end
     end
 
-    def initialize(organisation:, user:)
+    def initialize(user:, organisation: nil, all_organisations: false)
       @organisation = organisation
       @user = user
+      @all_organisations = all_organisations
     end
 
     def call
-      add_user_to_organistation
+      add_user_to_organistations
       update_user_notification_preferences
     end
 
@@ -22,8 +23,20 @@ module UserAssociationsService
 
   private
 
-    def add_user_to_organistation
+    def add_user_to_organistations
+      if all_organisations
+        add_user_to_all_organistations
+      else
+        add_user_to_a_single_organistation
+      end
+    end
+
+    def add_user_to_a_single_organistation
       organisation.add_user(user)
+    end
+
+    def add_user_to_all_organistations
+      user.organisations = Organisation.all
     end
 
     def update_user_notification_preferences

--- a/app/services/user_associations_service/delete.rb
+++ b/app/services/user_associations_service/delete.rb
@@ -1,0 +1,38 @@
+module UserAssociationsService
+  class Delete
+    attr_reader :user, :organisations
+
+    class << self
+      def call(**args)
+        new(args).call
+      end
+    end
+
+    def initialize(user:, organisations:)
+      @organisations = organisations
+      @user = user
+    end
+
+    def call
+      remove_access
+      update_user_notification_preferences
+    end
+
+    private_class_method :new
+
+  private
+
+    def remove_access
+      user.remove_access_to(organisations)
+    end
+
+    def update_user_notification_preferences
+      user_notification_preferences = UserNotificationPreferences.new(user_id: user.id)
+      return if user_notification_preferences.updated_at.nil?
+
+      user_notification_preferences.update(
+        enable_notifications: user_notification_preferences.enabled,
+      )
+    end
+  end
+end

--- a/lib/mcb/editor/grant_access_wizard.rb
+++ b/lib/mcb/editor/grant_access_wizard.rb
@@ -88,7 +88,7 @@ module MCB
         puts "\n"
         puts "You're about to give #{@user_to_grant} access to organisation #{@organisation.name}. They will manage:"
         puts MCB::Render::ActiveRecord.providers_table @organisation.providers, name: "Additional Providers"
-        @organisation.add_user(@user_to_grant) if @cli.agree("Agree?  ")
+        UserAssociationsService::Create.call(organisation: @organisation, user: @user_to_grant) if @cli.agree("Agree?  ")
       end
 
       def add_user_to_all_organisations

--- a/lib/mcb/editor/grant_access_wizard.rb
+++ b/lib/mcb/editor/grant_access_wizard.rb
@@ -92,7 +92,7 @@ module MCB
       end
 
       def add_user_to_all_organisations
-        @user_to_grant.organisations = Organisation.all
+        UserAssociationsService::Create.call(user: @user_to_grant, all_organisations: true)
 
         puts "\n"
         puts "#{@user_to_grant} given access to all orgs"

--- a/lib/mcb/editor/revoke_access_wizard.rb
+++ b/lib/mcb/editor/revoke_access_wizard.rb
@@ -45,7 +45,7 @@ module MCB
             return
           end
 
-          @user.remove_access_to @organisations
+          UserAssociationsService::Delete.call(user: @user, organisations: @organisations)
         else
           puts "#{@user.email} already has no access to #{@provider}"
         end

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -2,77 +2,147 @@ require "rails_helper"
 
 RSpec.describe UserAssociationsService::Create do
   let(:user) { create :user }
-  let(:accredited_body) { create(:provider, :accredited_body) }
-  let(:organisation) { create(:organisation, users: [user], providers: [accredited_body]) }
-
-  let(:new_accredited_body) { create(:provider, :accredited_body) }
-  let(:new_organisation) { create(:organisation, providers: [new_accredited_body]) }
-
-  subject do
-    described_class.call(
-      organisation: new_organisation,
-      user: user,
-    )
-  end
 
   describe "#call" do
-    context "when user have saved notification prefernces" do
-      let(:user_notification) do
-        create(
-          :user_notification,
+    context "when adding to a single organsation" do
+      let(:accredited_body) { create(:provider, :accredited_body) }
+      let(:organisation) { create(:organisation, users: [user], providers: [accredited_body]) }
+
+      let(:new_accredited_body) { create(:provider, :accredited_body) }
+      let(:new_organisation) { create(:organisation, providers: [new_accredited_body]) }
+
+      subject do
+        described_class.call(
+          organisation: new_organisation,
           user: user,
-          provider: accredited_body,
-          course_publish: true,
-          course_update: true,
         )
       end
 
-      let(:new_user_notification) do
-        create(
-          :user_notification,
-          user: user,
-          provider: new_accredited_body,
-          course_publish: true,
-          course_update: true,
-        )
+      context "when user have saved notification preferences" do
+        let(:user_notification) do
+          create(
+            :user_notification,
+            user: user,
+            provider: accredited_body,
+            course_publish: true,
+            course_update: true,
+          )
+        end
+
+        let(:new_user_notification) do
+          create(
+            :user_notification,
+            user: user,
+            provider: new_accredited_body,
+            course_publish: true,
+            course_update: true,
+          )
+        end
+
+        before do
+          organisation
+          user_notification
+        end
+
+        it "creates organisation_users association" do
+          subject
+
+          expect(new_organisation.users).to eq([user])
+          expect(user.organisations).to include(organisation, new_organisation)
+        end
+
+        it "creates user_notifications association with the previous enabled value" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(2)
+          expect(UserNotification.where(user_id: user.id)).to include(new_user_notification)
+        end
       end
 
-      before do
-        organisation
-        user_notification
-      end
+      context "when user has never set notification preferences" do
+        before do
+          organisation
+        end
 
-      it "creates organisation_users association" do
-        subject
+        it "creates organisation_users association" do
+          subject
 
-        expect(new_organisation.users).to eq([user])
-        expect(user.organisations).to include(organisation, new_organisation)
-      end
+          expect(new_organisation.users).to eq([user])
+          expect(user.organisations).to include(organisation, new_organisation)
+        end
 
-      it "creates user_notifications association with the previous enabled value" do
-        subject
+        it "doesn't create user_notifications association" do
+          subject
 
-        expect(UserNotification.where(user_id: user.id).count).to eq(2)
-        expect(UserNotification.where(user_id: user.id)).to include(new_user_notification)
+          expect(UserNotification.where(user_id: user.id).count).to eq(0)
+        end
       end
     end
 
-    context "when user has never set notification prefernces" do
+    context "when adding to all organsations" do
+      subject do
+        described_class.call(
+          user: user,
+          all_organisations: true,
+        )
+      end
+
+      let(:accredited_body) { create(:provider, :accredited_body) }
+      let(:organisation1) do
+        create(:organisation,
+               providers: [accredited_body])
+      end
+
+      let(:organisation2) do
+        create(:organisation,
+               providers: [create(:provider, :accredited_body)])
+      end
+
       before do
-        organisation
+        organisation1
+        organisation2
       end
 
-      it "creates organisation_users association" do
-        subject
+      context "when user have saved notification preferences" do
+        let(:user_notification) do
+          create(
+            :user_notification,
+            user: user,
+            provider: accredited_body,
+            course_publish: true,
+            course_update: true,
+          )
+        end
 
-        expect(new_organisation.users).to eq([user])
-        expect(user.organisations).to include(organisation, new_organisation)
+        before do
+          user_notification
+        end
+
+        it "creates organisation_users association" do
+          subject
+
+          expect(user.organisations).to match_array(Organisation.all)
+        end
+
+        it "creates user_notifications association for all user's accredited bodies" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(2)
+        end
       end
 
-      it "doesn't create user_notifications association" do
-        subject
+      context "when user has never set notification preferences" do
+        it "creates organisation_users association" do
+          subject
 
-        expect(UserNotification.where(user_id: user.id).count).to eq(0)
+          expect(user.organisations).to match_array(Organisation.all)
+        end
+
+        it "doesn't create user_notifications association" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(0)
+        end
       end
     end
   end

--- a/spec/services/user_associations_service/create_spec.rb
+++ b/spec/services/user_associations_service/create_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe UserAssociationsService::Create do
+  let(:user) { create :user }
+  let(:accredited_body) { create(:provider, :accredited_body) }
+  let(:organisation) { create(:organisation, users: [user], providers: [accredited_body]) }
+
+  let(:new_accredited_body) { create(:provider, :accredited_body) }
+  let(:new_organisation) { create(:organisation, providers: [new_accredited_body]) }
+
+  subject do
+    described_class.call(
+      organisation: new_organisation,
+      user: user,
+    )
+  end
+
+  describe "#call" do
+    context "when user have saved notification prefernces" do
+      let(:user_notification) do
+        create(
+          :user_notification,
+          user: user,
+          provider: accredited_body,
+          course_publish: true,
+          course_update: true,
+        )
+      end
+
+      let(:new_user_notification) do
+        create(
+          :user_notification,
+          user: user,
+          provider: new_accredited_body,
+          course_publish: true,
+          course_update: true,
+        )
+      end
+
+      before do
+        organisation
+        user_notification
+      end
+
+      it "creates organisation_users association" do
+        subject
+
+        expect(new_organisation.users).to eq([user])
+        expect(user.organisations).to include(organisation, new_organisation)
+      end
+
+      it "creates user_notifications association with the previous enabled value" do
+        subject
+
+        expect(UserNotification.where(user_id: user.id).count).to eq(2)
+        expect(UserNotification.where(user_id: user.id)).to include(new_user_notification)
+      end
+    end
+
+    context "when user has never set notification prefernces" do
+      before do
+        organisation
+      end
+
+      it "creates organisation_users association" do
+        subject
+
+        expect(new_organisation.users).to eq([user])
+        expect(user.organisations).to include(organisation, new_organisation)
+      end
+
+      it "doesn't create user_notifications association" do
+        subject
+
+        expect(UserNotification.where(user_id: user.id).count).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/services/user_associations_service/delete_spec.rb
+++ b/spec/services/user_associations_service/delete_spec.rb
@@ -1,0 +1,140 @@
+require "rails_helper"
+
+RSpec.describe UserAssociationsService::Delete do
+  let(:user) { create :user }
+
+  let(:accredited_body1) { create(:provider, :accredited_body) }
+  let(:organisation1) { create(:organisation, users: [user], providers: [accredited_body1]) }
+
+  let(:accredited_body2) { create(:provider, :accredited_body) }
+  let(:organisation2) { create(:organisation, users: [user], providers: [accredited_body2]) }
+
+  let(:user_notification1) do
+    create(
+      :user_notification,
+      user: user,
+      provider: accredited_body1,
+      course_publish: true,
+      course_update: true,
+    )
+  end
+
+  let(:user_notification2) do
+    create(
+      :user_notification,
+      user: user,
+      provider: accredited_body2,
+      course_publish: true,
+      course_update: true,
+    )
+  end
+
+  describe "#call" do
+    context "when removing access to a single organsation" do
+      subject do
+        described_class.call(
+          user: user,
+          organisations: organisation1,
+        )
+      end
+
+      before do
+        organisation1
+        organisation2
+      end
+
+      context "when user have saved notification preferences" do
+        before do
+          user_notification1
+          user_notification2
+        end
+
+        it "removes organisation_users association" do
+          subject
+
+          organisation1.reload
+          expect(organisation1.users).not_to include(user)
+          expect(user.organisations).not_to include(organisation1)
+        end
+
+        it "removes user_notifications association for providers within the organisation" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(1)
+          expect(UserNotification.where(user_id: user.id)).not_to include(user_notification1)
+        end
+      end
+
+      context "when user has never set notification preferences" do
+        it "removes organisation_users association" do
+          subject
+
+          organisation1.reload
+          expect(organisation1.users).not_to include(user)
+          expect(user.organisations).not_to include(organisation1)
+        end
+
+        it "doesn't update user_notifications association" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(0)
+        end
+      end
+    end
+
+    context "when removing access to multiple organsations" do
+      subject do
+        described_class.call(
+          user: user,
+          organisations: [organisation1, organisation2],
+        )
+      end
+
+      before do
+        organisation1
+        organisation2
+      end
+
+      let(:accredited_body3) { create(:provider, :accredited_body) }
+      let(:organisation3) { create(:organisation, users: [user], providers: [accredited_body3]) }
+
+      let(:user_notification3) do
+        create(
+          :user_notification,
+          user: user,
+          provider: accredited_body3,
+          course_publish: true,
+          course_update: true,
+        )
+      end
+
+      context "when user have saved notification preferences" do
+        before do
+          organisation3
+
+          user_notification1
+          user_notification2
+          user_notification3
+        end
+
+        it "removes organisation_users associations" do
+          subject
+
+          expect(user.organisations).not_to include(organisation1, organisation2)
+          organisation1.reload
+          expect(organisation1.users).not_to include(user)
+          organisation2.reload
+          expect(organisation2.users).not_to include(user)
+        end
+
+        it "removes user_notifications only for providers within the removed organisations" do
+          subject
+
+          expect(UserNotification.where(user_id: user.id).count).to eq(1)
+          expect(UserNotification.where(user_id: user.id).first.provider_code)
+            .to eq(accredited_body3.provider_code)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
A user's notification preferences are stored with one record (`UserNotification`) per accredited body. If the user is associated with a new accredited body and they have existing preferences stored we need to add a record for the new accredited body with the same preferences.

The opposite process also needs to take place if they are removed from an accredited body.

### Changes proposed in this pull request

Update user notifications when user is added or removed to an accredited body.
When user is granted access to a new organisation, they will receive notifications for the new organisation, if they opted in.   
When user's access to an organisation is revoked, they will no longer receive notifications for the organisation that was removed, if they opted in. 

Adding/removing access is done via MCB.

_Note:_
It is also possible to add a user to organisations in Publish `/access-requests/new` by copying another user's permission. However, this feature creates a new user so there is no need to update the notifications since the user has never opted-in.
https://github.com/DFE-Digital/teacher-training-api/blob/01eb5f002cb1125af0f669d774f41dbf9ba1d22f/app/models/access_request.rb#L17

### Guidance to review
1. Turn on notifications in Publish http://localhost:3000/notifications

2. Give yourself access to a new provider eg
`bundle exec bin/mcb users grant name.surname@digital.education.gov.uk -p B20`

- In the API console
`u = User.find_by(email: <email>)`
  - Check if the new organisations is added `u.organisations`
  - Check if the UserNotification was created `UserNotification.where(user_id: u.id)`

3. Revoke your access to that organisation
`bundle exec bin/mcb users revoke name.surname@digital.education.gov.uk --provider_code B20` and check in the console

4. Delete notifications `UserNotification.destroy_all` repeat 2. and 3. but the UserNotification should not be created

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
