### PR TITLE
[3681] - Create sites update notification

### DIFF
--- a/app/mailers/course_sites_update_email_mailer.rb
+++ b/app/mailers/course_sites_update_email_mailer.rb
@@ -1,0 +1,32 @@
+class CourseSitesUpdateEmailMailer < GovukNotifyRails::Mailer
+  include TimeFormat
+
+  def course_sites_update_email(
+    course:,
+    previous_site_names:,
+    updated_site_names:,
+    recipient:
+  )
+    set_template(Settings.govuk_notify.course_sites_update_email_template_id)
+
+    set_personalisation(
+      provider_name: course.provider.provider_name,
+      course_name: course.name,
+      course_code: course.course_code,
+      course_url: create_course_url(course),
+      previous_site_names: previous_site_names.join(", "),
+      updated_site_names: updated_site_names.join(", "),
+      sites_updated_datetime: gov_uk_format(course.updated_at),
+      )
+
+    mail(to: recipient.email)
+  end
+
+private
+
+  def create_course_url(course)
+    "#{Settings.find_url}" \
+      "/course/#{course.provider.provider_code}" \
+      "/#{course.course_code}"
+  end
+end

--- a/app/services/notification_service/course_sites_updated.rb
+++ b/app/services/notification_service/course_sites_updated.rb
@@ -1,0 +1,40 @@
+module NotificationService
+  class CourseSitesUpdated
+    include ServicePattern
+
+    def initialize(course:, previous_site_names:, updated_site_names:)
+      @course = course
+      @previous_site_names = previous_site_names
+      @updated_site_names = updated_site_names
+    end
+
+    def call
+      return unless course_needs_to_notify?
+
+      users_to_notify.each do |user|
+        CourseSitesUpdateEmailMailer.course_sites_update_email(
+          course: course,
+          previous_site_names: previous_site_names,
+          updated_site_names: updated_site_names,
+          recipient: user,
+          ).deliver_later(queue: "mailer")
+      end
+    end
+
+  private
+
+    attr_reader :course, :previous_site_names, :updated_site_names
+
+    def users_to_notify
+      User.joins(:user_notifications).merge(
+        UserNotification.course_update_notification_requests(course.accredited_body_code),
+        )
+    end
+
+    def course_needs_to_notify?
+      course.findable? &&
+        !course.self_accredited? &&
+        course.in_current_cycle?
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,8 @@ govuk_notify:
   magic_link_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
   course_vacancies_filled_email_template_id: please_change_me
+  course_sites_update_email_template_id: d5c8da46-9aa6-4c0a-8fad-ee782e89dbd3
+
 publish_url: http://localhost:3000
 find_url: http://localhost:3002
 mcbg:

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -5,6 +5,7 @@ govuk_notify:
   course_publish_email_template_id: please_change_me
   course_withdraw_email_template_id: please_change_me
   course_vacancies_filled_email_template_id: please_change_me
+  course_sites_update_email_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk

--- a/spec/mailers/course_sites_update_email_mailer_spec.rb
+++ b/spec/mailers/course_sites_update_email_mailer_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe CourseSitesUpdateEmailMailer, type: :mailer do
+  let(:course) { create(:course, :with_accrediting_provider, updated_at: DateTime.new(2001, 2, 3, 4, 5, 6)) }
+  let(:user) { create(:user) }
+  let(:mail) do
+    described_class.course_sites_update_email(
+      course: course,
+      recipient: user,
+      previous_site_names: previous_site_names,
+      updated_site_names: updated_site_names,
+    )
+  end
+  let(:previous_site_names) { ["location 1", "location 2"] }
+  let(:updated_site_names) { ["location 3", "location 4"] }
+
+  before do
+    course
+    mail
+  end
+
+  context "sending an email to a user" do
+    it "sends an email with the correct template" do
+      expect(mail.govuk_notify_template).to eq(Settings.govuk_notify.course_sites_update_email_template_id)
+    end
+
+    it "sends an email to the correct email address" do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it "includes the provider name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:provider_name]).to eq(course.provider.provider_name)
+    end
+
+    it "includes the course name in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_name]).to eq(course.name)
+    end
+
+    it "includes the course code in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:course_code]).to eq(course.course_code)
+    end
+
+    it "includes the previous site names in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:previous_site_names]).to eq("location 1, location 2")
+    end
+
+    it "includes the updated site names in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:updated_site_names]).to eq("location 3, location 4")
+    end
+
+    it "includes the datetime for the creation in the personalisation" do
+      expect(mail.govuk_notify_personalisation[:sites_updated_datetime]).to eq("4:05am on 3 February 2001")
+    end
+
+    it "includes the URL for the course in the personalisation" do
+      url = "#{Settings.find_url}" \
+        "/course/#{course.provider.provider_code}" \
+        "/#{course.course_code}"
+      expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
+    end
+  end
+end

--- a/spec/services/notification_service/course_sites_updated_spec.rb
+++ b/spec/services/notification_service/course_sites_updated_spec.rb
@@ -1,0 +1,151 @@
+require "rails_helper"
+
+module NotificationService
+  describe CourseSitesUpdated do
+    describe "#call" do
+      let(:accredited_body) { create(:provider, :accredited_body) }
+      let(:other_accredited_body) { create(:provider, :accredited_body) }
+      let(:course) { create(:course, accrediting_provider: accredited_body) }
+      let(:previous_site_names) { ["location 1", "location 2"] }
+      let(:updated_site_names) { ["location 3", "location 4"] }
+
+      let(:subscribed_user) { create(:user) }
+      let(:non_subscribed_user) { create(:user) }
+      let(:user_subscribed_to_other_provider) { create(:user) }
+
+      let(:subscribed_notification) do
+        create(
+          :user_notification,
+          user: subscribed_user,
+          course_update: true,
+          provider_code: accredited_body.provider_code,
+        )
+      end
+
+      let(:non_subscribed_notification) do
+        create(
+          :user_notification,
+          user: non_subscribed_user,
+          course_update: false,
+          provider_code: accredited_body.provider_code,
+        )
+      end
+
+      let(:other_provider_notification) do
+        create(
+          :user_notification,
+          user: user_subscribed_to_other_provider,
+          course_update: true,
+          provider_code: other_accredited_body.provider_code,
+        )
+      end
+      let(:self_accredited) { false }
+      let(:findable) { true }
+
+      def setup_notifications
+        allow(CourseSitesUpdateEmailMailer).to receive(:course_sites_update_email).and_return(double(deliver_later: true))
+        subscribed_notification
+        non_subscribed_notification
+        other_provider_notification
+        allow(course).to receive(:self_accredited?).and_return(self_accredited)
+        allow(course).to receive(:findable?).and_return(findable)
+      end
+
+      context "with a course that is in the current cycle" do
+        before { setup_notifications }
+
+        it "sends notifications" do
+          expect(CourseSitesUpdateEmailMailer).to receive(:course_sites_update_email)
+          expect(course.recruitment_cycle).to eql(RecruitmentCycle.current)
+          described_class.call(
+            course: course,
+            previous_site_names: previous_site_names,
+            updated_site_names: updated_site_names,
+          )
+        end
+      end
+
+      context "with a course that is not in the current cycle" do
+        let(:provider) { create(:provider, :next_recruitment_cycle) }
+        let(:course) { create(:course, accredited_body_code: accredited_body.provider_code, provider: provider) }
+
+        before { setup_notifications }
+
+        it "does not notifications" do
+          expect(CourseSitesUpdateEmailMailer).to_not receive(:course_sites_update_email)
+          expect(course.recruitment_cycle).to_not eql(RecruitmentCycle.current)
+          described_class.call(
+            course: course,
+            previous_site_names: previous_site_names,
+            updated_site_names: updated_site_names,
+          )
+        end
+      end
+
+      context "non self-accredited course" do
+        before { setup_notifications }
+
+        context "that is findable?" do
+          it "mails subscribed users" do
+            expect(CourseSitesUpdateEmailMailer)
+              .to receive(:course_sites_update_email)
+                    .with(
+                      course: course,
+                      recipient: subscribed_user,
+                      previous_site_names: previous_site_names,
+                      updated_site_names: updated_site_names,
+                    ).and_return(mailer = double)
+            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            described_class.call(
+              course: course,
+              previous_site_names: previous_site_names,
+              updated_site_names: updated_site_names,
+            )
+          end
+
+          it "does not email non subscribed users" do
+            expect(CourseSitesUpdateEmailMailer).not_to receive(:course_sites_update_email)
+                                                          .with(course, non_subscribed_user)
+            expect(CourseSitesUpdateEmailMailer).not_to receive(:course_sites_update_email)
+                                                          .with(course, user_subscribed_to_other_provider)
+            described_class.call(
+              course: course,
+              previous_site_names: previous_site_names,
+              updated_site_names: updated_site_names,
+            )
+          end
+        end
+
+        context "that is not findable?" do
+          let(:findable) { false }
+
+          it "does not mail subscribed users" do
+            expect(CourseSitesUpdateEmailMailer)
+              .not_to receive(:course_sites_update_email)
+            described_class.call(
+              course: course,
+              previous_site_names: previous_site_names,
+              updated_site_names: updated_site_names,
+            )
+          end
+        end
+      end
+
+      context "self accredited course" do
+        let(:self_accredited) { true }
+
+        before { setup_notifications }
+
+        it "does not mail subscribed users" do
+          expect(CourseSitesUpdateEmailMailer)
+            .not_to receive(:course_sites_update_email)
+          described_class.call(
+            course: course,
+            previous_site_names: previous_site_names,
+            updated_site_names: updated_site_names,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
We want to let subscribed users know when a course's locations have changed.

### Changes proposed in this pull request
When a user updates the sites (locations) for a course this will trigger a new notification indicating which sites have changed.

### Guidance to review
- You will need to have a Notify api key configured locally.
- Run locally against publish, and update the sites for a course. The `sites updated` notification should be sent. 
- View an example notification here - https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/notification/abf23bd6-4732-4121-bcd4-193f5e0b8ace

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
