### PR TITLE
Fix notify template config setting (spelling error)

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,7 @@ govuk_notify:
   course_publish_email_template_id: please_change_me
   magic_link_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
-  course_vacancies_filled_template_id: please_change_me
+  course_vacancies_filled_email_template_id: please_change_me
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:


### PR DESCRIPTION
### Context
Fix for notify template config setting (spelling error)
Have tested locally and vacancies filled email is sending ok

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
