### PR TITLE
[3502] Fix Code Climate test coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -192,6 +192,6 @@ group :test do
   gem "rspec-benchmark"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.3"
-  gem "simplecov", require: false
+  gem "simplecov", '< 0.18', require: false
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,6 +199,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
+    json (2.3.0)
     json-schema (2.8.1)
       addressable (>= 2.4)
     jsonapi-deserializable (0.2.0)
@@ -424,10 +425,11 @@ GEM
     sidekiq-cron (1.2.0)
       fugit (~> 1.1)
       sidekiq (>= 4.2.1)
-    simplecov (0.18.5)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     skylight (4.3.0)
       skylight-core (= 4.3.0)
     skylight-core (4.3.0)
@@ -543,7 +545,7 @@ DEPENDENCIES
   shoulda-matchers (~> 4.3)
   sidekiq
   sidekiq-cron
-  simplecov
+  simplecov (< 0.18)
   skylight
   spring
   spring-commands-rspec


### PR DESCRIPTION
### Context

Code Climate was not reporting our test coverage.

In our Azure jobs we were seeing the following errors:
```
Error: json: cannot unmarshal object into Go struct field input.coverage of type []formatters.NullInt
```
which meant that code climate was no longer receiving our test coverage
score. This is a known issue with code climates test-report and simplecov 0.18.x see codeclimate/test-reporter#418 

### Changes proposed in this pull request
- Rollback simplecov until code climate issue is resolved

### Guidance to review

- coverage is reported in the PR checks
![image](https://user-images.githubusercontent.com/3441519/84029040-ac9ff800-a989-11ea-980b-95dd30247806.png)
- Copy of recent test coverage submissions to code climate done during this work
![image](https://user-images.githubusercontent.com/3441519/84029103-c5101280-a989-11ea-9662-1f8a437114ff.png)


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
