### PR TITLE
[3557] Add course withdraw notification

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -116,6 +116,7 @@ module API
         authorize @course
         if @course.is_published?
           @course.withdraw
+          NotificationService::CourseWithdrawn.call(course: @course)
         else
           raise RuntimeError.new("This course has not been published and should be deleted not withdrawn")
         end

--- a/app/mailers/course_withdraw_email_mailer.rb
+++ b/app/mailers/course_withdraw_email_mailer.rb
@@ -1,0 +1,25 @@
+class CourseWithdrawEmailMailer < GovukNotifyRails::Mailer
+  include TimeFormat
+
+  def course_withdraw_email(course, user, datetime)
+    set_template(Settings.govuk_notify.course_withdraw_email_template_id)
+
+    set_personalisation(
+      provider_name: course.provider.provider_name,
+      course_name: course.name,
+      course_code: course.course_code,
+      withdraw_course_datetime: gov_uk_format(datetime),
+      course_url: create_course_url(course),
+    )
+
+    mail(to: user.email)
+  end
+
+private
+
+  def create_course_url(course)
+    "#{Settings.find_url}" \
+      "/course/#{course.provider.provider_code}" \
+      "/#{course.course_code}"
+  end
+end

--- a/app/services/notification_service/course_withdrawn.rb
+++ b/app/services/notification_service/course_withdrawn.rb
@@ -1,0 +1,35 @@
+module NotificationService
+  class CourseWithdrawn
+    include ServicePattern
+
+    def initialize(course:)
+      @course = course
+    end
+
+    def call
+      return false unless notify_accredited_body?
+
+      # Reusing existing scoping as we're doing all or nothing notifications atm
+      # for course_publish_notification_requests
+      users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
+
+      users.each do |user|
+        CourseWithdrawEmailMailer.course_withdraw_email(
+          course,
+          user,
+          DateTime.now,
+        ).deliver_later(queue: "mailer")
+      end
+    end
+
+  private
+
+    attr_reader :course
+
+    def notify_accredited_body?
+      return false if course.self_accredited?
+
+      true
+    end
+  end
+end

--- a/azure/template.json
+++ b/azure/template.json
@@ -178,6 +178,13 @@
         "description": "The GOV.UK Notify template id for the course publish email"
       }
     },
+    "govukNotifyCourseWithdrawEmailTemplateId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The GOV.UK Notify template id for the course withdraw email"
+      }
+    },
     "govukNotifyMagicLinkEmailTemplateId": {
       "type": "string",
       "defaultValue": "",
@@ -510,6 +517,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_PUBLISH_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyCoursePublishEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_WITHDRAW_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
               },
               {
                 "name": "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -10,6 +10,7 @@ govuk_notify:
   course_update_email_template_id: please_change_me
   course_publish_email_template_id: please_change_me
   magic_link_email_template_id: please_change_me
+  course_withdraw_email_template_id: please_change_me
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -3,6 +3,7 @@ govuk_notify:
   welcome_email_template_id: please_change_me
   course_update_email_template_id: please_change_me
   course_publish_email_template_id: please_change_me
+  course_withdraw_email_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/spec/mailers/course_withdraw_email_mailer_spec.rb
+++ b/spec/mailers/course_withdraw_email_mailer_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe CourseWithdrawEmailMailer, type: :mailer do
+  let(:course) { create(:course, :with_accrediting_provider) }
+  let(:user) { create(:user) }
+  let(:mail) { described_class.course_withdraw_email(course, user, DateTime.new(2001, 2, 3, 4, 5, 6)) }
+
+  before do
+    course
+    mail
+  end
+
+  context "sending an email to a user" do
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_withdraw_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the provider name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:provider_name]).to eq(course.provider.provider_name)
+    end
+
+    it "includes the course name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_name]).to eq(course.name)
+    end
+
+    it "includes the course code in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_code]).to eq(course.course_code)
+    end
+
+    it "includes the datetime for the withdrawl in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:withdraw_course_datetime]).to eq("4:05am on 3 February 2001")
+    end
+
+    it "includes the URL for the course in the personalisation" do
+      url = "#{Settings.find_url}" \
+        "/course/#{course.provider.provider_code}" \
+        "/#{course.course_code}"
+      expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
+    end
+  end
+end

--- a/spec/services/notification_service/course_withdrawn_spec.rb
+++ b/spec/services/notification_service/course_withdrawn_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+module NotificationService
+  describe CourseWithdrawn do
+    let(:subscribed_user1) { create(:user) }
+    let(:subscribed_user2) { create(:user) }
+    let(:non_subscribed_user) { create(:user) }
+    let(:accredited_body) { create(:provider, :accredited_body) }
+
+    let(:user_notifications) do
+      create(:user_notification, user: subscribed_user1, provider: accredited_body, course_publish: true)
+      create(:user_notification, user: subscribed_user2, provider: accredited_body, course_publish: true)
+      create(:user_notification, user: non_subscribed_user, provider: accredited_body, course_publish: false)
+    end
+
+    let(:course) { create(:course, accrediting_provider: accredited_body) }
+
+    let(:service_call) { described_class.call(course: course) }
+
+    before do
+      allow(CourseWithdrawEmailMailer).to receive(:course_withdraw_email)
+      user_notifications
+    end
+
+    context "course is not self accredited" do
+      before { allow(course).to receive(:self_accredited?).and_return(false) }
+
+      it "sends notifications to users who have elected to recieve notifications" do
+        [subscribed_user1, subscribed_user2].each do |user|
+          expect(CourseWithdrawEmailMailer)
+            .to receive(:course_withdraw_email)
+            .with(
+              course,
+              user,
+              DateTime.now,
+            ).and_return(mailer = double)
+          expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+        end
+
+        service_call
+      end
+    end
+
+    context "course is self accredited" do
+      before { allow(course).to receive(:self_accredited?).and_return(true) }
+
+      it "does not send a notification" do
+        expect(CourseWithdrawEmailMailer).not_to receive(:course_withdraw_email)
+        service_call
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/uuwGgy2X/3557-turn-on-accredited-body-notifications-for-when-course-is-withdrawn

Still need to sort out the Notify templates, setting up appropriate environment variables. 

### Changes proposed in this pull request
* Add withdraw notification mailer
* Add course withdrawn service
* Add hook for notification when course is withdrawn

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
