### PR TITLE
[3752] Use `api` instead `api2`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -33,7 +33,7 @@ Authorization: Bearer your_api_key
 ## Example
 
 ```shell
-curl "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/subjects" -H "Authorization: Bearer your_api_key"
+curl "https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/subjects" -H "Authorization: Bearer your_api_key"
 ```
 
 Replace `your_api_key` with your issued API key.
@@ -56,7 +56,7 @@ The expected usage is as follows:
 ## Populating an empty system
 
 1. Call the endpoint with no query parameters,
-   e.g. `GET https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/<recruitment_cycle>/providers`
+   e.g. `GET https://api.publish-teacher-training-courses.service.gov.uk/api/v1/<recruitment_cycle>/providers`
 2. The API will return the first page of records, and will include a response
    header indicating the url needed to request the next page of records.
 3. Make another GET using the provided next page url.
@@ -85,7 +85,7 @@ The header will be of the form with the contents of `<...>` replaced with the
 correct url:
 
 ```
-Link: <https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/providers?...>; rel="next"
+Link: <https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/providers?...>; rel="next"
 ```
 
 **The query parameters are considered an internal concern of the API** and
@@ -157,13 +157,13 @@ This endpoint retrieves a paginated list of courses.
 First page of the complete data set:
 
 ```shell
-curl -v "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses" -H "Authorization: Bearer your_api_key"
+curl -v "https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses" -H "Authorization: Bearer your_api_key"
 ```
 
 Subsequent pages / incremental fetch, using the "next" url in the "Link" header from the previous request:
 
 ```shell
-curl -v "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses?changed_since=xxx" -H "Authorization: Bearer your_api_key"
+curl -v "https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/courses?changed_since=xxx" -H "Authorization: Bearer your_api_key"
 ```
 
 ### What constitutes a course change
@@ -334,7 +334,7 @@ This endpoint retrieves all subjects.
 ### Example HTTP Request
 
 ```shell
-curl "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/subjects" -H "Authorization: Bearer your_api_key"
+curl "https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/subjects" -H "Authorization: Bearer your_api_key"
 ```
 
 ### List of known subjects
@@ -421,7 +421,7 @@ This endpoint retrieves all institutions.
 ### Example HTTP Request
 
 ```shell
-curl "https://api2.publish-teacher-training-courses.service.gov.uk/api/v1/2019/providers" -H "Authorization: Bearer your_api_key"
+curl "https://api.publish-teacher-training-courses.service.gov.uk/api/v1/2019/providers" -H "Authorization: Bearer your_api_key"
 ```
 
 ### What constitutes a provider change

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -1,5 +1,5 @@
 # Host to use for canonical URL generation (without trailing slash)
-host: api2.publish-teacher-training-courses.service.gov.uk
+host: api.publish-teacher-training-courses.service.gov.uk
 
 # Header-related options
 show_govuk_logo: true

--- a/docs/performance-testing.md
+++ b/docs/performance-testing.md
@@ -21,7 +21,7 @@ bundle exec rspec spec/performance/pre_deploy_spec.rb
 To specify an environment set the `CUSTOM_HOST_NAME` environment variable.
 
 ```
-CUSTOM_HOST_NAME=https://api2.publish-teacher-training-courses.service.gov.uk bundle exec rspec spec/performance/pre_deploy_spec.rb
+CUSTOM_HOST_NAME=https://api.publish-teacher-training-courses.service.gov.uk bundle exec rspec spec/performance/pre_deploy_spec.rb
 ```
 
 ## Configuration ENV vars

--- a/docs/source/specifications.html.md.erb
+++ b/docs/source/specifications.html.md.erb
@@ -5,4 +5,4 @@ weight: 4
 
 # OpenAPI specifications
 
-- [API v1 spec as OpenAPI JSON](https://api2.publish-teacher-training-courses.service.gov.uk/api-docs/public_v1/api_spec.json)
+- [API v1 spec as OpenAPI JSON](https://api.publish-teacher-training-courses.service.gov.uk/api-docs/public_v1/api_spec.json)

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -11,7 +11,7 @@
   },
   "servers": [
     {
-      "url": "https://api2.publish-teacher-training-courses.service.gov.uk/api/public/{version}",
+      "url": "https://api.publish-teacher-training-courses.service.gov.uk/api/public/{version}",
       "description": "Production url.",
       "variables": {
         "version": {

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -8,7 +8,7 @@ info:
     email: becomingateacher@digital.education.gov.uk
   description: "API for DfE's postgraduate teacher training course service."
 servers:
-  - url: https://api2.publish-teacher-training-courses.service.gov.uk/api/public/{version}
+  - url: https://api.publish-teacher-training-courses.service.gov.uk/api/public/{version}
     description: "Production url."
     variables:
       version:


### PR DESCRIPTION
### Context
In the api docs, we referred to the endpoint as `api2` instead we should
be referring to `api`.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
