### PR TITLE
[3558] - add 'course vacancies full' notification

### DIFF
--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -7,6 +7,10 @@ module API
         site_status = authorize SiteStatus.find(params[:id])
         site_status.update site_status_params
 
+        if site_status.no_vacancies?
+          NotificationService::CourseVacanciesFilled.call(course: site_status.course)
+        end
+
         render jsonapi: site_status
       end
 

--- a/app/controllers/api/v2/site_statuses_controller.rb
+++ b/app/controllers/api/v2/site_statuses_controller.rb
@@ -5,11 +5,14 @@ module API
 
       def update
         site_status = authorize SiteStatus.find(params[:id])
-        site_status.update site_status_params
 
-        if site_status.no_vacancies?
+        site_status.assign_attributes(site_status_params)
+
+        if site_status.vacancies_filled?
           NotificationService::CourseVacanciesFilled.call(course: site_status.course)
         end
+
+        site_status.save!
 
         render jsonapi: site_status
       end
@@ -19,7 +22,7 @@ module API
       def site_status_params
         params
           .require(:site_status)
-          .except(:id, :type, :site_id, :site_type, :has_vacancies?)
+          .except(:id, :type, :site_id, :site_type, :has_vacancies?, :recruitment_cycle_year)
           .permit(
             :publish,
             :status,

--- a/app/mailers/course_vacancies_filled_email_mailer.rb
+++ b/app/mailers/course_vacancies_filled_email_mailer.rb
@@ -1,0 +1,25 @@
+class CourseVacanciesFilledEmailMailer < GovukNotifyRails::Mailer
+  include TimeFormat
+
+  def course_vacancies_filled_email(course, user, datetime)
+    set_template(Settings.govuk_notify.course_vacancies_filled_email_template_id)
+
+    set_personalisation(
+      provider_name: course.provider.provider_name,
+      course_name: course.name,
+      course_code: course.course_code,
+      vacancies_filled_datetime: gov_uk_format(datetime),
+      course_url: create_course_url(course),
+    )
+
+    mail(to: user.email)
+  end
+
+private
+
+  def create_course_url(course)
+    "#{Settings.find_url}" \
+      "/course/#{course.provider.provider_code}" \
+      "/#{course.course_code}"
+  end
+end

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -84,6 +84,10 @@ class SiteStatus < ApplicationRecord
     with_vacancies?
   end
 
+  def vacancies_filled?
+    will_save_change_to_attribute?(:vac_status, to: "no_vacancies") && running?
+  end
+
 private
 
   def set_defaults

--- a/app/services/notification_service/course_vacancies_filled.rb
+++ b/app/services/notification_service/course_vacancies_filled.rb
@@ -1,0 +1,35 @@
+module NotificationService
+  class CourseVacanciesFilled
+    include ServicePattern
+
+    def initialize(course:)
+      @course = course
+    end
+
+    def call
+      return false unless notify_accredited_body?
+
+      # Reusing existing scoping as we're doing all or nothing notifications atm
+      # for course_publish_notification_requests
+      users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
+
+      users.each do |user|
+        CourseVacanciesFilledEmailMailer.course_vacancies_filled_email(
+          course,
+          user,
+          DateTime.now,
+          ).deliver_later(queue: "mailer")
+      end
+    end
+
+  private
+
+    attr_reader :course
+
+    def notify_accredited_body?
+      return false if course.self_accredited?
+
+      true
+    end
+  end
+end

--- a/azure/template.json
+++ b/azure/template.json
@@ -185,6 +185,13 @@
         "description": "The GOV.UK Notify template id for the course withdraw email"
       }
     },
+    "govukNotifyCourseVacanciesFilledEmailTemplateId": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The GOV.UK Notify template id for the course vacancies filled email"
+      }
+    },
     "govukNotifyMagicLinkEmailTemplateId": {
       "type": "string",
       "defaultValue": "",
@@ -513,6 +520,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_UPDATE_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyCourseUpdateEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_VACANCIES_FILLED_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseVacacniesFilledEmailTemplateId')]"
               },
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_PUBLISH_EMAIL_TEMPLATE_ID",
@@ -1008,6 +1019,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_WITHDRAW_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_VACANCIES_FILLED_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyCourseVacacniesFilledEmailTemplateId')]"
               }
             ]
           },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,6 +12,7 @@ govuk_notify:
   course_publish_email_template_id: please_change_me
   magic_link_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
+  course_vacancies_filled_template_id: please_change_me
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -4,6 +4,7 @@ govuk_notify:
   course_update_email_template_id: please_change_me
   course_publish_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
+  course_vacancies_filled_email_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -1,34 +1,48 @@
 require "rails_helper"
 
 describe API::V2::CoursesController, type: :controller do
+  let(:site_status) { build(:site_status, :new) }
+  let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
+  let(:course) {
+    create(:course,
+           site_statuses: [site_status],
+           enrichments: [enrichment],
+           subjects: [dfe_subject])
+  }
+  let(:email) { "manage_courses@digital.education.gov.uk" }
+  let(:sign_in_user_id) { "manage_courses_api" }
+  let(:existing_user) do
+    create(
+      :user, admin: true,
+      email: email,
+      sign_in_user_id: sign_in_user_id
+    )
+  end
+
+  before do
+    allow(controller).to receive(:authenticate).and_return(true)
+    controller.instance_variable_set(:@current_user, existing_user)
+  end
+
   describe "#publish" do
     let(:enrichment) { build(:course_enrichment, :initial_draft) }
-    let(:site_status) { build(:site_status, :new) }
-    let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
-    let(:course) {
-      create(:course,
-             site_statuses: [site_status],
-             enrichments: [enrichment],
-             subjects: [dfe_subject])
-    }
-    let(:email) { "manage_courses@digital.education.gov.uk" }
-    let(:sign_in_user_id) { "manage_courses_api" }
-    let(:existing_user) do
-      create(
-        :user, admin: true,
-        email: email,
-        sign_in_user_id: sign_in_user_id
-      )
-    end
 
