### PR TITLE
[3563] Add endpoint to show training provider

### DIFF
--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -65,6 +65,14 @@ module API
                }
       end
 
+      def show
+        training_provider = @provider.training_providers.find_by(provider_code: params[:training_provider_code])
+
+        authorize training_provider, :can_show_training_provider?
+
+        render jsonapi: training_provider
+      end
+
     private
 
       def build_recruitment_cycle

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -47,6 +47,15 @@ class ProviderPolicy
     user.present?
   end
 
+  def can_show_training_provider?
+    return true if user.admin?
+
+    accredited_bodies_codes = provider.accredited_bodies.map { |ab| ab[:provider_code] }
+    user_provider_codes = user.providers.pluck(:provider_code)
+
+    !(accredited_bodies_codes & user_provider_codes).compact.empty?
+  end
+
   alias_method :can_list_sites?, :show?
   alias_method :can_create_course?, :show?
   alias_method :update?, :show?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,6 +45,7 @@ Rails.application.routes.draw do
         end
         resources :sites, only: %i[index update show create]
         resources :recruitment_cycles, only: %i[index]
+        get "training_providers/:training_provider_code", to: "accredited_provider_training_providers#show"
         get :training_providers, to: "accredited_provider_training_providers#index"
         get "/training_providers/:training_provider_code/courses", to: "accredited_body_training_provider_courses#index"
       end

--- a/spec/controllers/api/v2/accredited_provider_training_providers_controller_spec.rb
+++ b/spec/controllers/api/v2/accredited_provider_training_providers_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe API::V2::AccreditedProviderTrainingProvidersController do
+  let(:current_user) do
+    create(:user, admin: true, email: "admin@digital.education.gov.uk")
+  end
+
+  let(:provider) { course.accrediting_provider }
+  let(:training_provider) { course.provider }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+  let(:course) { create(:course, :with_accrediting_provider) }
+
+  before do
+    allow(controller).to receive(:authenticate).and_return(true)
+    allow(controller).to receive(:current_user).and_return(current_user)
+  end
+
+  describe "#show" do
+    it "returns the training provider" do
+      get :show, params: {
+        recruitment_cycle_year: recruitment_cycle.year,
+        provider_code: provider.provider_code,
+        training_provider_code: training_provider.provider_code,
+      }
+
+      expect(JSON.parse(response.body).dig("data", "id").to_i).to eql(training_provider.id)
+    end
+  end
+end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -30,4 +30,18 @@ describe ProviderPolicy do
     it { should_not permit(user_outside_org, provider) }
     it { should permit(admin, provider) }
   end
+
+  permissions :can_show_training_provider? do
+    let(:admin) { build(:user, :admin) }
+    let(:allowed_user) { provider.users.first }
+    let(:not_allowed_user) { create(:user) }
+
+    let(:provider) { course.accrediting_provider }
+    let(:training_provider) { course.provider }
+    let(:course) { create(:course, :with_accrediting_provider) }
+
+    it { should permit(admin, training_provider) }
+    it { should permit(allowed_user, training_provider) }
+    it { should_not permit(not_allowed_user, training_provider) }
+  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/6S5IQpl1/3563-accredited-bodies-cant-see-the-courses-they-accredit
- The Providers#show endpoint is only accessible to users that are associated to the provider via an organisation
- Therefore it is not suitable for displaying of training provider which should be accessible to accredited bodies 

### Changes proposed in this pull request

- Add new endpoint
- This endpoint allows accredited body users to see a specific training
provider
- This endpoint is also accessible to admins
- This prevents ProvidersController#show from being overloaded
- ProvidersController#show is used for only showing direct providers the
user has access to

### Guidance to review

- paired with https://github.com/DFE-Digital/publish-teacher-training/pull/1195
- follow review guidance at https://github.com/DFE-Digital/publish-teacher-training/pull/1195

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
