### PR TITLE
[3557] Add withdraw email template ID to azure

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -1004,6 +1004,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_PUBLISH_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyCoursePublishEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_WITHDRAW_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
               }
             ]
           },


### PR DESCRIPTION
### Context
https://trello.com/c/uuwGgy2X/3557-turn-on-accredited-body-notifications-for-when-course-is-withdrawn

https://github.com/DFE-Digital/teacher-training-api/pull/1430

I've had to do this second PR as the first was merged

### Changes proposed in this pull request

Add notify template ID env variable to azure, was not done correctly in previous PR

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
