### PR TITLE
[3738] Prettify HTTP method and path headings

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -41,7 +41,7 @@ module GovukTechDocs
       def path(text)
         path = @document.paths[text]
         id = text.parameterize
-        operations = operations(path, id)
+        operations = operations(text: text, path: path, path_id: id)
         @template_path.result(binding)
       end
 
@@ -122,11 +122,12 @@ module GovukTechDocs
         schemas
       end
 
-      def operations(path, path_id)
+      def operations(text:, path:, path_id:)
         output = ""
         operations = get_operations(path)
         operations.compact.each do |key, operation|
           id = "#{path_id}-#{key.parameterize}"
+          text = text
           parameters = parameters(operation, id)
           responses = responses(operation, id)
           output += @template_operation.result(binding)

--- a/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
@@ -1,4 +1,13 @@
-<h3 id="<%= id %>"><%= key %></h3>
+<% if text %>
+  <h2 id="<%= id %>">
+    <span class="govuk-caption-l">
+      <%= key.upcase %>
+    </span>
+    <span class="govuk-heading-l">
+      <%= text %>
+    </span>
+  </h2>
+<% end %>
 
 <% if operation.summary %>
   <p><em><%= operation.summary %></em></p>

--- a/docs/lib/govuk_tech_docs/open_api/templates/parameters.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/parameters.html.erb
@@ -1,5 +1,5 @@
 <% if parameters.any? %>
-  <h4 id="<%= id %>">Parameters</h4>
+  <h3 id="<%= id %>">Parameters</h3>
 
   <table>
     <thead>

--- a/docs/lib/govuk_tech_docs/open_api/templates/path.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/path.html.erb
@@ -1,5 +1,1 @@
-<% if text %>
-  <h2 id="<%= id %>"><%= text %></h2>
-<% end %>
-
 <%= operations %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/responses.html.erb
@@ -1,5 +1,5 @@
 <% if responses.any? %>
-  <h4 id="<%= id %>">Responses</h4>
+  <h3 id="<%= id %>">Responses</h3>
 
   <table>
     <thead>
@@ -28,7 +28,7 @@
     </tbody>
   </table>
 
-  <h4 id="<%= id %>-examples">Response examples</h4>
+  <h3 id="<%= id %>-examples">Response examples</h3>
 
   <% responses.each do |key,response| %>
     <details class="govuk-details" data-module="govuk-details">
@@ -66,4 +66,6 @@
       </div>
     </details>
   <% end %>
+  <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+
 <% end %>


### PR DESCRIPTION
### Context
I made the HTTP method uppercase and styled as a caption because unlike
Apply's API our URL are longer and so they would automatically wrap to a
new line.

### Changes proposed in this pull request

## Before 

![image](https://user-images.githubusercontent.com/50492247/89031189-f1ad2e80-d329-11ea-8474-9aa3947e55ba.png)

## After

![image](https://user-images.githubusercontent.com/50492247/89031200-f5d94c00-d329-11ea-8ebc-139e1792278d.png)




### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
