### PR TITLE
[3359] - Send 'unrecognised email' notification

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -4,6 +4,8 @@ module API
       before_action :build_user, except: :generate_and_send_magic_link
       deserializable_resource :user, only: :update
       skip_before_action :check_terms_accepted, only: %i[accept_terms generate_and_send_magic_link]
+      skip_before_action :authenticate, only: :generate_and_send_magic_link
+      skip_before_action :check_user_is_kept, only: :generate_and_send_magic_link
 
       def show
         render jsonapi: @user,
@@ -31,10 +33,28 @@ module API
       def generate_and_send_magic_link
         skip_authorization
 
-        GenerateAndSendMagicLinkService.call(user: current_user)
+        user = User.where(email: email_from_token).first
+
+        if user
+          GenerateAndSendMagicLinkService.call(user: user)
+        else
+          NotificationService::UnrecognisedEmail.call(email: email_from_token)
+        end
       end
 
     private
+
+      def email_from_token
+        @email_from_token ||= authenticate_or_request_with_http_token do |token|
+          decoded_token = JWT.decode(
+            token,
+            Settings.authentication.secret,
+            Settings.authentication.algorithm,
+            )
+          (decoded_token_payload, _algorithm) = decoded_token
+          decoded_token_payload["email"]
+        end
+      end
 
       def build_user
         @user = authorize User.find(params[:id])

--- a/app/mailers/email_unrecognised_mailer.rb
+++ b/app/mailers/email_unrecognised_mailer.rb
@@ -1,0 +1,7 @@
+class EmailUnrecognisedMailer < GovukNotifyRails::Mailer
+  def email_unrecognised(email)
+    set_template(Settings.govuk_notify.email_unrecognised_template_id)
+
+    mail(to: email)
+  end
+end

--- a/app/services/notification_service/unrecognised_email.rb
+++ b/app/services/notification_service/unrecognised_email.rb
@@ -1,0 +1,19 @@
+module NotificationService
+  class UnrecognisedEmail
+    include ServicePattern
+
+    def initialize(email:)
+      @email = email
+    end
+
+    def call
+      EmailUnrecognisedMailer
+        .email_unrecognised(email)
+        .deliver_later
+    end
+
+  private
+
+    attr_reader :email
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ govuk_notify:
   magic_link_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
   course_vacancies_filled_email_template_id: please_change_me
+  email_unrecognised_template_id: please_change_me
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,6 +5,7 @@ govuk_notify:
   course_publish_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
   course_vacancies_filled_email_template_id: please_change_me
+  email_unrecognised_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/spec/mailers/email_unrecognised_mailer_spec.rb
+++ b/spec/mailers/email_unrecognised_mailer_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe EmailUnrecognisedMailer, type: :mailer do
+  let(:email) { "foo@bar.com" }
+  let(:mail) { described_class.email_unrecognised(email) }
+
+  before do
+    mail
+  end
+
+  context "sending an email to a user" do
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to(
+        eq(Settings.govuk_notify.magic_link_email_template_id),
+        )
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([email])
+    end
+  end
+end

--- a/spec/requests/api/v2/users/generate_and_send_magic_link_spec.rb
+++ b/spec/requests/api/v2/users/generate_and_send_magic_link_spec.rb
@@ -22,17 +22,22 @@ describe "PATCH /api/v2/users/generate_and_send_magic_link", type: :request do
     )
   end
 
-  context "when unauthenticated" do
-    let(:payload) { { email: "foo@bar" } }
+  context "when the user's email address is unknown" do
+    let(:email) { "foo@bar.com" }
+    let(:payload) { { email: email } }
 
     before do
+      allow(NotificationService::UnrecognisedEmail).to receive(:call)
+      token
       perform_request
     end
 
     subject { response }
 
-    xit { should have_http_status(:ok) }
-    xit "should send an email to the user saying they don't have an account"
+    it { should have_http_status(:no_content) }
+    it "should send an email to the user saying they don't have an account" do
+      expect(NotificationService::UnrecognisedEmail).to have_received(:call).with(email: email)
+    end
   end
 
   context "when authenticated and authorised" do

--- a/spec/services/notification_service/unrecognised_email_spec.rb
+++ b/spec/services/notification_service/unrecognised_email_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+module NotificationService
+  describe UnrecognisedEmail do
+    let(:email) { "foo@bar.com" }
+    let(:service_call) { described_class.call(email: email) }
+
+    before do
+      allow(EmailUnrecognisedMailer).to receive(:email_unrecognised).and_return(double(deliver_later: true))
+    end
+
+    it "sends a notification" do
+      expect(EmailUnrecognisedMailer).to receive(:email_unrecognised).with(email)
+      service_call
+    end
+  end
+end


### PR DESCRIPTION
### Context

If a user attempts to sign in via magic link but their email address is unknown, then a notification is sent to that email address saying that the are an unknown user.

### Guidance to review
- Turn magic link on locally on Publish via `development.local.yml'
```
features:
  signin_intercept: true
  signin_by_email: true
  dfe_signin: false
```
- Go to `/signin`
- Sign in via magic link using a made up address (e.g. foo@bar.com)
- API logs should show that an UnrecognisedEmail notification was sent


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
