### PR TITLE
3538 l treat university locations as an area rather than a single point in api

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -40,8 +40,14 @@ class CourseSearchService
       outer_scope = outer_scope.select("provider.provider_name", "course.*")
     elsif sort_by_distance?
       outer_scope = outer_scope.joins(courses_with_distance_from_origin)
-      outer_scope = outer_scope.select("course.*, distance")
-      outer_scope = outer_scope.order(:distance)
+      boosted_distance_column = "
+      (CASE
+        WHEN provider.provider_type = 'O' THEN (distance - 10)
+        ELSE distance
+      END) as boosted_distance"
+      select_criteria = "course.*, distance, #{boosted_distance_column}"
+      outer_scope = outer_scope.joins(:provider).select(select_criteria)
+      outer_scope = outer_scope.order(:boosted_distance)
     end
 
     outer_scope

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -91,7 +91,9 @@ private
     # select course_id and nearest site with shortest distance from origin
     # as courses may have multiple sites
     # this will remove duplicates by aggregating on course_id
-    locatable_sites.project(:course_id, Arel.sql("MIN#{Site.distance_sql(OpenStruct.new(lat: origin[0], lng: origin[1]))} as distance")).group(:course_id)
+    origin_lat_long = OpenStruct.new(lat: origin[0], lng: origin[1])
+    lowest_locatable_distance = Arel.sql("MIN#{Site.distance_sql(origin_lat_long)} as distance")
+    locatable_sites.project(:course_id, lowest_locatable_distance).group(:course_id)
   end
 
   def distance_table

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -59,21 +59,21 @@ private
     sites_with_status = site_status.join(sites).on(site_status[:site_id].eq(sites[:id]))
 
     # only want new and running sites
-    new_and_running_sites = sites_with_status.where(site_status[:status].in(%w[new_status running]))
+    running_and_published_sites = sites_with_status.where(site_status[:status].eq(SiteStatus.statuses[:running]).and(site_status[:publish].eq(SiteStatus.publishes[:published])))
 
     # we only want sites that have been geocoded
-    geocoded_new_and_running_sites = new_and_running_sites.where(sites[:latitude].not_eq(nil).and(sites[:longitude].not_eq(nil)))
+    geocoded_running_and_published_sites = running_and_published_sites.where(sites[:latitude].not_eq(nil).and(sites[:longitude].not_eq(nil)))
 
     # only sites that have a locatable address
     # there are some sites with no address1 or postcode that cannot be
     # accurately geocoded. We don't want to return these as the closest site.
     # This should be removed once the data is fixed
-    locatable_new_and_running_sites = geocoded_new_and_running_sites.where(sites[:address1].not_eq("").or(sites[:postcode].not_eq("")))
+    locatable_running_and_published_sites = geocoded_running_and_published_sites.where(sites[:address1].not_eq("").or(sites[:postcode].not_eq("")))
 
     # select course_id and nearest site with shortest distance from origin
     # as courses may have multiple sites
     # this will remove duplicates by aggregating on course_id
