### PR TITLE
Revert "[3336] - Add 'notifications_configured' attribute to UserSerializer"

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,10 +51,6 @@ class User < ApplicationRecord
       .positive?
   end
 
-  def notifications_configured?
-    user_notifications.count.positive?
-  end
-
 private
 
   def email_is_lowercase

--- a/app/serializers/api/v2/serializable_user.rb
+++ b/app/serializers/api/v2/serializable_user.rb
@@ -9,10 +9,6 @@ module API
       attribute :associated_with_accredited_body do
         @object.associated_with_accredited_body?
       end
-
-      attribute :notifications_configured do
-        @object.notifications_configured?
-      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -114,24 +114,6 @@ describe User, type: :model do
       end
     end
 
-    describe "#notifications_configured?" do
-      context "user has notifications configured" do
-        before do
-          subject.user_notifications << create(:user_notification)
-        end
-
-        it "returns true" do
-          expect(subject.notifications_configured?).to be true
-        end
-      end
-
-      context "user does not have notifications configured" do
-        it "returns false" do
-          expect(subject.notifications_configured?).to be false
-        end
-      end
-    end
-
     describe "multiple organisations" do
       before do
         subject.organisations = [organisation, other_organisation, yet_other_organisation]

--- a/spec/requests/api/v2/access_request_spec.rb
+++ b/spec/requests/api/v2/access_request_spec.rb
@@ -179,7 +179,6 @@ describe "Access Request API V2", type: :request do
               "admin" => first_access_request.requester.admin,
               "sign_in_user_id" => first_access_request.requester.sign_in_user_id,
               "associated_with_accredited_body" => first_access_request.requester.associated_with_accredited_body?,
-              "notifications_configured" => first_access_request.requester.notifications_configured?,
             },
             "relationships" => {
               "organisations" => {

--- a/spec/requests/api/v2/users_spec.rb
+++ b/spec/requests/api/v2/users_spec.rb
@@ -56,7 +56,6 @@ describe "/api/v2/users", type: :request do
       expect(data_attributes["last_name"]).to eq(user.last_name)
       expect(data_attributes["state"]).to eq(user.state)
       expect(data_attributes["associated_with_accredited_body"]).to eq(false)
-      expect(data_attributes["notifications_configured"]).to eq(false)
     end
 
     context "when user is associated with an accredited body" do
@@ -69,17 +68,6 @@ describe "/api/v2/users", type: :request do
         data_attributes = json_response["data"]["attributes"]
 
         expect(data_attributes["associated_with_accredited_body"]).to eq(true)
-      end
-    end
-
-    context "when user has notifications configured" do
-      let(:user) { create(:user, user_notifications: [create(:user_notification)]) }
-
-      it "has a data section with the correct attribute" do
-        json_response = JSON.parse(response.body)
-        data_attributes = json_response["data"]["attributes"]
-
-        expect(data_attributes["notifications_configured"]).to eq(true)
       end
     end
   end


### PR DESCRIPTION
### Context
This reverts commit 83e550c59bfb4994484d01070396cf1db1bf8411.

See related Publish PR for context - https://github.com/DFE-Digital/publish-teacher-training/pull/1209

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
