### PR TITLE
3408 api docs arrays

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -31,7 +31,6 @@ module GovukTechDocs
           paths += path(text)
         end
         schemas = ""
-        schemas_data = @document.components.schemas
         schemas_data.each do |schema_data|
           text = schema_data[0]
           schemas += schema(text)
@@ -47,48 +46,18 @@ module GovukTechDocs
       end
 
       def schema(text)
-        schemas = ""
-        schemas_data = @document.components.schemas
-        schemas_data.each do |schema_data|
-          properties = []
+        properties = properties_for_schema(text)
 
-          all_of = schema_data[1]["allOf"]
-          if !all_of.blank?
-            all_of.each do |schema_nested|
-              schema_nested.properties.each do |property|
-                properties.push property
-              end
-            end
-          end
+        schema_data = schemas_data.find { |s| s[0] == text }
 
-          any_of = schema_data[1]["anyOf"]
-          if !any_of.blank?
-            any_of.each do |schema_nested|
-              schema_nested.properties.each do |property|
-                properties.push property
-              end
-            end
-          end
+        title = schema_data[0]
+        schema = schema_data[1]
 
-          schema_data[1].properties.each do |property|
-            properties.push property
-          end
-
-          if schema_data[0] == text
-            if schema_data[1] && schema_data[1].type == "array"
-              properties.push ["Item", schema_data[1].items]
-            end
-
-            title = schema_data[0]
-            schema = schema_data[1]
-
-            if schema_data[1]["anyOf"]
-              return @template_any_of.result(binding)
-            end
-
-            return @template_schema.result(binding)
-          end
+        if schema_data[1]["anyOf"]
+          return @template_any_of.result(binding)
         end
+
+        @template_schema.result(binding)
       end
 
       def schemas_from_path(text)
@@ -323,6 +292,44 @@ module GovukTechDocs
           output = "<a href='\##{id}'>#{schema_name}</a>"
           output
         end
+      end
+
+      def schemas_data
+        @schemas_data ||= @document.components.schemas
+      end
+
+      def properties_for_schema(schema_name)
+        schema_data = schemas_data.find { |s| s[0] == schema_name }
+
+        properties = []
+
+        all_of = schema_data[1]["allOf"]
+        if !all_of.blank?
+          all_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property
+            end
+          end
+        end
+
+        any_of = schema_data[1]["anyOf"]
+        if !any_of.blank?
+          any_of.each do |schema_nested|
+            schema_nested.properties.each do |property|
+              properties.push property
+            end
+          end
+        end
+
+        schema_data[1].properties.each do |property|
+          properties.push property
+        end
+
+        if schema_data[1] && schema_data[1].type == "array"
+          properties.push ["Item", schema_data[1].items]
+        end
+
+        properties
       end
     end
   end

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -64,6 +64,10 @@ module GovukTechDocs
           end
 
           if schema_data[0] == text
+            if schema_data[1] && schema_data[1].type == "array"
+              properties.push ["Item", schema_data[1].items]
+            end
+
             title = schema_data[0]
             schema = schema_data[1]
             return @template_schema.result(binding)

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -18,6 +18,7 @@ module GovukTechDocs
         @template_operation = get_renderer("operation.html.erb")
         @template_parameters = get_renderer("parameters.html.erb")
         @template_responses = get_renderer("responses.html.erb")
+        @template_any_of = get_renderer("any_of.html.erb")
       end
 
       def api_full
@@ -49,10 +50,20 @@ module GovukTechDocs
         schemas = ""
         schemas_data = @document.components.schemas
         schemas_data.each do |schema_data|
-          all_of = schema_data[1]["allOf"]
           properties = []
+
+          all_of = schema_data[1]["allOf"]
           if !all_of.blank?
             all_of.each do |schema_nested|
+              schema_nested.properties.each do |property|
+                properties.push property
+              end
+            end
+          end
+
+          any_of = schema_data[1]["anyOf"]
+          if !any_of.blank?
+            any_of.each do |schema_nested|
               schema_nested.properties.each do |property|
                 properties.push property
               end
@@ -70,6 +81,11 @@ module GovukTechDocs
 
             title = schema_data[0]
             schema = schema_data[1]
+
+            if schema_data[1]["anyOf"]
+              return @template_any_of.result(binding)
+            end
+
             return @template_schema.result(binding)
           end
         end

--- a/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/any_of.html.erb
@@ -1,0 +1,11 @@
+<h3 id="<%= id = 'schema-' + title; id.parameterize %>"><%= title %></h3>
+
+<p>
+  This schema can be any one of the following schemas:
+</p>
+
+<ul>
+  <% schema_data[1]["anyOf"].node_data.each do |schema| %>
+    <li><%= get_schema_link(schema) %></li>
+  <% end %>
+</ul>


### PR DESCRIPTION
### Context

- https://trello.com/c/NnG2a0CU/3408-m-fix-rendering-of-arrays-in-api-docs
- API renderer for tech docs does not handle arrays and `anyOf` schema

### Changes proposed in this pull request

- Refactor some of the api renderer code, should now be slightly quicker and memory efficient (not benchmarked)
- Add a new view for `anyOf` schemas to link user to the schema
- Handle arrays by using the first in `items` as a property

### Guidance to review

- Load up the docs
- `AnyOf` schemas eg `Resource` should link off to relevant schemas
- arrays eg `Sort` should show some documentation for the element 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
