### PR TITLE
[3595] Add magic link template id to app settings

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -534,6 +534,10 @@
                 "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
               },
               {
+                "name": "SETTINGS__GOVUK_NOTIFY__MAGIC_LINK_EMAIL_TEMPLATE_ID",
+                "value": "[parameters('govukNotifyMagicLinkEmailTemplateId')]"
+              },
+              {
                 "name": "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",
                 "value": "[parameters('mcbeSystemAuthenticationToken')]"
               },


### PR DESCRIPTION
### Context

This has already been added to the environmentVariables section but
isn't visible on Azure. Trying this...

### Changes proposed in this pull request

Also set `SETTINGS__GOVUK_NOTIFY__MAGIC_LINK_EMAIL_TEMPLATE_ID` in the app service app settings section.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
