### PR TITLE
[3336] - Add 'notifications_configured' attribute to UserSerializer

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ApplicationRecord
     state :new, initial: true
     state :transitioned
     state :rolled_over
-    state :seen_accredited_body_features
+    state :notifications_configured
 
     event :accept_transition_screen do
       transitions from: :new, to: :transitioned
@@ -65,6 +65,10 @@ class User < ApplicationRecord
       .accredited_body
       .count
       .positive?
+  end
+
+  def notifications_configured?
+    user_notifications.count.positive?
   end
 
 private

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -9,6 +9,10 @@ module API
       attribute :associated_with_accredited_body do
         @object.associated_with_accredited_body?
       end
+
+      attribute :notifications_configured do
+        @object.notifications_configured?
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -137,6 +137,24 @@ describe User, type: :model do
       end
     end
 
+    describe "#notifications_configured?" do
+      context "user has notifications configured" do
+        before do
+          subject.user_notifications << create(:user_notification)
+        end
+
+        it "returns true" do
+          expect(subject.notifications_configured?).to be true
+        end
+      end
+
+      context "user does not have notifications configured" do
+        it "returns false" do
+          expect(subject.notifications_configured?).to be false
+        end
+      end
+    end
+
     describe "multiple organisations" do
       before do
         subject.organisations = [organisation, other_organisation, yet_other_organisation]

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -179,6 +179,7 @@ describe "Access Request API V2", type: :request do
               "admin" => first_access_request.requester.admin,
               "sign_in_user_id" => first_access_request.requester.sign_in_user_id,
               "associated_with_accredited_body" => first_access_request.requester.associated_with_accredited_body?,
+              "notifications_configured" => first_access_request.requester.notifications_configured?,
             },
             "relationships" => {
               "organisations" => {

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -56,6 +56,7 @@ describe "/api/v2/users", type: :request do
       expect(data_attributes["last_name"]).to eq(user.last_name)
       expect(data_attributes["state"]).to eq(user.state)
       expect(data_attributes["associated_with_accredited_body"]).to eq(false)
+      expect(data_attributes["notifications_configured"]).to eq(false)
     end
 
     context "when user is associated with an accredited body" do
@@ -68,6 +69,17 @@ describe "/api/v2/users", type: :request do
         data_attributes = json_response["data"]["attributes"]
 
         expect(data_attributes["associated_with_accredited_body"]).to eq(true)
+      end
+    end
+
+    context "when user has notifications configured" do
+      let(:user) { create(:user, user_notifications: [create(:user_notification)]) }
+
+      it "has a data section with the correct attribute" do
+        json_response = JSON.parse(response.body)
+        data_attributes = json_response["data"]["attributes"]
+
+        expect(data_attributes["notifications_configured"]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
### Context
- Publish needs to know if the user is subscribed to notifications in order to determine whether the 'accredited body new features' interruption screen is shown. See related PR - https://github.com/DFE-Digital/publish-teacher-training/pull/1178

### Changes proposed in this pull request
- An attribute is now returned on the user resource indicating whether the user is subscribed to notifications or not.

### Review guidance
- State machine has been updated to prevent breakages. Note this is a temporary edit as the user state machine is to be removed in https://github.com/DFE-Digital/teacher-training-api/pull/1427


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
