### PR TITLE
[3502] Fix branch name so its sent to code climate

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ steps:
     GIT_BRANCH: $(Build.SourceBranchName)
 - script: |
     set -x
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rake cc:report"
+    $DOCKER_OVERRIDE exec -T -e GIT_BRANCH=$GIT_BRANCH web rails cc:report
   displayName: 'Execute Code Climate reporter'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - DB_PASSWORD=developmentpassword
       - CC_TEST_REPORTER_ID=${CC_TEST_REPORTER_ID}
       - AGENT_JOBSTATUS=${AGENT_JOBSTATUS}
+      - GIT_BRANCH=${GIT_BRANCH}
   bg-geocode:
     build:
       args:


### PR DESCRIPTION
### Context

### Changes proposed in this pull request

### Guidance to review
I've checked the request made to code climate and as you can see the branch name is no longer `HEAD` and you can see the git commit assigned too.
![image](https://user-images.githubusercontent.com/3441519/84198869-1dcfd000-aa9c-11ea-94e9-51aadda46d9b.png)

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
