### PR TITLE
3643 Don't raise bad requests with suggest endpoint

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -76,7 +76,6 @@ module API
       def suggest_any
         authorize Provider
 
-        return render(status: :bad_request) if params[:query].nil? || params[:query].length < 2
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         scope = @recruitment_cycle.providers


### PR DESCRIPTION
### Context
https://trello.com/c/7MOribyu/3643-create-a-course-error-when-leaving-ab-field-empty

### Changes proposed in this pull request

Removed the `bad_request` check for searches less than 2 chars, as it was returning unhelpful json packets. 

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
