### PR TITLE
[3517] add bg jobs dockerfile

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ variables:
   imageName: 'teacher-training-api'
   imageNameBgGeoCode: 'teacher-training-bg-geocode'
   imageNameBgMailer: 'teacher-training-bg-mailer'
+  imageNameBgJobs: 'teacher-training-bg-jobs'
   dockerOverride: 'docker-compose -f docker-compose.yml'
 
 
@@ -22,11 +23,13 @@ steps:
     docker_middleman_path=$(dockerHubUsername)/$(imageName)-middleman
     docker_bg_geocode_path=$(dockerHubUsername)/$(imageNameBgGeoCode)
     docker_bg_mailer_path=$(dockerHubUsername)/$(imageNameBgMailer)
+    docker_bg_jobs_path=$(dockerHubUsername)/$(imageNameBgJobs)
     set +x # We confuse VSTS if we trace these commands
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=docker_path;]$docker_path"
     echo "##vso[task.setvariable variable=docker_bg_geocode_path;]$docker_bg_geocode_path"
     echo "##vso[task.setvariable variable=docker_bg_mailer_path;]$docker_bg_mailer_path"
+    echo "##vso[task.setvariable variable=docker_bg_jobs_path;]$docker_bg_jobs_path"
     echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
@@ -175,6 +178,19 @@ steps:
   inputs:
     command: Push an image
     imageName: "$(docker_bg_mailer_path):$(Build.BuildNumber)"
+
+- task: Docker@1
+  displayName: Tag bg_jobs image with current build number $(Build.BuildNumber)
+  inputs:
+    command: Tag image
+    imageName: "$(docker_bg_jobs_path):$(Build.SourceBranchName)"
+    arguments: "$(docker_bg_jobs_path):$(Build.BuildNumber)"
+
+- task: Docker@1
+  displayName: Push bg_jobs image with current build number $(Build.BuildNumber)
+  inputs:
+    command: Push an image
+    imageName: "$(docker_bg_jobs_path):$(Build.BuildNumber)"
 
 - task: CopyFiles@2
   displayName: 'Copy Files to: $(build.artifactstagingdirectory)'

--- a/bg-jobs/Dockerfile
+++ b/bg-jobs/Dockerfile
@@ -1,0 +1,7 @@
+ARG  DOCKER_REPOSITORY
+ARG  TEACHER_TRAINING_API
+ARG  CODE_VERSION=${GIT_BRANCH:-latest}
+
+FROM ${DOCKER_REPOSITORY}/${TEACHER_TRAINING_API}:${CODE_VERSION}
+
+CMD bundle exec rails db:migrate && bundle exec sidekiq -q save_statistic

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
      - dbdata:/var/lib/postgresql/data
     environment:
     - POSTGRES_PASSWORD=developmentpassword
+
   middleman:
     build:
       context: .
@@ -16,6 +17,7 @@ services:
       cache_from:
         - ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:master
     image: ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:${GIT_BRANCH:-latest}
+
   web:
     build:
       context: .
@@ -38,6 +40,7 @@ services:
       - CC_TEST_REPORTER_ID=${CC_TEST_REPORTER_ID}
       - AGENT_JOBSTATUS=${AGENT_JOBSTATUS}
       - GIT_BRANCH=${GIT_BRANCH}
+
   bg-geocode:
     build:
       args:
@@ -77,3 +80,21 @@ services:
       - DB_USERNAME=postgres
       - DB_PASSWORD=developmentpassword
       - SETTINGS__APPLICATION=teacher-training-api-bg-mailer
+
+  bg-jobs:
+    build:
+      args:
+        - DOCKER_REPOSITORY=${dockerHubUsername:-dfedigital}
+        - TEACHER_TRAINING_API=${dockerHubImageName:-teacher-training-api}
+      context: bg-jobs
+    image: ${dockerHubUsername:-dfedigital}/teacher-training-bg-jobs:${GIT_BRANCH:-latest}
+    volumes:
+      - .:/app
+    depends_on:
+      - web
+      - db
+    environment:
+      - DB_HOSTNAME=db
+      - DB_USERNAME=postgres
+      - DB_PASSWORD=developmentpassword
+      - SETTINGS__APPLICATION=teacher-training-api-bg-jobs


### PR DESCRIPTION
### Context

We need to run background jobs. We also need a generic job runner as it's turning into too much overhead having one container per task (mailer, geosync, etc).

### Changes proposed in this pull request

Add a generic background job runner image that's a copy of the existing ones, but with a generic name. A future PR will scrap the existing ones and configure this one to run all the queues.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
