### PR TITLE
[3557] Remove course url from withdrawn notification

### DIFF
--- a/app/mailers/course_withdraw_email_mailer.rb
+++ b/app/mailers/course_withdraw_email_mailer.rb
@@ -9,17 +9,8 @@ class CourseWithdrawEmailMailer < GovukNotifyRails::Mailer
       course_name: course.name,
       course_code: course.course_code,
       withdraw_course_datetime: gov_uk_format(datetime),
-      course_url: create_course_url(course),
     )
 
     mail(to: user.email)
-  end
-
-private
-
-  def create_course_url(course)
-    "#{Settings.find_url}" \
-      "/course/#{course.provider.provider_code}" \
-      "/#{course.course_code}"
   end
 end

--- a/spec/mailers/course_withdraw_email_mailer_spec.rb
+++ b/spec/mailers/course_withdraw_email_mailer_spec.rb
@@ -34,12 +34,5 @@ describe CourseWithdrawEmailMailer, type: :mailer do
     it "includes the datetime for the withdrawl in the personalisation" do
       expect(mail.govuk_notify_personalisation[:withdraw_course_datetime]).to eq("4:05am on 3 February 2001")
     end
-
-    it "includes the URL for the course in the personalisation" do
-      url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
-      expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
-    end
   end
 end


### PR DESCRIPTION
### Context
https://trello.com/c/uuwGgy2X/3557-turn-on-accredited-body-notifications-for-when-course-is-withdrawn

Turned up in product review, the course url doesn't work for the accredited body seeing as the course is withdraw, so removing it from the notification

### Changes proposed in this pull request
Remove the course url stuff from withdrawl notification

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
