### PR TITLE
[3287] Add 0 allocation request validations

### DIFF
--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -9,6 +9,7 @@ class Allocation < ApplicationRecord
   validates :number_of_places, numericality: true
 
   validate :accredited_body_is_an_accredited_body
+  validate :non_zero_initial_request
 
   enum request_type: { initial: 0, repeat: 1, declined: 2 }
 
@@ -32,5 +33,9 @@ private
 
   def accredited_body_is_an_accredited_body
     errors.add(:accredited_body, "must be an accredited body") unless accredited_body&.accredited_body?
+  end
+
+  def non_zero_initial_request
+    errors.add(:number_of_places, "must not be zero") if request_type == "initial" && number_of_places.zero?
   end
 end

--- a/spec/policies/allocation_policy_spec.rb
+++ b/spec/policies/allocation_policy_spec.rb
@@ -8,7 +8,12 @@ describe AllocationPolicy do
   let(:organisation) { create(:organisation, users: [user]) }
   let(:accredited_body) { create(:provider, :accredited_body) }
   let(:training_provider) { create(:provider) }
-  let(:allocation) { build(:allocation, accredited_body: accredited_body, provider: training_provider) }
+  let(:allocation) do
+    build(:allocation,
+          accredited_body: accredited_body,
+          provider: training_provider,
+          number_of_places: 1)
+  end
 
   permissions :index? do
     context "user is present" do
@@ -50,7 +55,12 @@ describe AllocationPolicy do
   end
 
   describe AllocationPolicy::Scope do
-    let(:allocation) { create(:allocation, accredited_body: accredited_body, provider: training_provider) }
+    let(:allocation) do
+      create(:allocation,
+             accredited_body: accredited_body,
+             provider: training_provider,
+             number_of_places: 1)
+    end
 
     subject { described_class.new(user, Allocation).resolve }
 


### PR DESCRIPTION
### Context
We shouldn't accept `0` allocation requests for initial requests.  "Repeat"
request should still allow "0" places because this is where we don't have date
for the training provider.

### Changes proposed in this pull request
Validate number_of_places is not zero if the request type is "initial" 

### Guidance to review
- try to create new allocations with the following params
provider_code: "B20", provider_id: 15052, **request_type: "initial", number_of_places: 0**

Note: when I tried adding `presence: true` Publish blows up

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