-    courses_with_nearest_site = locatable_new_and_running_sites.project(:course_id, Arel.sql("MIN#{Site.distance_sql(OpenStruct.new(lat: origin[0], lng: origin[1]))} as distance")).group(:course_id)
+    courses_with_nearest_site = locatable_running_and_published_sites.project(:course_id, Arel.sql("MIN#{Site.distance_sql(OpenStruct.new(lat: origin[0], lng: origin[1]))} as distance")).group(:course_id)
 
     # form a temporary table with results
     distance_table = Arel::Nodes::TableAlias.new(

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -81,11 +81,10 @@ private
     locatable_address_criteria = sites[:address1].not_eq("").or(sites[:postcode].not_eq(""))
 
     # Create virtual table with sites and site statuses
-    locatable_sites = site_status.join(sites).on(site_status[:site_id].eq(sites[:id]))
-
-    locatable_sites = locatable_sites.where(running_and_published_criteria)
-    locatable_sites = locatable_sites.where(has_been_geocoded_criteria)
-    locatable_sites.where(locatable_address_criteria)
+    site_status.join(sites).on(site_status[:site_id].eq(sites[:id]))
+     .where(running_and_published_criteria)
+     .where(has_been_geocoded_criteria)
+     .where(locatable_address_criteria)
   end
 
   def course_id_with_lowest_locatable_distance

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -42,7 +42,12 @@ class CourseSearchService
       outer_scope = outer_scope.joins(courses_with_distance_from_origin)
       outer_scope = outer_scope.joins(:provider)
       outer_scope = outer_scope.select("course.*, distance, #{distance_with_university_area_adjustment}")
-      outer_scope = outer_scope.order(:boosted_distance)
+
+      outer_scope = if expand_university?
+                      outer_scope.order(:boosted_distance)
+                    else
+                      outer_scope.order(:distance)
+                    end
     end
 
     outer_scope
@@ -51,6 +56,10 @@ class CourseSearchService
   private_class_method :new
 
 private
+
+  def expand_university?
+    filter[:expand_university].to_s.downcase == "true"
+  end
 
   def distance_with_university_area_adjustment
     university_provider_type = Provider.provider_types[:university]

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -55,7 +55,7 @@ private
   def distance_with_university_area_adjustment
     university_provider_type = Provider.provider_types[:university]
     university_location_area_radius = 10
-    <<~EOSQL.gsub(/^[\s\t]*/, "").gsub(/[\s\t]*\n/, " ").strip
+    <<~EOSQL.gsub(/\s+/m, " ").strip
       (CASE
         WHEN provider.provider_type = '#{university_provider_type}'
           THEN (distance - #{university_location_area_radius})

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -68,7 +68,7 @@ describe CourseSearchService do
           expect(Course).to receive(:where).and_return(findable_scope)
           expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
           expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-          distance_with_university_area_adjustment = <<~EOSQL.gsub(/^[\s\t]*/, "").gsub(/[\s\t]*\n/, " ").strip
+          distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
             (CASE
               WHEN provider.provider_type = 'O'
                 THEN (distance - 10)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -59,28 +59,80 @@ describe CourseSearchService do
 
       context "by distance" do
         let(:sort) { "distance" }
-        let(:filter) do
-          { latitude: 54.9713392, longitude: -1.6112336 }
-        end
 
-        it "orders in descending order" do
-          expect(findable_scope).to receive(:select).and_return(inner_query_scope)
-          expect(Course).to receive(:where).and_return(findable_scope)
-          expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
-          expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-          distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
-            (CASE
-              WHEN provider.provider_type = 'O'
-                THEN (distance - 10)
-              ELSE distance
-            END) as boosted_distance
-          EOSQL
-          select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
+        describe "expand university" do
+          context "when false" do
+            let(:filter) do
+              { latitude: 54.9713392, longitude: -1.6112336, expand_university: "false" }
+            end
+            it "orders in descending order by distance" do
+              expect(findable_scope).to receive(:select).and_return(inner_query_scope)
+              expect(Course).to receive(:where).and_return(findable_scope)
+              expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
+              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
+              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
+                (CASE
+                  WHEN provider.provider_type = 'O'
+                    THEN (distance - 10)
+                  ELSE distance
+                END) as boosted_distance
+              EOSQL
+              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
 
-          expect(select_scope).to receive(:select).with(select_criteria)
-            .and_return(order_scope)
-          expect(order_scope).to receive(:order).with(:boosted_distance).and_return(expected_scope)
-          expect(subject).to eq(expected_scope)
+              expect(select_scope).to receive(:select).with(select_criteria)
+                .and_return(order_scope)
+              expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
+              expect(subject).to eq(expected_scope)
+            end
+          end
+          context "when absent" do
+            let(:filter) do
+              { latitude: 54.9713392, longitude: -1.6112336 }
+            end
+            it "orders in descending order by distance" do
+              expect(findable_scope).to receive(:select).and_return(inner_query_scope)
+              expect(Course).to receive(:where).and_return(findable_scope)
+              expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
+              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
+              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
+                (CASE
+                  WHEN provider.provider_type = 'O'
+                    THEN (distance - 10)
+                  ELSE distance
+                END) as boosted_distance
+              EOSQL
+              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
+
+              expect(select_scope).to receive(:select).with(select_criteria)
+                .and_return(order_scope)
+              expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
+              expect(subject).to eq(expected_scope)
+            end
+          end
+          context "when true" do
+            let(:filter) do
+              { latitude: 54.9713392, longitude: -1.6112336, expand_university: "true" }
+            end
+            it "orders in descending order by boosted distance" do
+              expect(findable_scope).to receive(:select).and_return(inner_query_scope)
+              expect(Course).to receive(:where).and_return(findable_scope)
+              expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
+              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
+              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
+                (CASE
+                  WHEN provider.provider_type = 'O'
+                    THEN (distance - 10)
+                  ELSE distance
+                END) as boosted_distance
+              EOSQL
+              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
+
+              expect(select_scope).to receive(:select).with(select_criteria)
+                .and_return(order_scope)
+              expect(order_scope).to receive(:order).with(:boosted_distance).and_return(expected_scope)
+              expect(subject).to eq(expected_scope)
+            end
+          end
         end
       end
 
@@ -437,9 +489,15 @@ describe CourseSearchService do
     end
   end
 
-  describe "10 miles diff" do
+  describe "expand_university" do
     context "university course vs non university course" do
       null_island = { latitude: 0, longitude: 0 }
+
+      over_5_miles_from_null_island = { latitude: 0.1, longitude: 0 }
+
+      subject do
+        described_class.call(filter: filter, sort: "distance", course_scope: scope)
+      end
 
       let(:university_course) do
         create(:course, provider: university_provider,
@@ -458,7 +516,7 @@ describe CourseSearchService do
       end
 
       let(:site) do
-        build(:site, **null_island)
+        build(:site, **over_5_miles_from_null_island)
       end
 
       let(:site2) do
@@ -481,18 +539,57 @@ describe CourseSearchService do
         Course.all
       end
 
-      subject do
-        described_class.call(filter: null_island, sort: "distance", course_scope: scope)
+      context "when false" do
+        let(:filter) do
+          null_island.merge(expand_university: "false")
+        end
+
+        it "returns correctly" do
+          expect(subject.count(:id)).to eq(2)
+
+          expect(subject.first.boosted_distance).to eq(0)
+          expect(subject.first.distance).to eq(0)
+          expect(subject.first).to eq(non_university_course)
+
+          expect(subject.second.boosted_distance - subject.second.distance).to eq(-10)
+          expect(subject.second).to eq(university_course)
+        end
       end
 
-      it "returns correctly" do
-        expect(subject.count(:id)).to eq(2)
-        expect(subject.first.boosted_distance).to eq(-10)
-        expect(subject.first.distance).to eq(0)
-        expect(subject.first).to eq(university_course)
-        expect(subject.second.boosted_distance).to eq(0)
-        expect(subject.second.distance).to eq(0)
-        expect(subject.second).to eq(non_university_course)
+      context "when absent" do
+        let(:filter) do
+          null_island
+        end
+
+        it "returns correctly" do
+          expect(subject.count(:id)).to eq(2)
+
+          expect(subject.first.boosted_distance).to eq(0)
+          expect(subject.first.distance).to eq(0)
+          expect(subject.first).to eq(non_university_course)
+
+          expect(subject.second.boosted_distance - subject.second.distance).to eq(-10)
+          expect(subject.second).to eq(university_course)
+        end
+      end
+
+      context "when true" do
+        describe "university course has less 10 miles" do
+          let(:filter) do
+            null_island.merge(expand_university: "true")
+          end
+
+          it "returns correctly" do
+            expect(subject.count(:id)).to eq(2)
+
+            expect(subject.first.boosted_distance - subject.first.distance).to eq(-10)
+            expect(subject.first).to eq(university_course)
+
+            expect(subject.second.boosted_distance).to eq(0)
+            expect(subject.second.distance).to eq(0)
+            expect(subject.second).to eq(non_university_course)
+          end
+        end
       end
     end
   end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -68,12 +68,14 @@ describe CourseSearchService do
           expect(Course).to receive(:where).and_return(findable_scope)
           expect(findable_scope).to receive(:joins).and_return(joins_provider_scope)
           expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-          boosted_distance_column = "
-      (CASE
-        WHEN provider.provider_type = 'O' THEN (distance - 10)
-        ELSE distance
-      END) as boosted_distance"
-          select_criteria = "course.*, distance, #{boosted_distance_column}"
+          distance_with_university_area_adjustment = <<~EOSQL.gsub(/^[\s\t]*/, "").gsub(/[\s\t]*\n/, " ").strip
+            (CASE
+              WHEN provider.provider_type = 'O'
+                THEN (distance - 10)
+              ELSE distance
+            END) as boosted_distance
+          EOSQL
+          select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
 
           expect(select_scope).to receive(:select).with(select_criteria)
             .and_return(order_scope)


### PR DESCRIPTION
### Context
based upon #1356 

### Changes proposed in this pull request

Added a `boosted_distance` column where by it can be used as for the ordering
This is to improve university course ranking via distance searches
Added an `expand_university` filter flag when it is not set or set as `false` then it will retain current/old behaviour order via `distance`, when set to true then it will use the new `boosted_distance` for ordering.

~~Added provider type to serialiser~~ move to here https://github.com/DFE-Digital/teacher-training-api/pull/1440

### Guidance to review
Best to review commit by commit
Best to compare before and after https://github.com/DFE-Digital/find-teacher-training/pull/353

### Benchmark

command
```sh
time curl "http://localhost:3002/results?fulltime=false&hasvacancies=true&l=1&lat=54.9827086&lng=-1.6572078&loc=Newcastle+upon+Tyne+NE4+9YH%2C+UK&lq=Newcastle+upon+Tyne+NE4+9YH%2C+UK&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&rad=20&senCourses=false&sortby=2&subjects%5B%5D=31"
```

find (9c72d5fb8791db05c04db275acb6ddaba8be82be)

api

master (88058ede663f006559c23976878ac90f1a82ec37)

curl   0.01s user 0.02s system 0% cpu 2.626 total
curl   0.01s user 0.02s system 0% cpu 2.816 total
curl   0.01s user 0.02s system 0% cpu 2.687 total


3538-l-treat-university-locations-as-an-area-rather-than-a-single-point-in-api (82ccd36b139600fe682b7a6104798aeb0ef39545)

curl   0.01s user 0.03s system 1% cpu 2.453 total
curl   0.01s user 0.02s system 0% cpu 2.654 total
curl   0.01s user 0.02s system 1% cpu 2.486 total

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
