### PR TITLE
[3477] Add qa_paas environment

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -22,6 +22,13 @@ staging:
 qa:
   <<: *default
 
+qa_paas:
+  url: <%= ENV['DATABASE_URL'] %>
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+  database: <%= ENV['DB_DATABASE'] %>
+
 pentest:
   <<: *default
 

--- a/config/environments/qa_paas.rb
+++ b/config/environments/qa_paas.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/config/settings/qa_paas.yml
+++ b/config/settings/qa_paas.yml
@@ -1,0 +1,8 @@
+gcp_api_key: please_change_me
+publish_url: https://qa-publish-teacher-training-courses.london.cloudapps.digital
+find_url: https://qa-find-postgraduate-teacher-training.london.cloudapps.digital
+bg_jobs:
+  save_statistic:
+    cron: "0 0 * * *" # daily at midnight
+    class: "SaveStatisticJob"
+    queue: save_statistic


### PR DESCRIPTION
### Context
We are evaluating running this app on PAAS.

Eventually we will switch the existing QA, Staging and Production environments but while we are evaluating the PAAS this PAAS only environment will allow us to make configuration changes without disrupting the existing environments.

### Changes proposed in this pull request

Add qa_paas environment to allow deployment to the PAAS.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
