### PR TITLE
[3356] Improve api docs

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -1,18 +1,16 @@
 module API
   module Public
     module V1
-      class CoursesController < API::Public::V1::ApplicationController
+      class ProvidersController < API::Public::V1::ApplicationController
         def index
           render json: {
             data: [
               {
                 id: 123,
-                type: "Course",
+                type: "Provider",
                 attributes: {
-                  code: "3GTY",
-                  provider_code: "6CL",
-                  age_minimum: 11,
-                  age_maximum: 14,
+                  code: "ABC",
+                  name: "Some provider",
                 },
               },
             ],
@@ -26,12 +24,10 @@ module API
           render json: {
             data: {
               id: 123,
-              type: "Course",
+              type: "Provider",
               attributes: {
-                code: "3GTY",
-                provider_code: "6CL",
-                age_minimum: 11,
-                age_maximum: 14,
+                code: "ABC",
+                name: "Some provider",
               },
             },
             jsonapi: {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,8 +103,12 @@ Rails.application.routes.draw do
 
     namespace :public do
       namespace :v1 do
-        resources :courses, only: [:index] do
-          resources :locations, only: [:index]
+        resources :recruitment_cycles, param: :year, only: [:show] do
+          resources :providers, only: %i[index show] do
+            resources :courses, only: %i[index show] do
+              resources :locations, only: [:index]
+            end
+          end
         end
       end
     end

--- a/spec/api/courses_spec.rb
+++ b/spec/api/courses_spec.rb
@@ -1,28 +1,76 @@
 require "swagger_helper"
 
 describe "API" do
-  path "/courses" do
-    get "Returns courses for the current recruitment cycle" do
-      operationId :public_api_v1_courses
+  path "/recruitment_cycles/{year}/providers/{provider_code}/courses" do
+    get "Returns the courses for the specified provider." do
+      operationId :public_api_v1_provider_courses
       tags "course"
       produces "application/json"
+      parameter name: :year,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The starting year of the recruitment cycle."
+      parameter name: :provider_code,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The unique code of the provider."
       parameter name: :filter,
-        in: :query,
-        schema: { "$ref" => "#/components/schemas/Filter" },
-        style: :deepObject,
-        explode: true,
-        description: "Refine courses to return",
-        required: false
+                in: :query,
+                schema: { "$ref" => "#/components/schemas/Filter" },
+                type: :object,
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine courses to return."
       parameter name: :sort,
-        in: :query,
-        schema: { "$ref" => "#/components/schemas/Sort" },
-        style: :form,
-        explode: false,
-        example: "provider.provider_name,name",
-        description: "Field(s) to sort the courses by",
-        required: false
+                in: :query,
+                schema: { "$ref" => "#/components/schemas/Sort" },
+                type: :object,
+                style: :form,
+                explode: false,
+                required: false,
+                example: "provider.provider_name,name",
+                description: "Field(s) to sort the courses by."
 
-      response "200", "The list of courses in the current recruitment cycle" do
+      response "200", "The collection of courses." do
+        let(:year) { "2020" }
+        let(:provider_code) { "ABC" }
+
+        schema "$ref": "#/components/schemas/CourseListResponse"
+
+        run_test!
+      end
+    end
+  end
+
+  path "/recruitment_cycles/{year}/providers/{provider_code}/courses/{course_code}" do
+    get "Returns the specified course for the specified provider." do
+      operationId :public_api_v1_provider_course
+      tags "course"
+      produces "application/json"
+      parameter name: :year,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The starting year of the recruitment cycle."
+      parameter name: :provider_code,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The unique code of the provider."
+      parameter name: :course_code,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The code of the course."
+
+      response "200", "The collection of courses offered by the specified provider." do
+        let(:year) { "2020" }
+        let(:provider_code) { "ABC" }
+        let(:course_code) { "DEF" }
+
         schema "$ref": "#/components/schemas/CourseSingleResponse"
 
         run_test!

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -1,17 +1,29 @@
 require "swagger_helper"
 
 describe "API" do
-  path "/courses/{course_code}/locations" do
-    get "Returns locations for the given course" do
-      operationId :public_api_v1_course_locations
+  path "/recruitment_cycles/{year}/providers/{provider_code}/courses/{course_code}/locations" do
+    get "Returns the locations for the specified course." do
+      operationId :public_api_v1_provider_course_locations
       tags "location"
       produces "application/json"
+      parameter name: :year,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The starting year of the recruitment cycle."
+      parameter name: :provider_code,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The unique code of the provider."
       parameter name: :course_code,
-        in: :path,
-        type: :string,
-        description: "The code of the course"
+                in: :path,
+                type: :string,
+                description: "The code of the course."
 
-      response "200", "The list of locations for the given course" do
+      response "200", "The collection of locations for the specified course." do
+        let(:year) { "2020" }
+        let(:provider_code) { "ABC" }
         let(:course_code) { 123 }
 
         schema "$ref": "#/components/schemas/LocationsList"

--- a/spec/api/providers_spec.rb
+++ b/spec/api/providers_spec.rb
@@ -1,46 +1,67 @@
 require "swagger_helper"
 
 describe "API" do
-  path "/api/public/v4/providers" do
-    get "Returns providers for the current recruitment cycle" do
-      operationId :public_api_v1_providers_list
+  path "/recruitment_cycles/{year}/providers" do
+    get "Returns providers for the specified recruitment cycle." do
+      operationId :public_api_v1_provider_index
       tags "provider"
       produces "application/json"
+      parameter name: :year,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The starting year of the recruitment cycle."
       parameter name: :filter,
                 in: :query,
+                schema: { "$ref" => "#/components/schemas/Filter" },
                 type: :object,
-                style: "deepObject",
-                required: false
+                style: :deepObject,
+                explode: true,
+                required: false,
+                description: "Refine courses to return."
       parameter name: :sort,
                 in: :query,
+                schema: { "$ref" => "#/components/schemas/Sort" },
                 type: :object,
-                style: "deepObject",
-                required: false
+                style: :form,
+                explode: false,
+                required: false,
+                example: "provider.provider_name,name",
+                description: "Field(s) to sort the courses by."
 
-      response "200", "The list of providers in the current recruitment cycle" do
+      response "200", "Collection of providers." do
+        let(:year) { "2020" }
+
         schema "$ref": "#/components/schemas/ProviderListResponse"
+
+        run_test!
       end
     end
   end
 
-  path "/api/public/v4/providers/:provider_code" do
-    get "Returns provider resource in the current recruitment cycle" do
+  path "/recruitment_cycles/{year}/providers/{provider_code}" do
+    get "Returns the specified provider." do
       operationId :public_api_v1_provider_show
       tags "provider"
       produces "application/json"
-      parameter name: :filter,
-                in: :query,
-                type: :object,
-                style: "deepObject",
-                required: false
-      parameter name: :sort,
-                in: :query,
-                type: :object,
-                style: "deepObject",
-                required: false
+      parameter name: :year,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The starting year of the recruitment cycle."
+      parameter name: :provider_code,
+                in: :path,
+                type: :string,
+                required: true,
+                description: "The unique code of the provider."
 
-      response "200", "The provider resource in the current recruitment cycle" do
+      response "200", "The provider." do
+        let(:year) { "2020" }
+        let(:provider_code) { "ABC" }
+
         schema "$ref": "#/components/schemas/ProviderSingleResponse"
+
+        run_test!
       end
     end
   end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -381,6 +381,26 @@
           }
         }
       },
