### PR TITLE
3670 empty string docs

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -298,6 +298,14 @@ module GovukTechDocs
         @schemas_data ||= @document.components.schemas
       end
 
+      def format_possible_value(possible_value)
+        if possible_value == ""
+          "<em>empty string</em>"
+        else
+          possible_value
+        end
+      end
+
       def properties_for_schema(schema_name)
         schema_data = schemas_data.find { |s| s[0] == schema_name }
 

--- a/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/schema.html.erb
@@ -39,7 +39,7 @@
 
               <ul>
                 <% enum.each do |possible_value| %>
-                  <li><%= possible_value %></li>
+                  <li><%= format_possible_value(possible_value) %></li>
                 <% end %>
               </ul>
             <% end %>


### PR DESCRIPTION
### Context

- https://trello.com/c/7VV8EZki/3670-s-display-empty-values-in-examples-in-api-docs
- Empty strings in enumeration in open api docs are not immediately obvious  

### Changes proposed in this pull request

- Replace empty bullet points with `<em>empty string</em>`

![image](https://user-images.githubusercontent.com/92580/88081488-58875680-cb78-11ea-930f-7a1e8e463a14.png)

### Guidance to review

- Load open api docs
- Find a schema with an enumeration which can include empty strings eg `required_qualifications_english`
- Should not see an empty bullet point
- Should see `empty string` with text italicised

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
