### PR TITLE
[3684] Store request id from header for V3 api

### DIFF
--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -3,6 +3,7 @@ module API
     class ApplicationController < ActionController::API
       rescue_from ActiveRecord::RecordNotFound, with: :jsonapi_404
 
+      before_action :store_request_id
       before_action :check_disable_pagination
 
       def jsonapi_404
@@ -38,6 +39,10 @@ module API
           .permit(:subject_areas, :subjects, :courses, :providers)
           .to_h
           .map { |k, v| [k, v.split(",").map(&:to_sym)] }
+      end
+
+      def store_request_id
+        RequestStore.store[:request_id] = request.uuid
       end
     end
   end

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -16,6 +16,16 @@ describe "GET v3/recruitment_cycles/:year/courses" do
     next_course
   end
 
+  describe "request_id" do
+    it "stores request_id from header" do
+      headers = { "X-Request-Id" => "hello" }
+      hash = double
+      expect(RequestStore).to receive(:store).and_return(hash)
+      expect(hash).to receive(:[]=).with(:request_id, "hello")
+      get request_path, headers: headers
+    end
+  end
+
   describe "pagination" do
     it "returns a paginated list of courses in the recruitment cycle" do
       get request_path


### PR DESCRIPTION
### Context

- https://trello.com/c/2jQCohxd/3684-add-requestid-to-logging-for-find
- V3 api was not taking the `X-Request-Id` header from the request. Therefore a new `request_id` was being generated and this would not correlate with request ids from Find

### Changes proposed in this pull request

- V3 requests store request_id from header

### Guidance to review

- Checkout this PR
- `curl -H "X-Request-Id: foo" "http://localhost:3001/api/v3/subjects?fields%5Bsubjects%5D=subject_name%2Csubject_code&sort=subject_name"`
- add `binding.pry` after app/controllers/api/v3/application_controller.rb:44
- `request.uuid` should be `foo`
- alternatively if you want to check the logs you will have to enable the tagged logger for the dev environment

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
