### PR TITLE
Performance tests don't run by default

### DIFF
--- a/spec/performance/pre_deploy_spec.rb
+++ b/spec/performance/pre_deploy_spec.rb
@@ -24,7 +24,7 @@ tests = {
   "/api/v3/courses" => 4750,
 }
 
-describe "API performance" do
+describe "API performance", type: :performance do
   before do
     WebMock.allow_net_connect!
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -97,6 +97,5 @@ RSpec.configure do |config|
 
   ActiveJob::Base.queue_adapter = :test
 
-
   config.filter_run_excluding type: :performance
 end


### PR DESCRIPTION
### Context

The performance tests were only intended to run when called explicitly in CI. They shouldn't run with the default test suite as they require an API to be running and are very slow.

### Changes proposed in this pull request

Tag the tests `:performance` as intended so as the exclusion in `rails_helper` works.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
