### PR TITLE
[3574] Hardcode allocation year to 2020

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -49,9 +49,9 @@ module API
       end
 
       def destroy
-        authorize @allocation = Allocation.find(params[:id])
+        authorize @allocation = current_recruitment_cycle.allocations.find(params[:id])
 
-        if @allocation.safe_delete(current_recruitment_cycle)
+        if @allocation.destroy
           head :ok
         else
           render jsonapi_errors: @allocation.errors, status: :unprocessable_entity
@@ -61,7 +61,7 @@ module API
     private
 
       def current_recruitment_cycle
-        @current_recruitment_cycle ||= RecruitmentCycle.current_recruitment_cycle
+        @current_recruitment_cycle ||= RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR)
       end
 
       def accredited_body

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -1,4 +1,6 @@
 class Allocation < ApplicationRecord
+  ALLOCATION_CYCLE_YEAR = Settings.allocation_cycle_year.to_s.freeze
+
   belongs_to :provider
   belongs_to :accredited_body, class_name: "Provider"
   belongs_to :recruitment_cycle
@@ -19,14 +21,6 @@ class Allocation < ApplicationRecord
       accredited_body_code: accredited_body_code,
       recruitment_cycle: recruitment_cycle.previous,
     )
-  end
-
-  def safe_delete(recruitment_cycle)
-    if recruitment_cycle == self.recruitment_cycle
-      self.delete
-    else
-      errors.add(:safe_delete, "recruitment cycle does not match")
-    end
   end
 
 private

--- a/app/services/allocations/create.rb
+++ b/app/services/allocations/create.rb
@@ -46,7 +46,7 @@ module Allocations
     end
 
     def set_recruitment_cycle
-      object.recruitment_cycle_id ||= RecruitmentCycle.current_recruitment_cycle.id
+      object.recruitment_cycle_id ||= RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR).id
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,6 +4,7 @@ authentication:
   # forget to do this in production.
   secret: <%= SecureRandom.base64 %>
 current_recruitment_cycle_year: 2020
+allocation_cycle_year: 2020
 govuk_notify:
   api_key: please_change_me
   welcome_email_template_id: please_change_me

--- a/spec/models/allocation_spec.rb
+++ b/spec/models/allocation_spec.rb
@@ -70,28 +70,4 @@ RSpec.describe Allocation do
       end
     end
   end
-
-  describe "#safe_delete" do
-    subject { create(:allocation, number_of_places: 1) }
-
-    context "when the recruitment cycle does not match" do
-      let(:previous_recruitment_cycle) { create(:recruitment_cycle, :previous) }
-
-      it "returns an error" do
-        subject.safe_delete(previous_recruitment_cycle)
-
-        expect(subject.errors[:safe_delete]).to eq(["recruitment cycle does not match"])
-      end
-    end
-
-    context "when the recruitment cycle matches" do
-      let(:current_recruitment_cycle) { find_or_create(:recruitment_cycle) }
-
-      it "deletes the allocation" do
-        expect(subject).to receive(:delete)
-
-        subject.safe_delete(current_recruitment_cycle)
-      end
-    end
-  end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/KHA3DiHM/3574-hardcode-allocation-year-for-rollover
- Allocations will be present over different cycles and rollover
- However we want allocations to be created in correct cycle

### Changes proposed in this pull request

- Hardcode year to `2020`
- This should be controlled by us and not the client
- This will have to be changed once a year, every year

### Guidance to review

- Change the current recruitment cycle
- Create a new allocation
- Allocation should be created for the year `2020`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
