### PR TITLE
3682 basic detail notification ucas apply

### DIFF
--- a/app/services/course_attribute_formatter_service.rb
+++ b/app/services/course_attribute_formatter_service.rb
@@ -54,7 +54,7 @@ private
   end
 
   def entry_requirements_value
-    strip_underscores
+    I18n.t("course.values.entry_requirements.#{value}")
   end
 
   def strip_underscores

--- a/app/services/notification_service/course_updated.rb
+++ b/app/services/notification_service/course_updated.rb
@@ -9,17 +9,18 @@ module NotificationService
     def call
       return unless course_needs_to_notify?
 
-      updated_attribute = notifiable_changes.first
-      original_value, updated_value = course.saved_changes[updated_attribute]
+      notifiable_changes.each do |updated_attribute|
+        original_value, updated_value = course.saved_changes[updated_attribute]
 
-      users.each do |user|
-        CourseUpdateEmailMailer.course_update_email(
-          course: course,
-          attribute_name: updated_attribute,
-          original_value: original_value,
-          updated_value: updated_value,
-          recipient: user,
-        ).deliver_later(queue: "mailer")
+        users.each do |user|
+          CourseUpdateEmailMailer.course_update_email(
+            course: course,
+            attribute_name: updated_attribute,
+            original_value: original_value,
+            updated_value: updated_value,
+            recipient: user,
+          ).deliver_later(queue: "mailer")
+        end
       end
     end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,9 +5,9 @@ en:
       age_range_in_years: "age range"
       qualification: "outcome"
       study_mode: "study mode"
-      science: "entry requirements"
-      maths: "entry requirements"
-      english: "entry requirements"
+      science: "Science GCSE requirement"
+      maths: "Maths GCSE requirement"
+      english: "English GCSE requirement"
     values:
       qualification:
         qts: "QTS"
@@ -15,6 +15,11 @@ en:
         pgce: "PGCE"
         pgde_with_qts: "PGDE with QTS"
         pgde: "PGDE"
+      entry_requirements:
+        must_have_qualification_at_application_time: "Must have the GCSE"
+        expect_to_achieve_before_training_begins: "Taking the GCSE"
+        equivalence_test: "Equivalency test"
+        not_required: "Not required"
   activerecord:
     attributes:
       course:

--- a/spec/services/course_attribute_formatter_service_spec.rb
+++ b/spec/services/course_attribute_formatter_service_spec.rb
@@ -1,4 +1,4 @@
-require_relative "../../app/services/course_attribute_formatter_service"
+require "rails_helper"
 
 RSpec.describe CourseAttributeFormatterService do
   subject { CourseAttributeFormatterService.call(name: name, value: value) }
@@ -88,28 +88,28 @@ RSpec.describe CourseAttributeFormatterService do
   shared_examples_for "entry requirements" do
     context "must_have_qualification_at_application_time" do
       let(:value) { "must_have_qualification_at_application_time" }
-      let(:expected_value) { "must have qualification at application time" }
+      let(:expected_value) { "Must have the GCSE" }
 
       it { is_expected.to eq(expected_value) }
     end
 
     context "equivalence_test" do
       let(:value) { "equivalence_test" }
-      let(:expected_value) { "equivalence test" }
+      let(:expected_value) { "Equivalency test" }
 
       it { is_expected.to eq(expected_value) }
     end
 
     context "expect_to_achieve_before_training_begins" do
       let(:value) { "expect_to_achieve_before_training_begins" }
-      let(:expected_value) { "expect to achieve before training begins" }
+      let(:expected_value) { "Taking the GCSE" }
 
       it { is_expected.to eq(expected_value) }
     end
 
     context "not_required" do
       let(:value) { "not_required" }
-      let(:expected_value) { "not required" }
+      let(:expected_value) { "Not required" }
 
       it { is_expected.to eq(expected_value) }
     end


### PR DESCRIPTION
### Context
https://trello.com/c/vDDbpmtB/3682-m-basic-detail-notification-ucas-apply
Multiple emails are now sent. One per attribute being changed. 

### Changes proposed in this pull request
- Added a loop to course update attribute changes
- Added locale entry requirement value changes

### Guidance to review

### Checklist

- [X] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
