### PR TITLE
[3753] Responses & Responses eg's produces same id

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
@@ -28,7 +28,7 @@
     </tbody>
   </table>
 
-  <h4 id="<%= id %>">Response examples</h4>
+  <h4 id="<%= id %>-examples">Response examples</h4>
 
   <% responses.each do |key,response| %>
     <details class="govuk-details" data-module="govuk-details">


### PR DESCRIPTION
### Context
We were using malformed HTML where the "Responses" section had the same
id as "Responses Example". This meant that the left side nav was highlighting
both entries because their URL was the same.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
