### PR TITLE
[3590] - Rename 'attribute_changed' for 'full time or part time' to 'study mode'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     update_email:
       age_range_in_years: "age range"
       qualification: "outcome"
-      study_mode: "full or part time"
+      study_mode: "study mode"
       science: "entry requirements"
       maths: "entry requirements"
       english: "entry requirements"

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -3,32 +3,33 @@ require "rails_helper"
 describe CourseUpdateEmailMailer, type: :mailer do
   let(:course) { create(:course, :with_accrediting_provider, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6)) }
   let(:user) { create(:user) }
-  let(:mail) do
-    described_class.course_update_email(
-      course: course,
-      attribute_name: "qualification",
-      original_value: "original",
-      updated_value: "updated",
-      recipient: user,
-    )
-  end
-
-  before do
-    course
-    mail
-
-    allow(CourseAttributeFormatterService)
-      .to receive(:call)
-      .with(name: "qualification", value: "original")
-      .and_return("ORIGINAL")
-
-    allow(CourseAttributeFormatterService)
-      .to receive(:call)
-      .with(name: "qualification", value: "updated")
-      .and_return("UPDATED")
-  end
 
   context "sending an email to a user" do
+    let(:mail) do
+      described_class.course_update_email(
+        course: course,
+        attribute_name: "qualification",
+        original_value: "original",
+        updated_value: "updated",
+        recipient: user,
+        )
+    end
+
+    before do
+      course
+      mail
+
+      allow(CourseAttributeFormatterService)
+        .to receive(:call)
+              .with(name: "qualification", value: "original")
+              .and_return("ORIGINAL")
+
+      allow(CourseAttributeFormatterService)
+        .to receive(:call)
+              .with(name: "qualification", value: "updated")
+              .and_return("UPDATED")
+    end
+
     it "sends an email with the correct template" do
       expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_update_email_template_id)
     end
@@ -78,6 +79,65 @@ describe CourseUpdateEmailMailer, type: :mailer do
         "/course/#{course.provider.provider_code}" \
         "/#{course.course_code}"
       expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
+    end
+  end
+
+  context "study mode is updated" do
+    study_mode_update_scenarios = [
+      {
+         original_value: "full time",
+         updated_value: "part time",
+       },
+      {
+        original_value: "part time",
+        updated_value: "full time",
+      },
+      {
+        original_value: "part time",
+        updated_value: "full or part time",
+      },
+      {
+        original_value: "full time",
+        updated_value: "full or part time",
+      },
+      {
+        original_value: "full or part time",
+        updated_value: "full time",
+      },
+      {
+        original_value: "full or part time",
+        updated_value: "part time",
+      },
+    ]
+
+    study_mode_update_scenarios.each do |scenario|
+      context "study mode is updated to #{scenario[:updated_value]}" do
+        let(:mail) do
+          described_class.course_update_email(
+            course: course,
+            attribute_name: "study_mode",
+            original_value: scenario[:original_value],
+            updated_value: scenario[:updated_value],
+            recipient: user,
+            )
+
+          before do
+            allow(CourseAttributeFormatterService)
+              .to receive(:call)
+                    .with(name: "study_mode", value: scenario[:original_value])
+                    .and_return("ORIGINAL")
+
+            allow(CourseAttributeFormatterService)
+              .to receive(:call)
+                    .with(name: "study_mode", value: scenario[:updated_value])
+                    .and_return("UPDATED")
+          end
+
+          it "includes the updated detail in the personalisation" do
+            expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("study mode")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
```
As an Accredited Body
I need to be able to understand the notification I receive
So that I can act accordingly.
```

### Changes proposed in this pull request
When a user updates its study mode attribute then this will now be displayed in the Course Update email as 'study mode'.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
