### PR TITLE
[3679] - Subject change notification

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -111,11 +111,13 @@ module API
 
           @course.course_subjects.each(&:save)
 
-          NotificationService::CourseSubjectsUpdated.call(
-            course: @course,
-            previous_subject_names: @previous_subject_names,
-            previous_course_name: @previous_course_name,
-          ) if subject_ids
+          if subject_ids
+            NotificationService::CourseSubjectsUpdated.call(
+              course: @course,
+              previous_subject_names: @previous_subject_names,
+              previous_course_name: @previous_course_name,
+            )
+          end
 
           render jsonapi: @course.reload
         else

--- a/app/mailers/course_subjects_updated_email_mailer.rb
+++ b/app/mailers/course_subjects_updated_email_mailer.rb
@@ -4,11 +4,10 @@ class CourseSubjectsUpdatedEmailMailer < GovukNotifyRails::Mailer
   def course_subjects_updated_email(
     course:,
     previous_subject_names:,
-    updated_subject_names:,
     previous_course_name:,
-    updated_course_name:,
     recipient:
   )
+
     set_template(Settings.govuk_notify.course_subjects_updated_email_template_id)
 
     set_personalisation(
@@ -17,9 +16,9 @@ class CourseSubjectsUpdatedEmailMailer < GovukNotifyRails::Mailer
       subject_change_datetime: gov_uk_format(course.updated_at),
       course_url: create_course_url(course),
       previous_subjects: format(previous_subject_names),
-      updated_subjects: format(updated_subject_names),
+      updated_subjects: format(course.subjects.map(&:subject_name)),
       previous_course_name: previous_course_name,
-      updated_course_name: updated_course_name,
+      updated_course_name: course.name,
     )
 
     mail(to: recipient.email)

--- a/app/mailers/course_subjects_updated_email_mailer.rb
+++ b/app/mailers/course_subjects_updated_email_mailer.rb
@@ -27,11 +27,7 @@ class CourseSubjectsUpdatedEmailMailer < GovukNotifyRails::Mailer
 private
 
   def format(subject_names)
-    if subject_names.length == 1
-      subject_names.first
-    else
-      subject_names.join(", ")
-    end
+    subject_names.join(", ")
   end
 
   def create_course_url(course)

--- a/app/mailers/course_subjects_updated_email_mailer.rb
+++ b/app/mailers/course_subjects_updated_email_mailer.rb
@@ -1,0 +1,43 @@
+class CourseSubjectsUpdatedEmailMailer < GovukNotifyRails::Mailer
+  include TimeFormat
+
+  def course_subjects_updated_email(
+    course:,
+    previous_subject_names:,
+    updated_subject_names:,
+    previous_course_name:,
+    updated_course_name:,
+    recipient:
+  )
+    set_template(Settings.govuk_notify.course_subjects_updated_email_template_id)
+
+    set_personalisation(
+      provider_name: course.provider.provider_name,
+      course_code: course.course_code,
+      subject_change_datetime: gov_uk_format(course.updated_at),
+      course_url: create_course_url(course),
+      previous_subjects: format(previous_subject_names),
+      updated_subjects: format(updated_subject_names),
+      previous_course_name: previous_course_name,
+      updated_course_name: updated_course_name,
+    )
+
+    mail(to: recipient.email)
+  end
+
+private
+
+  def format(subject_names)
+    if subject_names.length == 1
+      subject_names.first
+    else
+      subject_names.join(", ")
+    end
+  end
+
+  def create_course_url(course)
+    "#{Settings.find_url}" \
+      "/course/#{course.provider.provider_code}" \
+      "/#{course.course_code}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,6 +21,12 @@ class User < ApplicationRecord
   scope :last_login_since, ->(timestamp) do
     where("last_login_date_utc > ?", timestamp)
   end
+  scope :course_update_subscribers, ->(accredited_body_code) do
+    joins(:user_notifications).merge(UserNotification.course_update_notification_requests(accredited_body_code))
+  end
+  scope :course_publish_subscribers, ->(accredited_body_code) do
+    joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(accredited_body_code))
+  end
 
   validates :email, presence: true, format: { with: /\A.*@.*\z/, message: "must contain @" }
   validate :email_is_lowercase

--- a/app/services/notification_service/course_published.rb
+++ b/app/services/notification_service/course_published.rb
@@ -10,8 +10,6 @@ module NotificationService
       return false unless notify_accredited_body?
       return false unless course.in_current_cycle?
 