+      "CourseListResponse": {
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CourseResource"
+            }
+          },
+          "included": {
+            "$ref": "#/components/schemas/Included"
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
       "CourseRelationships": {
         "type": "object",
         "properties": {
@@ -430,14 +450,12 @@
       "CourseSingleResponse": {
         "type": "object",
         "required": [
-          "data"
+          "data",
+          "jsonapi"
         ],
         "properties": {
           "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/CourseResource"
-            }
+            "$ref": "#/components/schemas/CourseResource"
           },
           "included": {
             "$ref": "#/components/schemas/Included"
@@ -1031,14 +1049,32 @@
     }
   },
   "paths": {
-    "/courses": {
+    "/recruitment_cycles/{year}/providers/{provider_code}/courses": {
       "get": {
-        "summary": "Returns courses for the current recruitment cycle",
-        "operationId": "public_api_v1_courses",
+        "summary": "Returns the courses for the specified provider.",
+        "operationId": "public_api_v1_provider_courses",
         "tags": [
           "course"
         ],
         "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "description": "The starting year of the recruitment cycle.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_code",
+            "in": "path",
+            "required": true,
+            "description": "The unique code of the provider.",
+            "schema": {
+              "type": "string"
+            }
+          },
           {
             "name": "filter",
             "in": "query",
@@ -1047,8 +1083,8 @@
             },
             "style": "deepObject",
             "explode": true,
-            "description": "Refine courses to return",
-            "required": false
+            "required": false,
+            "description": "Refine courses to return."
           },
           {
             "name": "sort",
@@ -1058,14 +1094,64 @@
             },
             "style": "form",
             "explode": false,
+            "required": false,
             "example": "provider.provider_name,name",
-            "description": "Field(s) to sort the courses by",
-            "required": false
+            "description": "Field(s) to sort the courses by."
           }
         ],
         "responses": {
           "200": {
-            "description": "The list of courses in the current recruitment cycle",
+            "description": "The list of courses.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CourseListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recruitment_cycles/{year}/providers/{provider_code}/courses/{course_code}": {
+      "get": {
+        "summary": "Returns the specified course for the specified provider.",
+        "operationId": "public_api_v1_provider_course",
+        "tags": [
+          "course"
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "description": "The starting year of the recruitment cycle.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_code",
+            "in": "path",
+            "required": true,
+            "description": "The unique code of the provider.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "course_code",
+            "in": "path",
+            "required": true,
+            "description": "The code of the course.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The collection of courses offered by the specified provider.",
             "content": {
               "application/json": {
                 "schema": {
@@ -1077,18 +1163,36 @@
         }
       }
     },
-    "/courses/{course_code}/locations": {
+    "/recruitment_cycles/{year}/providers/{provider_code}/courses/{course_code}/locations": {
       "get": {
-        "summary": "Returns locations for the given course",
-        "operationId": "public_api_v1_course_locations",
+        "summary": "Returns the locations for the specified course.",
+        "operationId": "public_api_v1_provider_course_locations",
         "tags": [
           "location"
         ],
         "parameters": [
           {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "description": "The starting year of the recruitment cycle.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_code",
+            "in": "path",
+            "required": true,
+            "description": "The unique code of the provider.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "course_code",
             "in": "path",
-            "description": "The code of the course",
+            "description": "The code of the course.",
             "required": true,
             "schema": {
               "type": "string"
@@ -1097,11 +1201,107 @@
         ],
         "responses": {
           "200": {
-            "description": "The list of locations for the given course",
+            "description": "The collection of locations for the specified course.",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/LocationsList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recruitment_cycles/{year}/providers": {
+      "get": {
+        "summary": "Returns providers for the specified recruitment cycle.",
+        "operationId": "public_api_v1_provider_index",
+        "tags": [
+          "provider"
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "description": "The starting year of the recruitment cycle.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Filter"
+            },
+            "style": "deepObject",
+            "explode": true,
+            "required": false,
+            "description": "Refine courses to return."
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/Sort"
+            },
+            "style": "form",
+            "explode": false,
+            "required": false,
+            "example": "provider.provider_name,name",
+            "description": "Field(s) to sort the courses by."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Collection of providers.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/recruitment_cycles/{year}/providers/{provider_code}": {
+      "get": {
+        "summary": "Returns the specified provider.",
+        "operationId": "public_api_v1_provider_show",
+        "tags": [
+          "provider"
+        ],
+        "parameters": [
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "description": "The starting year of the recruitment cycle.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "provider_code",
+            "in": "path",
+            "required": true,
+            "description": "The unique code of the provider.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The provider.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderSingleResponse"
                 }
               }
             }

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -88,7 +88,7 @@ components:
           $ref: "#/components/schemas/CourseAttributes"
         relationships:
           $ref: "#/components/schemas/CourseRelationships"
-    CourseSingleResponse:
+    CourseListResponse:
       type: object
       required:
         - data
@@ -97,6 +97,18 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CourseResource"
+        included:
+          $ref: "#/components/schemas/Included"
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPI"
+    CourseSingleResponse:
+      type: object
+      required:
+        - data
+        - jsonapi
+      properties:
+        data:
+          $ref: "#/components/schemas/CourseResource"
         included:
           $ref: "#/components/schemas/Included"
         jsonapi:


### PR DESCRIPTION
### Context

- https://trello.com/c/Wu4CewI6/3356-add-missing-endpoints-to-api-docs
- There were some missing proposed endpoint in the api docs

### Changes proposed in this pull request

- Namespace proposed api docs to recruitment cycle
- Add provider endpoints
- Add course show endpoint
- Nest course endpoints within provider
- Add missing api schema specs
- Add CourseListResponse schema
- Add missing url parameter docs

### Guidance to review

- Fire up the tech docs see the README
- Should see the new endpoints in the docs

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
