### PR TITLE
[3595] Set magic link template id env var

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -1023,6 +1023,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__COURSE_VACANCIES_FILLED_EMAIL_TEMPLATE_ID",
                 "value": "[parameters('govukNotifyCourseVacanciesFilledEmailTemplateId')]"
+              },
+              {
+                "name": "SETTINGS__GOVUK_NOTIFY__MAGIC_LINK_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyMagicLinkEmailTemplateId')]"
               }
             ]
           },


### PR DESCRIPTION
Set the environment variable for the magic link template id.

### Context

We have a magic link alternative to signin. The template ID environment variable is not present on Azure.

### Changes proposed in this pull request

Set it.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