-      users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
-
       users.each do |user|
         CoursePublishEmailMailer.course_publish_email(
           course,
@@ -23,6 +21,10 @@ module NotificationService
   private
 
     attr_reader :course
+
+    def users
+      User.course_publish_subscribers(course.accredited_body_code)
+    end
 
     def notify_accredited_body?
       return false if course.self_accredited?

--- a/app/services/notification_service/course_subjects_updated.rb
+++ b/app/services/notification_service/course_subjects_updated.rb
@@ -1,0 +1,48 @@
+module NotificationService
+  class CourseSubjectsUpdated
+    include ServicePattern
+
+    def initialize(
+      course:,
+      previous_subject_names:,
+      updated_subject_names:,
+      previous_course_name:,
+      updated_course_name:
+    )
+      @course = course
+      @previous_subject_names = previous_subject_names
+      @updated_subject_names = updated_subject_names
+      @previous_course_name = previous_course_name
+      @updated_course_name = updated_course_name
+    end
+
+    def call
+      return false unless notify_accredited_body?
+      return false unless course.in_current_cycle?
+
+      users = User.joins(:user_notifications).merge(UserNotification.course_update_notification_requests(course.accredited_body_code))
+
+      users.each do |user|
+        CourseSubjectsUpdatedEmailMailer.course_subjects_updated_email(
+          course: course,
+          previous_subject_names: previous_subject_names,
+          updated_subject_names: updated_subject_names,
+          previous_course_name: previous_course_name,
+          updated_course_name: updated_course_name,
+          recipient: user,
+        ).deliver_later(queue: "mailer")
+      end
+    end
+
+  private
+
+    attr_reader :course, :updated_subject_names, :previous_subject_names, :previous_course_name, :updated_course_name
+
+    def notify_accredited_body?
+      return false if course.self_accredited?
+      return false unless course.findable?
+
+      true
+    end
+  end
+end

--- a/app/services/notification_service/course_subjects_updated.rb
+++ b/app/services/notification_service/course_subjects_updated.rb
@@ -31,7 +31,7 @@ module NotificationService
     attr_reader :course, :previous_subject_names, :previous_course_name
 
     def users
-      @user ||= User.joins(:user_notifications).merge(UserNotification.course_update_notification_requests(course.accredited_body_code))
+      @users ||= User.joins(:user_notifications).merge(UserNotification.course_update_notification_requests(course.accredited_body_code))
     end
 
     def notify_accredited_body?

--- a/app/services/notification_service/course_subjects_updated.rb
+++ b/app/services/notification_service/course_subjects_updated.rb
@@ -31,7 +31,7 @@ module NotificationService
     attr_reader :course, :previous_subject_names, :previous_course_name
 
     def users
-      @users ||= User.joins(:user_notifications).merge(UserNotification.course_update_notification_requests(course.accredited_body_code))
+      User.course_update_subscribers(course.accredited_body_code)
     end
 
     def notify_accredited_body?

--- a/app/services/notification_service/course_updated.rb
+++ b/app/services/notification_service/course_updated.rb
@@ -12,7 +12,7 @@ module NotificationService
       updated_attribute = notifiable_changes.first
       original_value, updated_value = course.saved_changes[updated_attribute]
 
-      users_to_notify.each do |user|
+      users.each do |user|
         CourseUpdateEmailMailer.course_update_email(
           course: course,
           attribute_name: updated_attribute,
@@ -31,10 +31,8 @@ module NotificationService
       course.saved_changes.keys & course.update_notification_attributes
     end
 
-    def users_to_notify
-      User.joins(:user_notifications).merge(
-        UserNotification.course_update_notification_requests(course.accredited_body_code),
-      )
+    def users
+      User.course_update_subscribers(course.accredited_body_code)
     end
 
     def course_needs_to_notify?

--- a/app/services/notification_service/course_vacancies_filled.rb
+++ b/app/services/notification_service/course_vacancies_filled.rb
@@ -11,8 +11,6 @@ module NotificationService
 
       # Reusing existing scoping as we're doing all or nothing notifications atm
       # for course_publish_notification_requests
-      users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
-
       users.each do |user|
         CourseVacanciesFilledEmailMailer.course_vacancies_filled_email(
           course,
@@ -25,6 +23,10 @@ module NotificationService
   private
 
     attr_reader :course
+
+    def users
+      User.course_publish_subscribers(course.accredited_body_code)
+    end
 
     def notify_accredited_body?
       return false if course.self_accredited?

--- a/app/services/notification_service/course_withdrawn.rb
+++ b/app/services/notification_service/course_withdrawn.rb
@@ -10,10 +10,6 @@ module NotificationService
       return false unless notify_accredited_body?
       return false unless course.in_current_cycle?
 
-      # Reusing existing scoping as we're doing all or nothing notifications atm
-      # for course_publish_notification_requests
-      users = User.joins(:user_notifications).merge(UserNotification.course_publish_notification_requests(course.accredited_body_code))
-
       users.each do |user|
         CourseWithdrawEmailMailer.course_withdraw_email(
           course,
@@ -26,6 +22,10 @@ module NotificationService
   private
 
     attr_reader :course
+
+    def users
+      User.course_publish_subscribers(course.accredited_body_code)
+    end
 
     def notify_accredited_body?
       return false if course.self_accredited?

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,7 +14,7 @@ govuk_notify:
   course_withdraw_email_template_id: please_change_me
   course_vacancies_filled_email_template_id: please_change_me
   course_sites_update_email_template_id: d5c8da46-9aa6-4c0a-8fad-ee782e89dbd3
-
+  course_subjects_updated_email_template_id: b65aef1a-5847-44e6-90e0-88e0ea7898ec
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -58,9 +58,7 @@ describe API::V2::CoursesController, type: :controller do
               .with(
                 course: an_instance_of(Course),
                 previous_subject_names: ["Primary with English"],
-                updated_subject_names: ["Primary with mathematics"],
                 previous_course_name: previous_course_name,
-                updated_course_name: updated_course_name,
               )
       post :update, params: {
         recruitment_cycle_year: RecruitmentCycle.current_recruitment_cycle.year,

--- a/spec/mailers/course_subjects_updated_email_mailer_spec.rb
+++ b/spec/mailers/course_subjects_updated_email_mailer_spec.rb
@@ -2,18 +2,16 @@ require "rails_helper"
 
 describe CourseSubjectsUpdatedEmailMailer, type: :mailer do
   let(:previous_subject) { build(:primary_subject, :primary_with_english) }
+  let(:updated_course_name) { "Primary with Mathematics" }
+  let(:updated_subject) { build(:primary_subject, :primary_with_mathematics) }
   let(:course) { build(:course, :with_accrediting_provider, name: updated_course_name, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6), subjects: [updated_subject]) }
   let(:user) { build(:user) }
-  let(:updated_subject) { build(:primary_subject, :primary_with_mathematics) }
   let(:previous_course_name) { "primary with English" }
-  let(:updated_course_name) { "Primary with Mathematics" }
   let(:mail) do
     described_class.course_subjects_updated_email(
       course: course,
       previous_subject_names: [previous_subject.subject_name],
-      updated_subject_names: [updated_subject.subject_name],
       previous_course_name: previous_course_name,
-      updated_course_name: updated_course_name,
       recipient: user,
       )
   end
@@ -63,20 +61,18 @@ describe CourseSubjectsUpdatedEmailMailer, type: :mailer do
     end
 
     context "course has been updated with two subjects" do
-      let(:course) { build(:course, :with_accrediting_provider, name: updated_course_name, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6), subjects: [updated_subject]) }
-      let(:user) { build(:user) }
       let(:first_updated_subject) { build(:secondary_subject, :mathematics) }
       let(:second_updated_subject) { build(:secondary_subject, :biology) }
+      let(:updated_course_name) { "Mathematics with Biology" }
+      let(:course) { build(:course, :with_accrediting_provider, name: updated_course_name, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6), subjects: [first_updated_subject, second_updated_subject]) }
+      let(:user) { build(:user) }
       let(:previous_subject) { build(:secondary_subject, :mathematics) }
       let(:previous_course_name) { "Mathematics" }
-      let(:updated_course_name) { "Mathematics with Biology" }
       let(:mail) do
         described_class.course_subjects_updated_email(
           course: course,
           previous_subject_names: [previous_subject.subject_name],
-          updated_subject_names: [first_updated_subject.subject_name, second_updated_subject.subject_name],
           previous_course_name: previous_course_name,
-          updated_course_name: updated_course_name,
           recipient: user,
           )
       end

--- a/spec/mailers/course_subjects_updated_email_mailer_spec.rb
+++ b/spec/mailers/course_subjects_updated_email_mailer_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+describe CourseSubjectsUpdatedEmailMailer, type: :mailer do
+  let(:previous_subject) { build(:primary_subject, :primary_with_english) }
+  let(:course) { build(:course, :with_accrediting_provider, name: updated_course_name, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6), subjects: [updated_subject]) }
+  let(:user) { build(:user) }
+  let(:updated_subject) { build(:primary_subject, :primary_with_mathematics) }
+  let(:previous_course_name) { "primary with English" }
+  let(:updated_course_name) { "Primary with Mathematics" }
+  let(:mail) do
+    described_class.course_subjects_updated_email(
+      course: course,
+      previous_subject_names: [previous_subject.subject_name],
+      updated_subject_names: [updated_subject.subject_name],
+      previous_course_name: previous_course_name,
+      updated_course_name: updated_course_name,
+      recipient: user,
+      )
+  end
+
+  describe "sending an email to a user" do
+    before do
+      course
+      mail
+    end
+
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_subjects_updated_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the course code in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_code]).to eq(course.course_code)
+    end
+
+    it "includes the provider name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:provider_name]).to eq(course.provider.provider_name)
+    end
+
+    it "includes the datetime for the detail update in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:subject_change_datetime]).to eq("4:05am on 3 February 2001")
+    end
+
+    context "course has been updated with one subject" do
+      it "includes the updated subject" do
+        expect(mail.govuk_notify_personalisation[:updated_subjects]).to eq(updated_subject.subject_name)
+      end
+
+      it "includes the previous subject" do
+        expect(mail.govuk_notify_personalisation[:previous_subjects]).to eq(previous_subject.subject_name)
+      end
+
+      it "includes the updated course name" do
+        expect(mail.govuk_notify_personalisation[:updated_course_name]).to eq(updated_course_name)
+      end
+
+      it "includes the previous course name" do
+        expect(mail.govuk_notify_personalisation[:previous_course_name]).to eq(previous_course_name)
+      end
+    end
+
+    context "course has been updated with two subjects" do
+      let(:course) { build(:course, :with_accrediting_provider, name: updated_course_name, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6), subjects: [updated_subject]) }
+      let(:user) { build(:user) }
+      let(:first_updated_subject) { build(:secondary_subject, :mathematics) }
+      let(:second_updated_subject) { build(:secondary_subject, :biology) }
+      let(:previous_subject) { build(:secondary_subject, :mathematics) }
+      let(:previous_course_name) { "Mathematics" }
+      let(:updated_course_name) { "Mathematics with Biology" }
+      let(:mail) do
+        described_class.course_subjects_updated_email(
+          course: course,
+          previous_subject_names: [previous_subject.subject_name],
+          updated_subject_names: [first_updated_subject.subject_name, second_updated_subject.subject_name],
+          previous_course_name: previous_course_name,
+          updated_course_name: updated_course_name,
+          recipient: user,
+          )
+      end
+
+      it "includes the updated subjects" do
+        expect(mail.govuk_notify_personalisation[:updated_subjects]).to eq("Mathematics, Biology")
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -186,4 +186,85 @@ describe User, type: :model do
       end
     end
   end
