### PR TITLE
[3532] Add default kept scope to user mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -192,6 +192,6 @@ group :test do
   gem "rspec-benchmark"
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.3"
-  gem "simplecov", '< 0.18', require: false
+  gem "simplecov", "< 0.18", require: false
   gem "webmock"
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -33,7 +33,7 @@ class Provider < ApplicationRecord
   belongs_to :recruitment_cycle
 
   has_and_belongs_to_many :organisations, join_table: :organisation_provider
-  has_many :users, through: :organisations
+  has_many :users, -> { kept }, through: :organisations, inverse_of: false
 
   has_many :sites
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -29,5 +29,9 @@ FactoryBot.define do
       magic_link_token { SecureRandom.uuid }
       magic_link_token_sent_at { Time.now.utc }
     end
+
+    trait :discarded do
+      discarded_at { Time.now.utc }
+    end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -34,6 +34,18 @@ describe Provider, type: :model do
     end
   end
 
+  describe "users" do
+    let(:discarded_user) { create(:user, :discarded) }
+
+    before do
+      provider.organisation.users << discarded_user
+    end
+
+    it "returns users who haven't been discarded" do
+      expect(subject.users).not_to include(discarded_user)
+    end
+  end
+
   describe "changed_at" do
     it "is set on create" do
       provider = Provider.create(


### PR DESCRIPTION
### Context
https://trello.com/c/Z9uH4OZB/3532-only-show-kept-users-on-orgusers-list

### Changes proposed in this pull request
Add default scope to users to prevent showing discarded 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
