### PR TITLE
[3500] Add provider suggestions filtering

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -79,17 +79,23 @@ module API
         return render(status: :bad_request) if params[:query].nil? || params[:query].length < 2
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
-        found_providers = @recruitment_cycle.providers
-          .search_by_code_or_name(params[:query])
-          .limit(5)
+        scope = @recruitment_cycle.providers
+                                  .search_by_code_or_name(params[:query])
+                                  .limit(5)
+
+        scope = scope.accredited_body if only_accredited_body_filter?
 
         render(
-          jsonapi: found_providers,
+          jsonapi: scope,
           class: { Provider: SerializableProviderSuggestion },
         )
       end
 
     private
+
+      def only_accredited_body_filter?
+        params.dig(:filter, :only_accredited_body) == "true"
+      end
 
       def begins_with_alphanumeric(string)
         string.match?(/^[[:alnum:]].*$/)


### PR DESCRIPTION
### Context

- https://trello.com/c/OO8AqZZe/3500-course-creation-accredited-body-search
- Provider suggestions can not be filtered to only show accredited bodies which is needed by publish for autocomplete purposes (or non-js equivalent)

### Changes proposed in this pull request

- Provider suggestions can now be filtered to only suggest providers that are accredited bodies

### Guidance to review

- with valid api key `curl http://localhost:3001/api/v2/providers/suggest_any?filter%5Baccredited_body%5D=true&query=london`
- should only return accredited bodies

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
