### PR TITLE
[3672] Tweak page and filter open api docs

### DIFF
--- a/spec/api/courses_spec.rb
+++ b/spec/api/courses_spec.rb
@@ -26,7 +26,7 @@ describe "API" do
                 explode: true,
                 required: false,
                 description: "Refine courses to return.",
-                example: "filter[has_vacancies]=true&filter[subjects]=00,01"
+                example: { has_vacancies: true, subjects: "00,01" }
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },
@@ -40,10 +40,10 @@ describe "API" do
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Pagination" },
                 type: :object,
-                style: :form,
-                explode: false,
+                style: :deepObject,
+                explode: true,
                 required: false,
-                example: "page[page]=2&page[per_page]=10",
+                example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
 
       response "200", "The collection of courses." do

--- a/spec/api/locations_spec.rb
+++ b/spec/api/locations_spec.rb
@@ -27,10 +27,10 @@ describe "API" do
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Pagination" },
                 type: :object,
-                style: :form,
-                explode: false,
+                style: :deepObject,
+                explode: true,
                 required: false,
-                example: "page[page]=2&page[per_page]=10",
+                example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
 
       response "200", "The collection of locations for the specified course." do

--- a/spec/api/providers_spec.rb
+++ b/spec/api/providers_spec.rb
@@ -12,14 +12,6 @@ describe "API" do
                 required: true,
                 description: "The starting year of the recruitment cycle.",
                 example: "2020"
-      parameter name: :filter,
-                in: :query,
-                schema: { "$ref" => "#/components/schemas/Filter" },
-                type: :object,
-                style: :deepObject,
-                explode: true,
-                required: false,
-                description: "Refine courses to return."
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },
@@ -33,10 +25,10 @@ describe "API" do
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Pagination" },
                 type: :object,
-                style: :form,
-                explode: false,
+                style: :deepObject,
+                explode: true,
                 required: false,
-                example: "page[page]=2&page[per_page]=10",
+                example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
 
       response "200", "Collection of providers." do

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1189,7 +1189,10 @@
             "explode": true,
             "required": false,
             "description": "Refine courses to return.",
-            "example": "filter[has_vacancies]=true&filter[subjects]=00,01"
+            "example": {
+              "has_vacancies": true,
+              "subjects": "00,01"
+            }
           },
           {
             "name": "sort",
@@ -1209,10 +1212,13 @@
             "schema": {
               "$ref": "#/components/schemas/Pagination"
             },
-            "style": "form",
-            "explode": false,
+            "style": "deepObject",
+            "explode": true,
             "required": false,
-            "example": "page[page]=2&page[per_page]=10",
+            "example": {
+              "page": 2,
+              "per_page": 10
+            },
             "description": "Pagination options to navigate through the collection."
           }
         ],
@@ -1327,10 +1333,13 @@
             "schema": {
               "$ref": "#/components/schemas/Pagination"
             },
-            "style": "form",
-            "explode": false,
+            "style": "deepObject",
+            "explode": true,
             "required": false,
-            "example": "page[page]=2&page[per_page]=10",
+            "example": {
+              "page": 2,
+              "per_page": 10
+            },
             "description": "Pagination options to navigate through the collection."
           }
         ],
@@ -1367,17 +1376,6 @@
             }
           },
           {
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "$ref": "#/components/schemas/Filter"
-            },
-            "style": "deepObject",
-            "explode": true,
-            "required": false,
-            "description": "Refine courses to return."
-          },
-          {
             "name": "sort",
             "in": "query",
             "schema": {
@@ -1395,10 +1393,13 @@
             "schema": {
               "$ref": "#/components/schemas/Pagination"
             },
-            "style": "form",
-            "explode": false,
+            "style": "deepObject",
+            "explode": true,
             "required": false,
-            "example": "page[page]=2&page[per_page]=10",
+            "example": {
+              "page": 2,
+              "per_page": 10
+            },
             "description": "Pagination options to navigate through the collection."
           }
         ],


### PR DESCRIPTION
### Context

- https://trello.com/c/471nIyfp/3672-s-fix-documentation-of-api-query-parametersfilters-and-page
- When using the open api specification in swagger, requests would not be generated correctly for pagination and filtering

### Changes proposed in this pull request

- Change styling of page and filter open api docs
- This fixes the ability to use the the specification in swagger editor
- Remove filtering from providers endpoint as the current filtering is designed to be used on the courses endpoint

![image](https://user-images.githubusercontent.com/92580/88071568-e6a91000-cb6b-11ea-8dc0-07e86d78ba83.png)

### Guidance to review

- Take the generated open api specification and use the swagger editor at https://editor.swagger.io
- Alternatively use the local rswag ui at http://localhost:3001/api-docs/index.html
- Generate a courses request with filtering and pagination
- Run against local api
- Should get some test results

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
