### PR TITLE
[3341] - Optimise courses as an accredited body query

### DIFF
--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -50,7 +50,21 @@ module API
 
         providers = TrainingProviderSearch.new(provider: @provider, params: params).call
 
-        render jsonapi: providers, include: params[:include]
+        course_counts = {}
+
+        providers.map do |provider|
+          courses_count = provider
+                            .courses
+                            .where(accrediting_provider_code: @provider.provider_code,)
+                            .count
+          course_counts[provider.provider_code] = courses_count
+        end
+
+        render jsonapi: providers,
+               include: params[:include],
+               meta: {
+                 course_counts: course_counts
+               }
       end
 
     private

--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -48,22 +48,20 @@ module API
       def index
         authorize @provider, :can_list_training_providers?
 
-        providers = TrainingProviderSearch.new(provider: @provider, params: params).call
+        providers = TrainingProviderSearch.new(provider: @provider, params: params)
+                                          .call
+                                          .include_accredited_courses_counts(@provider.provider_code)
 
-        course_counts = {}
+        accredited_courses_counts = {}
 
-        providers.map do |provider|
-          courses_count = provider
-                            .courses
-                            .where(accrediting_provider_code: @provider.provider_code,)
-                            .count
-          course_counts[provider.provider_code] = courses_count
+        providers.each do |p|
+          accredited_courses_counts[p.provider_code] = p.accredited_courses_count
         end
 
         render jsonapi: providers,
                include: params[:include],
                meta: {
-                 course_counts: course_counts
+                 accredited_courses_counts: accredited_courses_counts,
                }
       end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -182,11 +182,11 @@ class Provider < ApplicationRecord
   end
 
   def courses_count
-    self.respond_to?("included_courses_count") ? included_courses_count : courses.size
+    self.has_attribute?("included_courses_count") ? included_courses_count : courses.size
   end
 
   def accredited_courses_count
-    self.respond_to?("included_accredited_courses_count") ? included_accredited_courses_count : 0
+    self.has_attribute?("included_accredited_courses_count") ? included_accredited_courses_count : 0
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -167,8 +167,26 @@ class Provider < ApplicationRecord
     ).select("provider.*, COALESCE(a.courses_count, 0) AS included_courses_count")
   end
 
+  def self.include_accredited_courses_counts(provider_code)
+    joins(
+      %{
+        LEFT OUTER JOIN (
+          SELECT b.provider_id, COUNT(*) courses_count
+          FROM course b
+          WHERE b.discarded_at IS NULL
+          AND b.accrediting_provider_code = #{ActiveRecord::Base.connection.quote(provider_code)}
+          GROUP BY b.provider_id
+        ) a ON a.provider_id = provider.id
+      },
+      ).select("provider.*, COALESCE(a.courses_count, 0) AS included_accredited_courses_count")
+  end
+
   def courses_count
     self.respond_to?("included_courses_count") ? included_courses_count : courses.size
+  end
+
+  def accredited_courses_count
+    self.respond_to?("included_accredited_courses_count") ? included_accredited_courses_count : 0
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -261,14 +261,18 @@ describe Provider, type: :model do
           expect(provider_with_included.courses).to_not have_received(:size)
         end
       end
-    end
 
-    describe ".include_courses_counts" do
-      let(:courses) { [course] }
-      let(:first_provider) { Provider.include_courses_counts.first }
+      context "with .include_accredited_courses_counts" do
+        let(:provider_with_included) { Provider.include_accredited_courses_counts(provider.provider_code).first }
 
-      it "includes course counts" do
-        expect(first_provider.courses_count).to eq(1)
+        it "return course count using included_accredited_courses_count" do
+          allow(provider_with_included).to receive(:included_accredited_courses_count).and_return(1)
+          allow(provider_with_included.courses).to receive(:size)
+
+          expect(provider_with_included.accredited_courses_count).to eq(1)
+          expect(provider_with_included).to have_received(:included_accredited_courses_count)
+          expect(provider_with_included.courses).to_not have_received(:size)
+        end
       end
     end
 

--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -218,10 +218,10 @@ describe "AccreditedBody API v2", type: :request do
             },
           ],
           "meta" => {
-            "course_counts" => {
-              "#{delivering_provider1.provider_code}" => 1,
-              "#{accredited_provider.provider_code}" => 0,
-              "#{delivering_provider2.provider_code}" => 1,
+            "accredited_courses_counts" => {
+              delivering_provider1.provider_code.to_s => 1,
+              accredited_provider.provider_code.to_s => 0,
+              delivering_provider2.provider_code.to_s => 1,
             },
           },
           "jsonapi" => {

--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -217,6 +217,13 @@ describe "AccreditedBody API v2", type: :request do
               },
             },
           ],
+          "meta" => {
+            "course_counts" => {
+              "#{delivering_provider1.provider_code}" => 1,
+              "#{accredited_provider.provider_code}" => 0,
+              "#{delivering_provider2.provider_code}" => 1,
+            },
+          },
           "jsonapi" => {
             "version" => "1.0",
           },


### PR DESCRIPTION
### Context
“Courses as accredited body” page is extremely slow, 20-40sec Time to First Byte. This is because the API endpoint returning the list of training providers or course counts are extremely slow.

This is a spike to see what improvements could be made. This is one option for feedback purposes.

### Changes proposed 
- Return the courses as an accredited body count as meta
- NB: this code has not been refactored. No tests yet
- Publish `ProvidersController` would just then need a minor tweak to access the count via the meta object

```
def index
    page = (params[:page] || 1).to_i
    per_page = 10

    @providers = providers.page(page)

     # No longer making a separate Courses API call
    @pagy = Pagy.new(count: @providers.meta.count, page: page, items: per_page)

    @providers_view = ProvidersView.new(providers: providers)

    render "providers/no_providers", status: :forbidden if @providers.empty?
    redirect_to provider_path(@providers.first.provider_code) if @providers.size == 1
  end
```
### Load times
Running locally, the follow show Publish load times

#### Before the change

```
003] (10.195s) ProvidersController -- Completed #training_providers -- {:controller=>"ProvidersController", :action=>"training_providers", :params=>{"provider_code"=>"K30", "year"=>"2020"}, :format=>"HTML", :method=>"GET", :path=>"/organisations/K30/2020/training-providers", :status=>200, :view_runtime=>240.8, :user=>{:id=>"10866", :sign_in_user_id=>"52fd0689-809e-469b-9f7b-28741f03949f"}, :request_id=>"f0e139ae-8efe-40ef-a269-c33a5c281945", :status_message=>"OK"}
```

#### After the change
```
003] (827.4ms) ProvidersController -- Completed #training_providers -- {:controller=>"ProvidersController", :action=>"training_providers", :params=>{"provider_code"=>"K30", "year"=>"2020"}, :format=>"HTML", :method=>"GET", :path=>"/organisations/K30/2020/training-providers", :status=>200, :view_runtime=>193.04, :user=>{:id=>"10866", :sign_in_user_id=>"52fd0689-809e-469b-9f7b-28741f03949f"}, :request_id=>"58a2bce5-0972-445d-a48d-1bba95ee0761", :status_message=>"OK"}
```

### Run it
To see it in action, run this branch against this Publish branch - https://github.com/DFE-Digital/publish-teacher-training/tree/3341-optimise-courses-as-accredited-body

Visit `localhost:3000/organisations/M80/2020/training-providers`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
