### PR TITLE
[3660] Accepting terms returns user json

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -20,7 +20,12 @@ module API
 
       def accept_terms
         @user.accept_terms_date_utc = Time.zone.now
-        @user.save
+
+        if @user.save
+          render jsonapi: @user
+        else
+          render jsonapi_errors: @user.errors, status: :unprocessable_entity
+        end
       end
 
       def generate_and_send_magic_link

--- a/spec/controllers/api/v2/users_controller_spec.rb
+++ b/spec/controllers/api/v2/users_controller_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe API::V2::UsersController do
+  let(:user) { create(:user, :inactive) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    allow(controller).to receive(:authenticate)
+  end
+
+  describe "#accept_terms" do
+    it "updates accept_terms_date_utc" do
+      put :accept_terms, params: { id: user.id }
+      expect(user.reload.accept_terms_date_utc).to be_present
+    end
+
+    it "returns updated user json" do
+      put :accept_terms, params: { id: user.id }
+      expect(JSON.parse(response.body)["data"]["attributes"]["accept_terms_date_utc"]).to be_present
+    end
+
+    it "raises an error when the user is not saved" do
+      allow(User).to receive(:find).and_return(user)
+      allow(user).to receive(:save).and_return(false)
+      user.errors.add(:email, "bar")
+      put :accept_terms, params: { id: user.id }
+      expect(JSON.parse(response.body)["errors"]).to eq([{ "title" => "Invalid email", "detail" => "Email bar", "source" => {} }])
+      expect(response.status.to_i).to be(422)
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/sDVFcGD0/3660-update-session-when-user-accepts-terms
- After the user accepts the terms the client is not able to keep in sync with the API

### Changes proposed in this pull request

- Accepting terms return json of the updated use
- This is so publish can keep in sync with the API

### Guidance to review

- Hit the accept terms endpoint for a user
- Should now return json of the user

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally