### PR TITLE
[3580] Notifications only for current cycle

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -516,6 +516,10 @@ class Course < ApplicationRecord
     services[:assignable_subjects].execute(course: self)
   end
 
+  def in_current_cycle?
+    recruitment_cycle.current?
+  end
+
 private
 
   def add_site!(site:)

--- a/app/services/notification_service/course_published.rb
+++ b/app/services/notification_service/course_published.rb
@@ -8,6 +8,7 @@ module NotificationService
 
     def call
       return false unless notify_accredited_body?
+      return false unless course.in_current_cycle?
 
       users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
 

--- a/app/services/notification_service/course_updated.rb
+++ b/app/services/notification_service/course_updated.rb
@@ -38,7 +38,10 @@ module NotificationService
     end
 
     def course_needs_to_notify?
-      course.findable? && !course.self_accredited? && notifiable_changes.any?
+      course.findable? &&
+        !course.self_accredited? &&
+        notifiable_changes.any? &&
+        course.in_current_cycle?
     end
   end
 end

--- a/app/services/notification_service/course_vacancies_filled.rb
+++ b/app/services/notification_service/course_vacancies_filled.rb
@@ -18,7 +18,7 @@ module NotificationService
           course,
           user,
           DateTime.now,
-          ).deliver_later(queue: "mailer")
+        ).deliver_later(queue: "mailer")
       end
     end
 
@@ -28,6 +28,7 @@ module NotificationService
 
     def notify_accredited_body?
       return false if course.self_accredited?
+      return false unless course.in_current_cycle?
 
       true
     end

--- a/app/services/notification_service/course_withdrawn.rb
+++ b/app/services/notification_service/course_withdrawn.rb
@@ -8,6 +8,7 @@ module NotificationService
 
     def call
       return false unless notify_accredited_body?
+      return false unless course.in_current_cycle?
 
       # Reusing existing scoping as we're doing all or nothing notifications atm
       # for course_publish_notification_requests

--- a/spec/services/notification_service/course_updated_spec.rb
+++ b/spec/services/notification_service/course_updated_spec.rb
@@ -22,18 +22,45 @@ module NotificationService
     end
 
     let(:service_call) { described_class.call(course: course) }
+    let(:findable) { true }
+    let(:self_accredited) { false }
 
-    before do
-      allow(CourseUpdateEmailMailer).to receive(:course_update_email)
+    def setup_notifications
+      allow(CourseUpdateEmailMailer).to receive(:course_update_email).and_return(double(deliver_later: true))
+      allow(course).to receive(:self_accredited?).and_return(self_accredited)
+      allow(course).to receive(:findable?).and_return(findable)
       user_notifications
     end
 
+    context "with a course that is in the current cycle" do
+      before { setup_notifications }
+
+      it "sends notifications" do
+        expect(CourseUpdateEmailMailer).to receive(:course_update_email)
+        expect(course.recruitment_cycle).to eql(RecruitmentCycle.current)
+        service_call
+      end
+    end
+
+    context "with a course that is not in the current cycle" do
+      let(:provider) { create(:provider, :next_recruitment_cycle) }
+      let(:course) { create(:course, accredited_body_code: accredited_body.provider_code, provider: provider) }
+
+      before { setup_notifications }
+
+      it "does not send notifications" do
+        expect(CourseUpdateEmailMailer).to_not receive(:course_update_email)
+        expect(course.recruitment_cycle).to_not eql(RecruitmentCycle.current)
+        service_call
+      end
+    end
+
     context "course is findable" do
-      before { allow(course).to receive(:findable?).and_return(true) }
+      before do
+        setup_notifications
+      end
 
       context "course is not self accredited" do
-        before { allow(course).to receive(:self_accredited?).and_return(false) }
-
         it "sends notifications to users who have elected to recieve notifications" do
           [subscribed_user1, subscribed_user2].each do |user|
             expect(CourseUpdateEmailMailer)
@@ -55,7 +82,7 @@ module NotificationService
       end
 
       context "course is self accredited" do
-        before { allow(course).to receive(:self_accredited?).and_return(true) }
+        let(:self_accredited) { true }
 
         it "does not send a notification" do
           expect(CourseUpdateEmailMailer).not_to receive(:course_update_email)
@@ -65,7 +92,11 @@ module NotificationService
     end
 
     context "course is not findable" do
-      before { allow(course).to receive(:findable?).and_return(false) }
+      let(:findable) { false }
+
+      before do
+        setup_notifications
+      end
 
       it "does not send a notification" do
         expect(CourseUpdateEmailMailer).not_to receive(:course_update_email)

--- a/spec/services/notification_service/course_withdrawn_spec.rb
+++ b/spec/services/notification_service/course_withdrawn_spec.rb
@@ -17,13 +17,39 @@ module NotificationService
 
     let(:service_call) { described_class.call(course: course) }
 
-    before do
-      allow(CourseWithdrawEmailMailer).to receive(:course_withdraw_email)
+    def setup_notifications
+      allow(CourseWithdrawEmailMailer).to receive(:course_withdraw_email).and_return(double(deliver_later: true))
       user_notifications
     end
 
+    context "with a course that is in the current cycle" do
+      before { setup_notifications }
+
+      it "sends notifications" do
+        expect(CourseWithdrawEmailMailer).to receive(:course_withdraw_email)
+        expect(course.recruitment_cycle).to eql(RecruitmentCycle.current)
+        described_class.call(course: course)
+      end
+    end
+
+    context "with a course that is not in the current cycle" do
+      let(:provider) { create(:provider, :next_recruitment_cycle) }
+      let(:course) { create(:course, accredited_body_code: accredited_body.provider_code, provider: provider) }
+
+      before { setup_notifications }
+
+      it "does not send notifications" do
+        expect(CourseWithdrawEmailMailer).to_not receive(:course_withdraw_email)
+        expect(course.recruitment_cycle).to_not eql(RecruitmentCycle.current)
+        described_class.call(course: course)
+      end
+    end
+
     context "course is not self accredited" do
-      before { allow(course).to receive(:self_accredited?).and_return(false) }
+      before do
+        setup_notifications
+        allow(course).to receive(:self_accredited?).and_return(false)
+      end
 
       it "sends notifications to users who have elected to recieve notifications" do
         [subscribed_user1, subscribed_user2].each do |user|
@@ -42,7 +68,10 @@ module NotificationService
     end
 
     context "course is self accredited" do
-      before { allow(course).to receive(:self_accredited?).and_return(true) }
+      before do
+        setup_notifications
+        allow(course).to receive(:self_accredited?).and_return(true)
+      end
 
       it "does not send a notification" do
         expect(CourseWithdrawEmailMailer).not_to receive(:course_withdraw_email)


### PR DESCRIPTION
### Context

- https://trello.com/c/DvAQtnEy/3580-disable-notifications-at-roll-over
- We only want to send notifications for courses in the current cycle. So that during rollover notifications around the next cycle are not sent

### Changes proposed in this pull request

- For course notifications add guard to ensure only courses in the current cycle send out notifications 

### Guidance to review

- With rollover enabled
- Find.a course in the next cycle that has user notifications
- Update the course eg fill the vacancies
- A notification should not be sent
- The same course in the current cycle if updated should send a notification

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
