### PR TITLE
[3680] - Sends notification when course title changes

### DIFF
--- a/app/mailers/course_update_email_mailer.rb
+++ b/app/mailers/course_update_email_mailer.rb
@@ -12,7 +12,7 @@ class CourseUpdateEmailMailer < GovukNotifyRails::Mailer
 
     set_personalisation(
       provider_name: course.provider.provider_name,
-      course_name: course.name,
+      course_name: set_course_name(course, attribute_name, original_value),
       course_code: course.course_code,
       course_description: course.description,
       course_funding_type: course.funding_type,
@@ -36,5 +36,11 @@ private
 
   def formatter
     CourseAttributeFormatterService
+  end
+
+  def set_course_name(course, attribute_name, original)
+    return original if attribute_name == "name"
+
+    course.name
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -266,7 +266,7 @@ class Course < ApplicationRecord
   after_validation :remove_unnecessary_enrichments_validation_message
 
   def update_notification_attributes
-    %w[age_range_in_years qualification study_mode maths english science]
+    %w[name age_range_in_years qualification study_mode maths english science]
   end
 
   def self.get_by_codes(year, provider_code, course_code)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,7 @@
 en:
   course:
     update_email:
+      name: "title"
       age_range_in_years: "age range"
       qualification: "outcome"
       study_mode: "study mode"

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -120,22 +120,22 @@ describe CourseUpdateEmailMailer, type: :mailer do
             updated_value: scenario[:updated_value],
             recipient: user,
             )
+        end
 
-          before do
-            allow(CourseAttributeFormatterService)
-              .to receive(:call)
-                    .with(name: "study_mode", value: scenario[:original_value])
-                    .and_return("ORIGINAL")
+        before do
+          allow(CourseAttributeFormatterService)
+            .to receive(:call)
+                  .with(name: "study_mode", value: scenario[:original_value])
+                  .and_return("ORIGINAL")
 
-            allow(CourseAttributeFormatterService)
-              .to receive(:call)
-                    .with(name: "study_mode", value: scenario[:updated_value])
-                    .and_return("UPDATED")
-          end
+          allow(CourseAttributeFormatterService)
+            .to receive(:call)
+                  .with(name: "study_mode", value: scenario[:updated_value])
+                  .and_return("UPDATED")
+        end
 
-          it "includes the updated detail in the personalisation" do
-            expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("study mode")
-          end
+        it "includes the updated detail in the personalisation" do
+          expect(mail.govuk_notify_personalisation[:attribute_changed]).to eq("study mode")
         end
       end
     end

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -140,4 +140,34 @@ describe CourseUpdateEmailMailer, type: :mailer do
       end
     end
   end
+
+  context "course name is updated" do
+    let(:previous_name) { course.name }
+    let(:mail) do
+      course.name = "new course"
+      described_class.course_update_email(
+        course: course,
+        attribute_name: "name",
+        original_value: previous_name,
+        updated_value: "new course",
+        recipient: user,
+        )
+    end
+
+    before do
+      allow(CourseAttributeFormatterService)
+        .to receive(:call)
+              .with(name: "name", value: previous_name)
+              .and_return("ORIGINAL")
+
+      allow(CourseAttributeFormatterService)
+        .to receive(:call)
+              .with(name: "name", value: "new course")
+              .and_return("UPDATED")
+    end
+
+    it "includes the original course name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_name]).to eq(previous_name)
+    end
+  end
 end


### PR DESCRIPTION
### Trello Ticket

https://trello.com/c/6mxlYteo/3680-m-basic-detail-notification-course-title

### Changes proposed in this pull request

- Added `name` (Course name) to the list of update notification attribute
- Toggle course name based on whether the user changed the course name or not.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
