### PR TITLE
run rubocop with mutlithreading

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,7 +87,7 @@ steps:
     failedTaskOnFailedTest: true
 - script: |
     set -x
-    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang"
+    $DOCKER_OVERRIDE exec -T web /bin/sh -c "bundle exec rubocop app config db lib spec --format clang --parallel"
   displayName: 'Execute linters'
   env:
     DOCKER_OVERRIDE: $(dockerOverride)


### PR DESCRIPTION
### Context

- Run rubocop in CI with multithreading to improve running times by a small amount

### Guidance to review

- See this build in CI
- Step for rubocop should be slightly faster compared to previous runs

### Checklist

- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
