### PR TITLE
[3615] Course publication now requires age range

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -261,7 +261,7 @@ class Course < ApplicationRecord
   validates_with UniqueCourseValidator, on: :new
 
   validates :name, :profpost_flag, :program_type, :qualification, :start_date, :study_mode, presence: true
-  validates :age_range_in_years, presence: true, on: %i[new create], unless: :further_education_course?
+  validates :age_range_in_years, presence: true, on: %i[new create publish], unless: :further_education_course?
   validates :level, presence: true, on: %i[new create publish]
 
   after_validation :remove_unnecessary_enrichments_validation_message

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,6 +22,10 @@ FactoryBot.define do
       )
     }
 
+    trait :without_validation do
+      to_create { |instance| instance.save(validate: false) }
+    end
+
     trait :primary do
       level { :primary }
       age_range_in_years { "3_to_7" }

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -334,6 +334,19 @@ describe Course, type: :model do
         end
       end
 
+      context "on publish" do
+        let(:course) { create(:course, :without_validation, age_range_in_years: nil) }
+        let(:errors) { course.errors.messages }
+
+        before { course.valid?(:publish) }
+
+        it "requires age_range_in_years" do
+          error = errors[:age_range_in_years]
+          expect(error).not_to be_empty
+          expect(error.first).to include("You need to pick an age range")
+        end
+      end
+
       context "A further education course" do
         let(:course) { build(:course, level: "further_education") }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/4OdjeI1q/3615-make-age-range-a-required-field-for-courses-in-2020-cycle
- We want to collect `age_range_in_years` data which is missing from approximately 14,000 / 15,000 courses
- During rollover this gives us the opportunity to collect this data

### Changes proposed in this pull request

- Course publication requires `age_range_in_years`
- Otherwise the course cannot be published
- This is to improve data collection

### Guidance to review

- Wire up publish to this PR
- login as admin
- Find a course with `age_range_in_years` data missing  e.g.`Course.joins(:provider).where(provider: { recruitment_cycle_id: 2 }, age_range_in_years: nil).first.provider`
- Find the course via the publish web interface
- Attempt to publish the course
- Should be shown a validation message
- Course should not be published
- Set the `age_range_in_years` with some data
- Attempt to publish the course again
- Course should now be published

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally