### PR TITLE
[3735] Added implementation of providers endpoint

### DIFF
--- a/app/controllers/api/public/v1/providers_controller.rb
+++ b/app/controllers/api/public/v1/providers_controller.rb
@@ -3,21 +3,7 @@ module API
     module V1
       class ProvidersController < API::Public::V1::ApplicationController
         def index
-          render json: {
-            data: [
-              {
-                id: 123,
-                type: "Provider",
-                attributes: {
-                  code: "ABC",
-                  name: "Some provider",
-                },
-              },
-            ],
-            jsonapi: {
-              version: "1.0",
-            },
-          }
+          render jsonapi: recruitment_cycle.providers.by_name_ascending, class: { Provider: API::Public::V1::SerializableProvider }, fields: { providers: provider_fields }
         end
 
         def show
@@ -34,6 +20,35 @@ module API
               version: "1.0",
             },
           }
+        end
+
+      private
+
+        def recruitment_cycle
+          RecruitmentCycle.find_by(
+            year: params[:recruitment_cycle_year],
+          ) || RecruitmentCycle.current_recruitment_cycle
+        end
+
+        def provider_fields
+          params.dig(:fields, :providers)&.split(",") || %i[
+             accredited_body
+             changed_at
+             city
+             code
+             county
+             created_at
+             name
+             postcode
+             provider_type
+             recruitment_cycle_year
+             region_code
+             street_address_1
+             street_address_2
+             train_with_disability
+             train_with_us
+             website
+            ]
         end
       end
     end

--- a/spec/api/providers_spec.rb
+++ b/spec/api/providers_spec.rb
@@ -19,8 +19,8 @@ describe "API" do
                 style: :form,
                 explode: false,
                 required: false,
-                example: "provider.provider_name,name",
-                description: "Field(s) to sort the courses by."
+                example: "name",
+                description: "Field(s) to sort the providers by."
       parameter name: :page,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Pagination" },

--- a/spec/requests/api/public/v1/providers/index_spec.rb
+++ b/spec/requests/api/public/v1/providers/index_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
+  let(:organisation) { create(:organisation) }
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+
+  let!(:provider) {
+    create(:provider,
+           provider_code: "1AT",
+           provider_name: "First provider",
+           organisations: [organisation],
+           contacts: [contact])
+  }
+
+  let(:contact) { build(:contact) }
+
+  let(:json_response) { JSON.parse(response.body) }
+  let(:data) { json_response["data"] }
+
+  def perform_request
+    get request_path
+  end
+
+  subject do
+    perform_request
+
+    response
+  end
+
+  let(:request_path) { "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers" }
+
+  describe "JSON generated for a providers" do
+    it { should have_http_status(:success) }
+
+    it "has a data section with the correct attributes" do
+      perform_request
+
+      expect(json_response).to eq(
+        "data" => [{
+          "id" => provider.id.to_s,
+          "type" => "providers",
+          "attributes" => {
+            "code" => provider.provider_code,
+            "name" => provider.provider_name,
+            "recruitment_cycle_year" => provider.recruitment_cycle.year,
+            "postcode" => provider.postcode,
+            "provider_type" => provider.provider_type,
+            "region_code" => provider.region_code,
+            "train_with_disability" => provider.train_with_disability,
+            "train_with_us" => provider.train_with_us,
+            "website" => provider.website,
+            "accredited_body" => provider.accredited_body?,
+            "changed_at" => provider.changed_at.iso8601,
+            "city" => provider.address3,
+            "county" => provider.address4,
+            "created_at" => provider.created_at.iso8601,
+            "street_address_1" => provider.address1,
+            "street_address_2" => provider.address2,
+          },
+        }],
+        "jsonapi" => {
+          "version" => "1.0",
+        },
+      )
+    end
+  end
+
+  context "with unalphabetical ordering in the database" do
+    let(:second_alphabetical_provider) do
+      create(:provider, provider_name: "Zork", organisations: [organisation])
+    end
+
+    before do
+      second_alphabetical_provider
+
+      # This moves it last in the order that it gets fetched by default.
+      provider.update(provider_name: "Acme")
+    end
+
+    let(:provider_names_in_response) {
+      data.map { |provider|
+        provider["attributes"]["name"]
+      }
+    }
+
+    it "returns them in alphabetical order" do
+      perform_request
+      expect(provider_names_in_response).to eq(%w(Acme Zork))
+    end
+  end
+
+  context "with two recruitment cycles" do
+    let(:next_recruitment_cycle) { create :recruitment_cycle, :next }
+    let(:next_provider) {
+      create :provider,
+             organisations: [organisation],
+             provider_code: provider.provider_code,
+             recruitment_cycle: next_recruitment_cycle
+    }
+
+    describe "making a request without specifying a recruitment cycle" do
+      it "only returns data for the current recruitment cycle" do
+        next_provider
+
+        perform_request
+
+        expect(data.count).to eq 1
+        expect(data.first)
+          .to have_attribute("recruitment_cycle_year")
+                .with_value(recruitment_cycle.year)
+      end
+    end
+
+    describe "making a request for the next recruitment cycle" do
+      let(:request_path) {
+        "/api/public/v1/recruitment_cycles/#{next_recruitment_cycle.year}/providers"
+      }
+
+      it "only returns data for the next recruitment cycle" do
+        next_provider
+
+        perform_request
+
+        expect(data.count).to eq 1
+        expect(data.first)
+          .to have_attribute("recruitment_cycle_year")
+                .with_value(next_recruitment_cycle.year)
+      end
+    end
+  end
+
+  context "Sparse fields" do
+    before { perform_request }
+
+    context "Only returning specified fields" do
+      let(:request_path) { "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?fields[providers]=name,recruitment_cycle_year" }
+
+      it "Only returns the specified field" do
+        expect(data.first["attributes"].keys.count).to eq(2)
+        expect(data.first).to have_attribute("name")
+        expect(data.first).to have_attribute("recruitment_cycle_year")
+      end
+    end
+
+    context "Default fields" do
+      fields = %w[ postcode
+                   provider_type
+                   region_code
+                   train_with_disability
+                   train_with_us
+                   website
+                   accredited_body
+                   changed_at
+                   city
+                   code
+                   county
+                   created_at
+                   name
+                   recruitment_cycle_year
+                   street_address_1
+                   street_address_2]
+
+      it "Returns the Default fields" do
+        expect(data.first["attributes"].keys).to match_array(fields)
+      end
+    end
+  end
+end

--- a/spec/requests/api/public/v1/providers/index_spec.rb
+++ b/spec/requests/api/public/v1/providers/index_spec.rb
@@ -4,13 +4,13 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
   let(:organisation) { create(:organisation) }
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
 
-  let!(:provider) {
+  let!(:provider) do
     create(:provider,
            provider_code: "1AT",
            provider_name: "First",
            organisations: [organisation],
            contacts: [contact])
-  }
+  end
 
   let(:contact) { build(:contact) }
 
@@ -27,7 +27,9 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
     response
   end
 
-  let(:request_path) { "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers" }
+  let(:request_path) do
+    "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers"
+  end
 
   describe "JSON generated for a providers" do
     it { should have_http_status(:success) }
@@ -64,27 +66,27 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
   end
 
   describe "sorting" do
-    let!(:provider2) {
+    let!(:provider2) do
       create(:provider,
              provider_code: "0AT",
              provider_name: "Before",
              organisations: [organisation],
              contacts: [contact])
-    }
+    end
 
-    let!(:provider3) {
+    let!(:provider3) do
       create(:provider,
              provider_code: "2AT",
              provider_name: "Second",
              organisations: [organisation],
              contacts: [contact])
-    }
+    end
 
-    let(:provider_names_in_response) {
+    let(:provider_names_in_response) do
       data.map { |provider|
         provider["attributes"]["name"]
       }
-    }
+    end
 
     context "default ordering" do
       it "returns them in a-z order" do
@@ -92,13 +94,12 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
       end
 
       describe "passing in sort param" do
-        let(:request_path) {
+        let(:request_path) do
           "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?sort=#{sort_field}"
-        }
+        end
+
         context "name" do
-          let(:sort_field) {
-            "name"
-          }
+          let(:sort_field) { "name" }
 
 
           it "returns them in a-z order" do
@@ -107,9 +108,7 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
         end
 
         context "-name" do
-          let(:sort_field) {
-            "-name"
-          }
+          let(:sort_field) { "-name" }
 
           it "returns them in z-a order" do
             expect(provider_names_in_response).to eq(%w(Second First Before))
@@ -117,9 +116,7 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
         end
 
         context "name,-name" do
-          let(:sort_field) {
-            "name,-name"
-          }
+          let(:sort_field) { "name,-name" }
 
           it "returns them in a-z order" do
             expect(provider_names_in_response).to eq(%w(Before First Second))
@@ -127,9 +124,7 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
         end
 
         context "-name,name" do
-          let(:sort_field) {
-            "-name,name"
-          }
+          let(:sort_field) { "-name,name" }
 
           it "returns them in a-z order" do
             expect(provider_names_in_response).to eq(%w(Before First Second))
@@ -141,12 +136,12 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
 
   context "with two recruitment cycles" do
     let(:next_recruitment_cycle) { create :recruitment_cycle, :next }
-    let!(:next_provider) {
+    let!(:next_provider) do
       create :provider,
              organisations: [organisation],
              provider_code: provider.provider_code,
              recruitment_cycle: next_recruitment_cycle
-    }
+    end
 
     describe "making a request without specifying a recruitment cycle" do
       it "only returns data for the current recruitment cycle" do
@@ -158,9 +153,9 @@ describe "GET public/v1/recruitment_cycle/:recruitment_cycle_year/providers" do
     end
 
     describe "making a request for the next recruitment cycle" do
-      let(:request_path) {
+      let(:request_path) do
         "/api/public/v1/recruitment_cycles/#{next_recruitment_cycle.year}/providers"
-      }
+      end
 
       it "only returns data for the next recruitment cycle" do
         expect(data.count).to eq 1

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1384,8 +1384,8 @@
             "style": "form",
             "explode": false,
             "required": false,
-            "example": "provider.provider_name,name",
-            "description": "Field(s) to sort the courses by."
+            "example": "name",
+            "description": "Field(s) to sort the provider by."
           },
           {
             "name": "page",


### PR DESCRIPTION
### Context
public v1 providers endpoint

### Changes proposed in this pull request
Returns collection of providers based on recruitment cycle
Defaults to be sorted alphabetically by provider name (asc)
Added support for sparse fields
Added ability to sort providers via its name from `a-z` or `z-a`
### Guidance to review
No pagination


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
