### PR TITLE
[3336] - Accredited Body New Feature Interruption Screen

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -60,6 +60,7 @@ module API
             :sign_in_user_id,
             :welcome_email_date_utc,
             :invite_date_utc,
+            :state,
             :accept_terms_date_utc,
           )
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
     state :new, initial: true
     state :transitioned
     state :rolled_over
+    state :seen_accredited_body_features
 
     event :accept_transition_screen do
       transitions from: :new, to: :transitioned
@@ -56,6 +57,14 @@ class User < ApplicationRecord
   # accepts array or single organisation
   def remove_access_to(organisations_to_remove)
     self.organisations = self.organisations - Array(organisations_to_remove)
+  end
+
+  def associated_with_accredited_body?
+    providers
+      .in_current_cycle
+      .accredited_body
+      .count
+      .positive?
   end
 
 private

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -5,6 +5,10 @@ module API
       has_many :organisations
 
       attributes :first_name, :last_name, :email, :accept_terms_date_utc, :state, :admin, :sign_in_user_id
+
+      attribute :associated_with_accredited_body do
+        @object.associated_with_accredited_body?
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -118,6 +118,25 @@ describe User, type: :model do
       end
     end
 
+    describe "#associated_with_accredited_body?" do
+      context "user is associated with accredited body" do
+        let(:organisation) { create(:organisation, providers: [accredited_body]) }
+        let(:current_recruitment_cycle) { find_or_create(:recruitment_cycle) }
+        let(:accredited_body) { create(:provider, :accredited_body, recruitment_cycle: current_recruitment_cycle) }
+        subject { create(:user, organisations: [organisation]) }
+
+        it "returns true" do
+          expect(subject.associated_with_accredited_body?).to be true
+        end
+      end
+
+      context "user is not associated with an accredited body" do
+        it "returns false" do
+          expect(subject.associated_with_accredited_body?).to be false
+        end
+      end
+    end
+
     describe "multiple organisations" do
       before do
         subject.organisations = [organisation, other_organisation, yet_other_organisation]

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -178,6 +178,7 @@ describe "Access Request API V2", type: :request do
               "state" => first_access_request.requester.state,
               "admin" => first_access_request.requester.admin,
               "sign_in_user_id" => first_access_request.requester.sign_in_user_id,
+              "associated_with_accredited_body" => first_access_request.requester.associated_with_accredited_body?,
             },
             "relationships" => {
               "organisations" => {

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -50,10 +50,25 @@ describe "/api/v2/users", type: :request do
     it "has a data section with the correct attributes" do
       json_response = JSON.parse(response.body)
       data_attributes = json_response["data"]["attributes"]
+
       expect(data_attributes["email"]).to eq(user.email)
       expect(data_attributes["first_name"]).to eq(user.first_name)
       expect(data_attributes["last_name"]).to eq(user.last_name)
       expect(data_attributes["state"]).to eq(user.state)
+      expect(data_attributes["associated_with_accredited_body"]).to eq(false)
+    end
+
+    context "when user is associated with an accredited body" do
+      let(:organisation) { create(:organisation, providers: [accredited_body]) }
+      let(:user) { create(:user, organisations: [organisation]) }
+      let(:accredited_body) { create(:provider, :accredited_body) }
+
+      it "has a data section with the correct attribute" do
+        json_response = JSON.parse(response.body)
+        data_attributes = json_response["data"]["attributes"]
+
+        expect(data_attributes["associated_with_accredited_body"]).to eq(true)
+      end
     end
   end
 
@@ -104,27 +119,35 @@ describe "/api/v2/users", type: :request do
       subject { perform_request }
 
       it "updates email on the user" do
-        expect { subject }.to(change { user.reload.email }
-          .from(user.email)
-          .to(email))
+        expect { subject }.to(
+          change { user.reload.email }
+            .from(user.email)
+            .to(email),
+        )
       end
 
       it "updates accept_terms_date_utc on the user" do
-        expect { subject }.to(change { user.reload.accept_terms_date_utc }
-          .from(user.accept_terms_date_utc.change(usec: 0))
-          .to(accept_terms_date_utc.change(usec: 0)))
+        expect { subject }.to(
+          change { user.reload.accept_terms_date_utc }
+            .from(user.accept_terms_date_utc.change(usec: 0))
+            .to(accept_terms_date_utc.change(usec: 0)),
+        )
       end
 
       it "updates first_name on the user" do
-        expect { subject }.to(change { user.reload.first_name }
-          .from(user.first_name)
-          .to(first_name))
+        expect { subject }.to(
+          change { user.reload.first_name }
+            .from(user.first_name)
+            .to(first_name),
+        )
       end
 
       it "updates last_name on the user" do
-        expect { subject }.to(change { user.reload.last_name }
-          .from(user.last_name)
-          .to(last_name))
+        expect { subject }.to(
+          change { user.reload.last_name }
+            .from(user.last_name)
+            .to(last_name),
+        )
       end
 
       context "response output" do
@@ -146,7 +169,7 @@ describe "/api/v2/users", type: :request do
             :first_name,
             :last_name,
             :accept_terms_date_utc,
-          )
+            )
         end
 
         context "with validation errors" do

--- a/spec/serializers/api/v2/serializable_user_spec.rb
+++ b/spec/serializers/api/v2/serializable_user_spec.rb
@@ -13,6 +13,7 @@ describe API::V2::SerializableUser do
   it { should have_type "users" }
   it { should have_attribute(:state).with_value(user.state.to_s) }
   it { should have_attribute(:sign_in_user_id).with_value(user.sign_in_user_id.to_s) }
+  it { should have_attribute(:associated_with_accredited_body).with_value(false) }
 
   context "when a non admin user" do
     it { should have_attribute(:admin).with_value(false) }


### PR DESCRIPTION
### Context
On Publish a new interruption screen will be shown to users who are associated with an accredited body. 

### Changes proposed in this pull request
In order to determine whether the screen should be shown the V2 users#show endpoint now contains a meta object confirming whether the user is associated with an accredited body.

### Out of scope
- Another PR will be raised to remove the AASM library and state machine. 
- Custom user endpoints for triggering state will also be removed in a subsequent PR (as all state updated now happen through the update action)

### Guidance to review
This PR relies on this Publish PR-  https://github.com/DFE-Digital/publish-teacher-training/pull/1178 - please see this for instructions on on how to test changes 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