+
+  describe "notification subscribers" do
+    let(:accredited_body) { create(:provider, :accredited_body) }
+    let(:other_accredited_body) { create(:provider, :accredited_body) }
+    let(:course) { create(:course, accredited_body_code: accredited_body.provider_code) }
+    let(:subscribed_user) { create(:user) }
+    let(:non_subscribed_user) { create(:user) }
+    let(:user_subscribed_to_other_provider) { create(:user) }
+
+    before do
+      subscribed_notification
+      non_subscribed_notification
+      other_provider_notification
+    end
+
+    describe ".course_update_subscribers" do
+      let(:subscribed_notification) do
+        create(
+          :user_notification,
+          user: subscribed_user,
+          course_update: true,
+          provider_code: accredited_body.provider_code,
+          )
+      end
+
+      let(:non_subscribed_notification) do
+        create(
+          :user_notification,
+          user: non_subscribed_user,
+          course_update: false,
+          provider_code: accredited_body.provider_code,
+          )
+      end
+
+      let(:other_provider_notification) do
+        create(
+          :user_notification,
+          user: user_subscribed_to_other_provider,
+          course_publish: true,
+          provider_code: other_accredited_body.provider_code,
+          )
+      end
+
+      it "returns users who are subscribed to course update notifications for a given accredited body" do
+        expect(User.course_update_subscribers(course.accredited_body_code)).to eq([subscribed_user])
+      end
+    end
+
+    describe ".course_publish_subscribers" do
+      let(:subscribed_notification) do
+        create(
+          :user_notification,
+          user: subscribed_user,
+          course_publish: true,
+          provider_code: accredited_body.provider_code,
+          )
+      end
+
+      let(:non_subscribed_notification) do
+        create(
+          :user_notification,
+          user: non_subscribed_user,
+          course_publish: false,
+          provider_code: accredited_body.provider_code,
+          )
+      end
+
+      let(:other_provider_notification) do
+        create(
+          :user_notification,
+          user: user_subscribed_to_other_provider,
+          course_update: true,
+          provider_code: other_accredited_body.provider_code,
+          )
+      end
+
+      it "includes user who are subscribed to course publish notifications for a given accredited body" do
+        expect(User.course_publish_subscribers(course.accredited_body_code)).to eq([subscribed_user])
+      end
+    end
+  end
 end

