### PR TITLE
[3573] Admins can update provider_name

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -166,6 +166,7 @@ module API
           .except(
             :train_with_us,
             :train_with_disability,
+            :provider_name,
             :email,
             :telephone,
             :website,
@@ -202,20 +203,7 @@ module API
             :gt12_contact,
             :application_alert_contact,
             :send_application_alerts,
-          )
-          .permit(
-            :train_with_us,
-            :train_with_disability,
-            :email,
-            :telephone,
-            :website,
-            :address1,
-            :address2,
-            :address3,
-            :address4,
-            :postcode,
-            :region_code,
-          )
+          ).permit(policy(@provider).permitted_provider_attributes)
       end
 
       def ucas_contact_params
@@ -224,6 +212,7 @@ module API
           .except(
             :train_with_us,
             :train_with_disability,
+            :provider_name,
             :email,
             :telephone,
             :website,
@@ -260,6 +249,7 @@ module API
             :finance_contact,
             :train_with_us,
             :train_with_disability,
+            :provider_name,
             :email,
             :telephone,
             :website,

--- a/app/deserializers/api/v2/deserializable_provider.rb
+++ b/app/deserializers/api/v2/deserializable_provider.rb
@@ -4,6 +4,7 @@ module API
       PROVIDER_ATTRIBUTES = %i[
         train_with_us
         train_with_disability
+        provider_name
         email
         telephone
         website

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -61,4 +61,34 @@ class ProviderPolicy
   alias_method :update?, :show?
   alias_method :build_new?, :show?
   alias_method :can_list_training_providers?, :show?
+
+  def permitted_provider_attributes
+    if user.admin?
+      admin_provider_attributes
+    else
+      user_provider_attributes
+    end
+  end
+
+private
+
+  def user_provider_attributes
+    %i[
+      train_with_us
+      train_with_disability
+      email
+      telephone
+      website
+      address1
+      address2
+      address3
+      address4
+      postcode
+      region_code
+    ]
+  end
+
+  def admin_provider_attributes
+    user_provider_attributes + [:provider_name]
+  end
 end

--- a/spec/controllers/api/v2/providers_controller_spec.rb
+++ b/spec/controllers/api/v2/providers_controller_spec.rb
@@ -54,4 +54,42 @@ RSpec.describe API::V2::ProvidersController do
       end
     end
   end
+
+  describe "#update" do
+    context "when user is not an admin" do
+      let(:user) { provider.users.first }
+      let(:provider) { course.provider }
+      let(:course) { create(:course) }
+
+      it "cannot update provider_name" do
+        expect {
+          put :update,
+              params: {
+                code: provider.provider_code,
+                provider: {
+                  provider_name: "new provider name",
+                },
+              }
+        }.to raise_error(ActionController::UnpermittedParameters)
+      end
+    end
+
+    context "when user is an admin" do
+      let(:user) { create(:user, :admin) }
+      let(:provider) { course.provider }
+      let(:course) { create(:course) }
+
+      it "can update provider_name" do
+        put :update,
+            params: {
+              code: provider.provider_code,
+              provider: {
+                provider_name: "new provider name",
+              },
+            }
+
+        expect(provider.reload.provider_name).to eql("new provider name")
+      end
+    end
+  end
 end

--- a/spec/policies/provider_policy_spec.rb
+++ b/spec/policies/provider_policy_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 describe ProviderPolicy do
-  let(:user) { create(:user) }
+  let(:user) { build(:user) }
+  let(:admin) { build(:user, :admin) }
 
   describe "scope" do
     let(:organisation) { create(:organisation, users: [user]) }
@@ -21,10 +22,9 @@ describe ProviderPolicy do
   end
 
   permissions :create? do
-    let(:user_outside_org) { create(:user) }
-    let(:admin) { create(:user, :admin) }
-    let(:provider) { create(:provider) }
-    let!(:organisation) { create(:organisation, providers: [provider], users: [user]) }
+    let(:user_outside_org) { build(:user) }
+    let(:provider) { build(:provider) }
+    let!(:organisation) { build(:organisation, providers: [provider], users: [user]) }
 
     it { should_not permit(user, provider) }
     it { should_not permit(user_outside_org, provider) }
@@ -32,7 +32,6 @@ describe ProviderPolicy do
   end
 
   permissions :can_show_training_provider? do
-    let(:admin) { build(:user, :admin) }
     let(:allowed_user) { provider.users.first }
     let(:not_allowed_user) { create(:user) }
 
@@ -43,5 +42,31 @@ describe ProviderPolicy do
     it { should permit(admin, training_provider) }
     it { should permit(allowed_user, training_provider) }
     it { should_not permit(not_allowed_user, training_provider) }
+  end
+
+  describe "#permitted_provider_attributes" do
+    context "when user" do
+      subject { described_class.new(user, build(:provider)) }
+
+      it "includes email" do
+        expect(subject.permitted_provider_attributes).to include(:email)
+      end
+
+      it "excludes provider_name" do
+        expect(subject.permitted_provider_attributes).to_not include(:provider_name)
+      end
+    end
+
+    context "when admin" do
+      subject { described_class.new(admin, build(:provider)) }
+
+      it "includes email" do
+        expect(subject.permitted_provider_attributes).to include(:email)
+      end
+
+      it "includes provider_name" do
+        expect(subject.permitted_provider_attributes).to include(:provider_name)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/KXiJdzYT/3573-m-make-provider-name-editable
- Admin users of publish want to be able to update provider names for convenience

### Changes proposed in this pull request

- Thru strong params allow `provider_name` for admins
- This is done thru a convention available via pundit

### Guidance to review

#### Non admins

- Use publish with https://github.com/DFE-Digital/publish-teacher-training/pull/1237
- Login a non-admin
- Navigate to provider contact page to update their details
- Modify the DOM so it sends a new value for `provider[provider_name]`
- Submit
- Provider name should not be update

#### Admins

- Use publish with https://github.com/DFE-Digital/publish-teacher-training/pull/1237
- Login an admin
- Navigate to provider contact page to update their details
- Submit
- Provider name should name should now be updated

#### Code climate

- I don't see these low level changes as being beneficial
- The update endpoint seems to be updating multiple resources, either this endpoint should be split to solve this problem
- Or the resources should be combined so there is no duplication

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally