### PR TITLE
[3636] - Ensure sites and providers are not geocoded on rollover

### DIFF
--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -22,6 +22,7 @@ module Providers
           rolled_over_provider.ucas_preferences = provider.ucas_preferences.dup
           rolled_over_provider.contacts << provider.contacts.map(&:dup)
           rolled_over_provider.recruitment_cycle = new_recruitment_cycle
+          rolled_over_provider.skip_geocoding = true
 
           rolled_over_provider.save!
         end

--- a/app/services/sites/copy_to_provider_service.rb
+++ b/app/services/sites/copy_to_provider_service.rb
@@ -7,6 +7,7 @@ module Sites
 
       new_site = site.dup
       new_site.provider_id = new_provider.id
+      new_site.skip_geocoding = true
       new_site.save(validate: false)
       new_provider.reload
 

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -720,6 +720,32 @@ describe Provider, type: :model do
         end
       end
     end
+
+    describe "#skip_geocoding" do
+      before do
+        allow(GeocodeJob).to receive(:perform_later)
+      end
+
+      context "skip_geocoding is 'true'" do
+        it "does not geocode" do
+          provider.skip_geocoding = true
+
+          provider.save
+
+          expect(GeocodeJob).to_not have_received(:perform_later)
+        end
+      end
+
+      context "skip_geocoding is 'false'" do
+        it "does not geocode" do
+          provider.skip_geocoding = false
+
+          provider.save
+
+          expect(GeocodeJob).to have_received(:perform_later)
+        end
+      end
+    end
   end
 
   describe "#search_by_code_or_name" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -113,6 +113,33 @@ describe Site, type: :model do
       end
     end
 
+    describe "#skip_geocoding" do
+      before do
+        site.provider = create(:provider, latitude: "foo", longitude: "bar")
+        allow(GeocodeJob).to receive(:perform_later)
+      end
+
+      context "skip_geocoding is 'true'" do
+        it "does not geocode" do
+          site.skip_geocoding = true
+
+          site.save
+
+          expect(GeocodeJob).to_not have_received(:perform_later)
+        end
+      end
+
+      context "skip_geocoding is 'false'" do
+        it "does not geocode" do
+          site.skip_geocoding = false
+
+          site.save
+
+          expect(GeocodeJob).to have_received(:perform_later)
+        end
+      end
+    end
+
     describe "#needs_geolocation?" do
       subject { site.needs_geolocation? }
 


### PR DESCRIPTION
### Context
Running the rollover `mcb` command has triggered geocoding requests when duplicating sites and providers. This is because the `:needs_geolocation?`  guard is resolving to true. See https://github.com/DFE-Digital/teacher-training-api/blob/master/app/models/site.rb#L34

### Changes proposed in this pull request
- Introduce a new virtual boolean attribute on the Site and Provider models so that geocoding can be skipped where required

### Guidance to review
The `after_commit` geocoding callback is no longer triggered when running the mcb rollover command. 

### Other stuff
I think there could be a case for extracting the geocoding logic out of the Site and Provider models which is largely similiar.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