--- a/spec/services/notification_service/course_subjects_updated_spec.rb
+++ b/spec/services/notification_service/course_subjects_updated_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+module NotificationService
+  describe CourseSubjectsUpdated do
+    describe "#call" do
+      let(:accredited_body) { create(:provider, :accredited_body) }
+      let(:other_accredited_body) { create(:provider, :accredited_body) }
+      let(:course) { create(:course, accredited_body_code: accredited_body.provider_code) }
+      let(:previous_subject_names) {['primary with english']}
+      let(:updated_subject_names) {['primary with mathematics']}
+      let(:previous_course_name) { previous_subject_names.first }
+      let(:updated_course_name) { updated_subject_names.first }
+
+      let(:subscribed_user) { create(:user) }
+      let(:non_subscribed_user) { create(:user) }
+      let(:user_subscribed_to_other_provider) { create(:user) }
+
+      let(:subscribed_notification) do
+        create(
+          :user_notification,
+          user: subscribed_user,
+          course_update: true,
+          provider_code: accredited_body.provider_code,
+        )
+      end
+
+      let(:non_subscribed_notification) do
+        create(
+          :user_notification,
+          user: non_subscribed_user,
+          course_update: false,
+          provider_code: accredited_body.provider_code,
+        )
+      end
+
+      let(:other_provider_notification) do
+        create(
+          :user_notification,
+          user: user_subscribed_to_other_provider,
+          course_publish: true,
+          provider_code: other_accredited_body.provider_code,
+        )
+      end
+      let(:self_accredited) { false }
+      let(:findable) { true }
+
+      def setup_notifications
+        allow(CourseSubjectsUpdatedEmailMailer).to receive(:course_subjects_updated_email).and_return(double(deliver_later: true))
+        subscribed_notification
+        non_subscribed_notification
+        other_provider_notification
+        allow(course).to receive(:self_accredited?).and_return(self_accredited)
+        allow(course).to receive(:findable?).and_return(findable)
+      end
+
+      context "with a course that is in the current cycle" do
+        before { setup_notifications }
+
+        it "sends notifications" do
+          expect(CourseSubjectsUpdatedEmailMailer).to receive(:course_subjects_updated_email)
+          expect(course.recruitment_cycle).to eql(RecruitmentCycle.current)
+          described_class.call(
+            course: course,
+            previous_subject_names: previous_subject_names,
+            updated_subject_names: updated_subject_names,
+            previous_course_name: previous_course_name,
+            updated_course_name: updated_course_name
+          )
+        end
+      end
+
+      context "with a course that is not in the current cycle" do
+        let(:provider) { create(:provider, :next_recruitment_cycle) }
+        let(:course) { create(:course, accredited_body_code: accredited_body.provider_code, provider: provider) }
+
+        before { setup_notifications }
+
+        it "does not send a notification" do
+          expect(CourseSubjectsUpdatedEmailMailer).to_not receive(:course_subjects_updated_email)
+          expect(course.recruitment_cycle).to_not eql(RecruitmentCycle.current)
+          described_class.call(
+            course: course,
+            previous_subject_names: previous_subject_names,
+            updated_subject_names: updated_subject_names,
+            previous_course_name: previous_course_name,
+            updated_course_name: updated_course_name,
+          )
+        end
+      end
+
+      context "non self-accredited course" do
+        before { setup_notifications }
+
+        context "that is findable" do
+          it "mails subscribed users" do
+            expect(CourseSubjectsUpdatedEmailMailer)
+              .to receive(:course_subjects_updated_email)
+              .with(
+              course: course,
+              previous_subject_names: previous_subject_names,
+              updated_subject_names: updated_subject_names,
+              previous_course_name: previous_course_name,
+              updated_course_name: updated_course_name,
+              recipient: subscribed_user,).and_return(mailer = double)
+            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+
+            described_class.call(
+              course: course,
+              previous_subject_names: previous_subject_names,
+              updated_subject_names: updated_subject_names,
+              previous_course_name: previous_course_name,
+              updated_course_name: updated_course_name,
+            )
+          end
+
+          it "does not email non subscribed users" do
+            expect(CourseSubjectsUpdatedEmailMailer).not_to receive(:course_subjects_updated_email)
+              .with(course, non_subscribed_user)
+            expect(CourseSubjectsUpdatedEmailMailer).not_to receive(:course_subjects_updated_email)
+              .with(course, user_subscribed_to_other_provider)
+            described_class.call(
+              course: course,
+              previous_subject_names: previous_subject_names,
+              updated_subject_names: updated_subject_names,
+              previous_course_name: previous_course_name,
+              updated_course_name: updated_course_name
+            )
+          end
+        end
+
+        context "that is not findable?" do
+          let(:findable) { false }
+
+          it "does not mail subscribed users" do
+            expect(CourseSubjectsUpdatedEmailMailer)
+              .not_to receive(:course_subjects_updated_email)
+            described_class.call(
+              course: course,
+              previous_subject_names: previous_subject_names,
+              updated_subject_names: updated_subject_names,
+              previous_course_name: previous_course_name,
+              updated_course_name: updated_course_name,
+            )
+          end
+        end
+      end
+
+      context "self accredited course" do
+        let(:self_accredited) { true }
+
+        before { setup_notifications }
+
+        it "does not mail subscribed users" do
+          expect(CourseSubjectsUpdatedEmailMailer)
+            .not_to receive(:course_subjects_updated_email)
+
+          described_class.call(
+            course: course,
+            previous_subject_names: previous_subject_names,
+            updated_subject_names: updated_subject_names,
+            previous_course_name: previous_course_name,
+            updated_course_name: updated_course_name,
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/services/notification_service/course_subjects_updated_spec.rb
+++ b/spec/services/notification_service/course_subjects_updated_spec.rb
@@ -6,8 +6,8 @@ module NotificationService
       let(:accredited_body) { create(:provider, :accredited_body) }
       let(:other_accredited_body) { create(:provider, :accredited_body) }
       let(:course) { create(:course, accredited_body_code: accredited_body.provider_code) }
-      let(:previous_subject_names) {['primary with english']}
-      let(:updated_subject_names) {['primary with mathematics']}
+      let(:previous_subject_names) { ["primary with english"] }
+      let(:updated_subject_names) { ["primary with mathematics"] }
       let(:previous_course_name) { previous_subject_names.first }
       let(:updated_course_name) { updated_subject_names.first }
 
@@ -90,10 +90,11 @@ module NotificationService
             expect(CourseSubjectsUpdatedEmailMailer)
               .to receive(:course_subjects_updated_email)
               .with(
-              course: course,
-              previous_subject_names: previous_subject_names,
-              previous_course_name: previous_course_name,
-              recipient: subscribed_user,).and_return(mailer = double)
+                course: course,
+                previous_subject_names: previous_subject_names,
+                previous_course_name: previous_course_name,
+                recipient: subscribed_user,
+).and_return(mailer = double)
             expect(mailer).to receive(:deliver_later).with(queue: "mailer")
 
             call_service


### PR DESCRIPTION
### Context
When a user updates a courses subjects we want to trigger a new 'Subjects updated' notification

### Changes proposed in this pull request
- 'Subjects updated' notification is triggered when the V2 API receives a request to update a course's subjects
- Any number of subjects can be updated

### 

### Guidance to review
- To test locally you will need to be subscribed to notifications and have a Notify key
- Go to a course that you are subscribed to get course updates for. Edit the courses subjects via 'basic details` tab. Once the update is submitted a subjects updated notification should fire.
- See a real example of the notification on Notify - https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/notification/1b579e0d-fd6b-4cf9-9806-321cd716c8f1

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
