### PR TITLE
[3572] Course titles can be modified by admins

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -43,7 +43,7 @@ module API
         @course.errors.messages.each do |error_key, _|
           @course.errors.full_messages_for(error_key).each do |error_message|
             json_data[:data][:errors] << {
-              "title" => "Invalid #{error_key}",
+              "title" => "Invalid #{Course.human_attribute_name(error_key).downcase}",
               "detail" => error_message,
               "source" => { "pointer" => "/data/attributes/#{error_key}" },
             }

--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -283,22 +283,8 @@ module API
                   :sites_types,
                   :course_code,
                   :subjects_ids,
-                  :subjects_types,
-                  :name)
-          .permit(
-            :english,
-            :maths,
-            :science,
-            :qualification,
-            :age_range_in_years,
-            :start_date,
-            :applications_open_from,
-            :study_mode,
-            :is_send,
-            :accredited_body_code,
-            :funding_type,
-            :level,
-          )
+                  :subjects_types)
+          .permit(policy(Course.new).permitted_attributes)
       end
 
       def update_further_education_fields

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -43,4 +43,35 @@ class CoursePolicy
   alias_method :publishable?, :update?
   alias_method :new?, :index?
   alias_method :withdraw?, :show?
+
+  def permitted_attributes
+    if user.admin?
+      permitted_admin_attributes
+    else
+      permitted_user_attributes
+    end
+  end
+
+private
+
+  def permitted_user_attributes
+    %i[
+      english
+      maths
+      science
+      qualification
+      age_range_in_years
+      start_date
+      applications_open_from
+      study_mode
+      is_send
+      accredited_body_code
+      funding_type
+      level
+    ]
+  end
+
+  def permitted_admin_attributes
+    permitted_user_attributes + [:name]
+  end
 end

--- a/app/serializers/api/v2/serializable_course_without_name.rb
+++ b/app/serializers/api/v2/serializable_course_without_name.rb
@@ -1,0 +1,8 @@
+module API
+  module V2
+    class SerializableCourseWithoutName < SerializableCourse
+    end
+  end
+end
+
+API::V2::SerializableCourseWithoutName.instance_variable_get(:@attribute_blocks).delete(:name)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -16,6 +16,8 @@ en:
         pgde: "PGDE"
   activerecord:
     attributes:
+      course:
+        name: Title
       course_enrichment:
         fee_uk_eu: "Course fees for UK and EU students"
         fee_international: "Course fees for international students"

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -62,4 +62,38 @@ describe API::V2::CoursesController, type: :controller do
       }
     end
   end
+
+  describe "#update" do
+    let(:enrichment) { build(:course_enrichment, :published) }
+
+    context "as non-admin" do
+      let(:existing_user) { course.provider.users.first }
+
+      it "cannot update admin fields" do
+        expect {
+          put :update, params: {
+            recruitment_cycle_year: RecruitmentCycle.current_recruitment_cycle.year,
+            provider_code: course.provider.provider_code,
+            code: course.course_code,
+            course: { name: "new course name" },
+          }
+        }.to raise_error(ActionController::UnpermittedParameters)
+
+        expect(course.reload.name).to_not eql("new course name")
+      end
+    end
+
+    context "as admin" do
+      it "can update admin fields" do
+        put :update, params: {
+          recruitment_cycle_year: RecruitmentCycle.current_recruitment_cycle.year,
+          provider_code: course.provider.provider_code,
+          code: course.course_code,
+          course: { name: "new course name" },
+        }
+
+        expect(course.reload.name).to eql("new course name")
+      end
+    end
+  end
 end

--- a/spec/policies/course_policy_spec.rb
+++ b/spec/policies/course_policy_spec.rb
@@ -26,6 +26,26 @@ describe CoursePolicy do
     end
   end
 
+  describe "#permitted_attributes" do
+    subject { described_class.new(user, build(:course)) }
+
+    context "when non admin user" do
+      it "returns user attributes" do
+        expect(subject.permitted_attributes).to include(:english)
+        expect(subject.permitted_attributes).to_not include(:name)
+      end
+    end
+
+    context "when admin user" do
+      let(:user) { build(:user, :admin) }
+
+      it "returns user and admin attributes" do
+        expect(subject.permitted_attributes).to include(:english)
+        expect(subject.permitted_attributes).to include(:name)
+      end
+    end
+  end
+
   describe CoursePolicy::Scope do
     let(:accredited_body) { create(:provider, :accredited_body, organisations: [organisation]) }
     let(:training_provider) { create(:provider) }

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -42,7 +42,6 @@ describe "/api/v2/build_new_course", type: :request do
   context "with subjects" do
     let(:params) do
       { course: {
-        name: "Foo Bar Course",
         maths: "must_have_qualification_at_application_time",
         english: "must_have_qualification_at_application_time",
         subjects_ids: subjects.map(&:id),
@@ -69,7 +68,6 @@ describe "/api/v2/build_new_course", type: :request do
   context "With multiple secondary subjects" do
     let(:params) do
       { course: {
-        name: "Foo Bar Course",
         maths: "must_have_qualification_at_application_time",
         english: "must_have_qualification_at_application_time",
         subjects_ids: subjects.map(&:id),
@@ -410,7 +408,6 @@ describe "/api/v2/build_new_course", type: :request do
         maths: "must_have_qualification_at_application_time",
         english: "must_have_qualification_at_application_time",
         science: "must_have_qualification_at_application_time",
-        name: "Primary",
         study_mode: "full_time",
         start_date: DateTime.new(provider.recruitment_cycle.year.to_i, 9, 1),
         qualification: "qts",

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -217,7 +217,7 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid applications_open_from",
+                "title" => "Invalid applications open from",
                 "detail" => "You must say when applications open from",
                 "source" => {
                   "pointer" => "/data/attributes/applications_open_from",
@@ -231,42 +231,42 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid name",
-                "detail" => "Name can't be blank",
+                "title" => "Invalid title",
+                "detail" => "Title can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/name",
                 },
               },
               {
-                "title" => "Invalid profpost_flag",
+                "title" => "Invalid profpost flag",
                 "detail" => "Profpost flag can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/profpost_flag",
                 },
               },
               {
-                "title" => "Invalid program_type",
+                "title" => "Invalid program type",
                 "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/program_type",
                 },
               },
               {
-                "title" => "Invalid start_date",
+                "title" => "Invalid start date",
                 "detail" => "Start date can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/start_date",
                 },
               },
               {
-                "title" => "Invalid study_mode",
+                "title" => "Invalid study mode",
                 "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/study_mode",
                 },
               },
               {
-                "title" => "Invalid age_range_in_years",
+                "title" => "Invalid age range in years",
                 "detail" => "You need to pick an age range",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
@@ -327,21 +327,21 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid name",
-                "detail" => "Name can't be blank",
+                "title" => "Invalid title",
+                "detail" => "Title can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/name",
                 },
               },
               {
-                "title" => "Invalid profpost_flag",
+                "title" => "Invalid profpost flag",
                 "detail" => "Profpost flag can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/profpost_flag",
                 },
               },
               {
-                "title" => "Invalid program_type",
+                "title" => "Invalid program type",
                 "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/program_type",
@@ -355,21 +355,21 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid start_date",
+                "title" => "Invalid start date",
                 "detail" => "Start date can't be blank",
                 "source" => {
                   "pointer" => "/data/attributes/start_date",
                 },
               },
               {
-                "title" => "Invalid study_mode",
+                "title" => "Invalid study mode",
                 "detail" => "You need to pick an option",
                 "source" => {
                   "pointer" => "/data/attributes/study_mode",
                 },
               },
               {
-                "title" => "Invalid age_range_in_years",
+                "title" => "Invalid age range in years",
                 "detail" => "You need to pick an age range",
                 "source" => {
                   "pointer" => "/data/attributes/age_range_in_years",
@@ -390,7 +390,7 @@ describe "/api/v2/build_new_course", type: :request do
                 },
               },
               {
-                "title" => "Invalid applications_open_from",
+                "title" => "Invalid applications open from",
                 "detail" => "You must say when applications open from",
                 "source" => {
                   "pointer" => "/data/attributes/applications_open_from",

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -1,11 +1,13 @@
-describe "POST /providers/:provider_code/courses/:course_code" do
+require "rails_helper"
+
+RSpec.describe "POST /providers/:provider_code/courses/:course_code" do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
   before do
     jsonapi_data = jsonapi_renderer.render(
       course,
       class: {
-        Course: API::V2::SerializableCourse,
+        Course: API::V2::SerializableCourseWithoutName,
         PrimarySubject: API::V2::SerializableSubject,
         Site: API::V2::SerializableSite,
       },
@@ -36,7 +38,6 @@ describe "POST /providers/:provider_code/courses/:course_code" do
   }
   let(:site) { build(:site) }
   let(:subject) { find_or_create(:primary_subject) }
-
 
   let(:age_range_in_years) { "3_to_7" }
 

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -32,7 +32,7 @@ describe "Course POST #create API V2", type: :request do
     jsonapi_data = jsonapi_renderer.render(
       course,
       class: {
-        Course: API::V2::SerializableCourse,
+        Course: API::V2::SerializableCourseWithoutName,
         PrimarySubject: API::V2::SerializableSubject,
         Site: API::V2::SerializableSite,
       },
@@ -129,7 +129,7 @@ describe "Course POST #create API V2", type: :request do
         jsonapi_data = jsonapi_renderer.render(
           course,
           class: {
-            Course: API::V2::SerializableCourse,
+            Course: API::V2::SerializableCourseWithoutName,
             Site: API::V2::SerializableSite,
             PrimarySubject: API::V2::SerializableSubject,
           },
@@ -199,7 +199,7 @@ describe "Course POST #create API V2", type: :request do
         jsonapi_data = jsonapi_renderer.render(
           course,
           class: {
-            Course: API::V2::SerializableCourse,
+            Course: API::V2::SerializableCourseWithoutName,
             Site: API::V2::SerializableSite,
           },
           include: %i[sites],

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -7,7 +7,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data = jsonapi_renderer.render(
       course,
       class: {
-        Course: API::V2::SerializableCourse,
+        Course: API::V2::SerializableCourseWithoutName,
       },
     )
 


### PR DESCRIPTION
### Context

- https://trello.com/c/bKhHARtf/3572-m-make-course-title-editable
- This is the api side on allowing admins to modify course title

### Changes proposed in this pull request

- Permitted course parameters moved to policy and depending on whether admin/non-admin returns different fields for mass assignment
- Updating of course now name available in the API and only available to admins
- Added `SerializableCourseWithoutName` to handle existing test cases which simply serialised an entire course and threw it at the api. This can no longer be done for non-admins hence the serialiser was added to remove the `name` field

### Guidance to review

- Using publish https://github.com/DFE-Digital/publish-teacher-training/pull/1241
- Login as admin
- Find a course
- Change the title of the course
- Course title should now be changed
- Attempting the same API request as a non-admin but in correct organisation should not update the course title

### Code climate

- Issues are relating to long lists of fields. Personally I think this is fine for now

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
