### PR TITLE
[3653] Publish course enrichments validations

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -232,13 +232,10 @@ describe Course, type: :model do
     it { should validate_presence_of(:qualification) }
     it { should validate_presence_of(:start_date) }
     it { should validate_presence_of(:study_mode) }
-
-
     it { should validate_presence_of(:sites).on(:publish) }
     it { should validate_presence_of(:subjects).on(:publish) }
-    it { should validate_presence_of(:enrichments).on(:publish) }
-
     it { should validate_presence_of(:level).on(:create) }
+
     it {
       should validate_presence_of(:level)
         .on(:publish)

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -131,22 +131,28 @@ describe "Publish API v2", type: :request do
 
       context "no enrichments, sites and subjects" do
         let(:course) { create(:course, provider: provider, enrichments: [], site_statuses: []) }
+
         it { should have_http_status(:unprocessable_entity) }
+
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
-            "Complete your course information before publishing",
             "You must pick at least one location for this course",
+            "Enter details about this course",
+            "Enter details about school placements",
+            "Enter a course length",
+            "Give details about the salary for this course",
+            "Enter details about the qualifications needed",
           ])
         end
       end
 
       context "fee type based course" do
-        let(:course) {
+        let(:course) do
           create(:course, :fee_type_based,
                  provider: provider,
                  enrichments: [invalid_enrichment],
                  site_statuses: [site_status])
-        }
+        end
 
         context "invalid enrichment with invalid content lack_presence fields" do
           let(:invalid_enrichment) { create(:course_enrichment, :without_content) }

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -38,9 +38,9 @@ describe "Publishable API v2", type: :request do
     end
 
     context "unpublished course with draft enrichment" do
-      let(:course) {
+      let(:course) do
         create(:course, :primary, :unpublished, :draft_enrichment)
-      }
+      end
 
       it "returns ok" do
         expect(subject).to have_http_status(:success)
@@ -51,14 +51,19 @@ describe "Publishable API v2", type: :request do
       let(:json_data) { JSON.parse(subject.body)["errors"] }
 
       context "no enrichments and location" do
-        let(:course) {
+        let(:course) do
           create(:course, :primary, :unpublished, site_statuses: [], enrichments: [])
-        }
+        end
 
         it { should have_http_status(:unprocessable_entity) }
+
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
-            "Complete your course information before publishing",
+            "Enter details about this course",
+            "Enter details about school placements",
+            "Enter a course length",
+            "Give details about the salary for this course",
+            "Enter details about the qualifications needed",
             "You must pick at least one location for this course",
           ])
         end
@@ -66,13 +71,13 @@ describe "Publishable API v2", type: :request do
 
       context "fee type based course" do
         context "invalid enrichment with invalid content lack_presence fields" do
-          let(:course) {
+          let(:course) do
             create(:course,
                    :fee_type_based,
                    :unpublished,
                    :primary,
                    enrichments: [build(:course_enrichment, :without_content)])
-          }
+          end
 
           it { should have_http_status(:unprocessable_entity) }
 


### PR DESCRIPTION
### Context

- https://trello.com/c/97e3BxBu/3653-missing-broken-error-summaries-when-trying-to-publish-a-course-in-rollover
- When publish a course that does not have an enrichment the error message are not very user friendly

### Changes proposed in this pull request

- If a course does not have an enrichment we now present back errors as
if the course did have an enrichment
- This gives more meaningful errors to the user
- Rather than the enrichment is missing

![image](https://user-images.githubusercontent.com/92580/87666648-e4584780-c760-11ea-892e-5ba1ae4fff09.png)

### Guidance to review

- Find or create a course without an enrichment
- Attempt to publish it
- Should see errors as seen in attached screenshot
- All errors should link to relevant error or page at least with the exception for age range which will be fixed in another change

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