-    before do
-      allow(controller).to receive(:authenticate).and_return(true)
-      controller.instance_variable_set(:@current_user, existing_user)
-    end
-
-    it "sends the notification" do
-      allow(NotificationService::CoursePublished).to receive(:call).with(course: course)
+    it "sends the course publish notification" do
+      expect(NotificationService::CoursePublished).to receive(:call).with(course: course)
       post :publish, params: {
+        recruitment_cycle_year: RecruitmentCycle.current_recruitment_cycle.year,
+        provider_code: course.provider.provider_code,
+        code: course.course_code,
+      }
+    end
+  end
+
+  describe "#withdraw" do
+    let(:enrichment) { build(:course_enrichment, :published) }
+
+    it "sends the course withdrawn notification" do
+      expect(NotificationService::CourseWithdrawn).to receive(:call).with(course: course)
+      post :withdraw, params: {
         recruitment_cycle_year: RecruitmentCycle.current_recruitment_cycle.year,
         provider_code: course.provider.provider_code,
         code: course.course_code,

--- a/spec/controllers/api/v2/site_statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/site_statuses_controller_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe API::V2::SiteStatusesController, type: :controller do
+  let(:site_status) { build(:site_status, :new) }
+  let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
+  let(:course) {
+    create(:course,
+           site_statuses: [site_status],
+           enrichments: [enrichment],
+           subjects: [dfe_subject])
+  }
+  let(:email) { "manage_courses@digital.education.gov.uk" }
+  let(:sign_in_user_id) { "manage_courses_api" }
+  let(:existing_user) do
+    create(
+      :user, admin: true,
+      email: email,
+      sign_in_user_id: sign_in_user_id
+    )
+  end
+
+  before do
+    allow(controller).to receive(:authenticate).and_return(true)
+    controller.instance_variable_set(:@current_user, existing_user)
+  end
+
+  describe "#update" do
+    let(:enrichment) { build(:course_enrichment, :published) }
+
+    it "sends the course vacancies full notification" do
+      expect(NotificationService::CourseVacanciesFilled).to receive(:call).with(course: course)
+      post :update, params: {
+        id: site_status.id,
+        site_status: {
+          vac_status: "no_vacancies",
+        },
+      }
+    end
+  end
+end

--- a/spec/controllers/api/v2/site_statuses_controller_spec.rb
+++ b/spec/controllers/api/v2/site_statuses_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 describe API::V2::SiteStatusesController, type: :controller do
-  let(:site_status) { build(:site_status, :new) }
+  let(:site_status) { build(:site_status, :running) }
   let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
   let(:course) {
     create(:course,

--- a/spec/mailers/course_vacancies_filled_email_mailer_spec.rb
+++ b/spec/mailers/course_vacancies_filled_email_mailer_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe CourseVacanciesFilledEmailMailer, type: :mailer do
+  let(:course) { create(:course, :with_accrediting_provider) }
+  let(:user) { create(:user) }
+  let(:mail) { described_class.course_vacancies_filled_email(course, user, DateTime.new(2001, 2, 3, 4, 5, 6)) }
+
+  before do
+    course
+    mail
+  end
+
+  context "sending an email to a user" do
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_vacancies_filled_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the provider name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:provider_name]).to eq(course.provider.provider_name)
+    end
+
+    it "includes the course name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_name]).to eq(course.name)
+    end
+
+    it "includes the course code in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_code]).to eq(course.course_code)
+    end
+
+    it "includes the datetime for the withdrawl in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:vacancies_filled_datetime]).to eq("4:05am on 3 February 2001")
+    end
+
+    it "includes the URL for the course in the personalisation" do
+      url = "#{Settings.find_url}" \
+        "/course/#{course.provider.provider_code}" \
+        "/#{course.course_code}"
+      expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
+    end
+  end
+end

--- a/spec/models/site_status_spec.rb
+++ b/spec/models/site_status_spec.rb
@@ -165,4 +165,30 @@ RSpec.describe SiteStatus, type: :model do
       end
     end
   end
+
+  describe "#vacancies_filled?" do
+    context "vacancies filled" do
+      subject { create(:site_status, :running, :full_time_vacancies) }
+
+      before do
+        subject.assign_attributes(vac_status: "no_vacancies")
+      end
+
+      it "returns true" do
+        expect(subject.vacancies_filled?).to eq(true)
+      end
+    end
+
+    context "vacancies available" do
+      subject { create(:site_status, :running, :with_no_vacancies) }
+
+      before do
+        subject.assign_attributes(vac_status: "full_time_vacancies")
+      end
+
+      it "returns false" do
+        expect(subject.vacancies_filled?).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/services/notification_service/course_vacancies_filled_spec.rb
+++ b/spec/services/notification_service/course_vacancies_filled_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+module NotificationService
+  describe CourseVacanciesFilled do
+    let(:subscribed_user1) { create(:user) }
+    let(:subscribed_user2) { create(:user) }
+    let(:non_subscribed_user) { create(:user) }
+    let(:accredited_body) { create(:provider, :accredited_body) }
+
+    let(:user_notifications) do
+      create(:user_notification, user: subscribed_user1, provider: accredited_body, course_publish: true)
+      create(:user_notification, user: subscribed_user2, provider: accredited_body, course_publish: true)
+      create(:user_notification, user: non_subscribed_user, provider: accredited_body, course_publish: false)
+    end
+
+    let(:course) { create(:course, accrediting_provider: accredited_body) }
+
+    let(:service_call) { described_class.call(course: course) }
+
+    before do
+      allow(CourseVacanciesFilledEmailMailer).to receive(:course_vacancies_filled_email)
+      user_notifications
+    end
+
+    context "course is not self accredited" do
+      before { allow(course).to receive(:self_accredited?).and_return(false) }
+
+      it "sends notifications to users who have elected to recieve notifications" do
+        [subscribed_user1, subscribed_user2].each do |user|
+          expect(CourseVacanciesFilledEmailMailer)
+            .to receive(:course_vacancies_filled_email)
+                  .with(
+                    course,
+                    user,
+                    DateTime.now,
+                    ).and_return(mailer = double)
+          expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+        end
+
+        service_call
+      end
+    end
+
+    context "course is self accredited" do
+      before { allow(course).to receive(:self_accredited?).and_return(true) }
+
+      it "does not send a notification" do
+        expect(CourseVacanciesFilledEmailMailer).not_to receive(:course_vacancies_filled_email)
+        service_call
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
When a user indicates that a course is full (has no vacancies) a notification will now be sent to notification subscribers.

### Changes proposed in this pull request
- Adds 'course vacancies full' emailer
-  Adds test coverage for 'course withdrawal' notification

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
