### PR TITLE
[3750] Document Provider Suggestions Endpoint

### DIFF
--- a/app/controllers/api/public/v1/provider_suggestions_controller.rb
+++ b/app/controllers/api/public/v1/provider_suggestions_controller.rb
@@ -1,0 +1,31 @@
+module API
+  module Public
+    module V1
+      class ProviderSuggestionsController < API::Public::V1::ApplicationController
+        def index
+          return render(status: :bad_request) if params[:query].nil? || params[:query].length < 3
+
+          render json: {
+            data: [
+              {
+                id: "O66",
+                type: "Oxford Brookes University",
+              },
+              {
+                id: "1DE",
+                type: "Oxfordshire Teacher Training",
+              },
+              {
+                id: "O33",
+                type: "Oxford University",
+              },
+            ],
+            jsonapi: {
+              version: "1.0",
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,6 +108,8 @@ Rails.application.routes.draw do
             end
           end
         end
+
+        get "provider_suggestions", to: "provider_suggestions#index"
       end
     end
   end

--- a/spec/api/provider_suggestions_spec.rb
+++ b/spec/api/provider_suggestions_spec.rb
@@ -1,0 +1,31 @@
+require "swagger_helper"
+
+describe "API" do
+  path "/provider_suggestions" do
+    get "Returns a list of providers suggestions matching the query term." do
+      operationId :public_api_v1_provider_suggestions
+      tags "provider_suggestions"
+      produces "application/json"
+      parameter name: :query,
+                in: :query,
+                type: :string,
+                required: true,
+                description: "The provider's marketing name or code",
+                example: "oxf"
+
+      response "200", "A list of provider suggestions matching the query term" do
+        let(:query) { "oxf" }
+
+        schema "$ref": "#/components/schemas/ProviderSuggestionListResponse"
+
+        run_test!
+      end
+
+      response "400", "A bad request" do
+        let(:query) { nil }
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -995,6 +995,38 @@
           }
         }
       },
+      "ProviderSuggestion": {
+        "description": "This schema provides metadata about a provider.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "066"
+          },
+          "code": {
+            "type": "string",
+            "example": "Oxford Brookes University"
+          }
+        }
+      },
+      "ProviderSuggestionListResponse": {
+        "description": "This schema is used to return a collection of provider suggestions.",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProviderSuggestion"
+            }
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
       "RecruitmentCycleAttributes": {
         "description": "This schema is used to describe a recruitment cycle.",
         "type": "object",
@@ -1353,6 +1385,42 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/provider_suggestions": {
+      "get": {
+        "summary": "Returns a list of providers suggestions matching the query term.",
+        "operationId": "public_api_v1_provider_suggestions",
+        "tags": [
+          "provider_suggestions"
+        ],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "The provider's marketing name or code",
+            "example": "oxf",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A list of provider suggestions matching the query term",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProviderSuggestionListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "A bad request"
           }
         }
       }

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -309,6 +309,28 @@ components:
           $ref: "#/components/schemas/Included"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
+    ProviderSuggestion:
+      description: "This schema provides metadata about a provider."
+      type: object
+      properties:
+        name:
+          type: string
+          example: "066"
+        code:
+          type: string
+          example: "Oxford Brookes University"
+    ProviderSuggestionListResponse:
+      description: "This schema is used to return a collection of provider suggestions."
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProviderSuggestion"
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPI"
     Relationship:
       description: "This schema describes a single associated object."
       type: object


### PR DESCRIPTION
### Context

- https://trello.com/c/6u0XPujL/3750-document-api-endpoint-api-public-v1-provider-suggestions
- Document `/api/public/v1/provider_suggestions`

### Changes proposed in this pull request

- Document the provider suggestions endpoint in the new public api docs

### Guidance to review

- Run the middleman docs, see the new endpoint documentation for provider suggestions
- Discuss whether it's worth making the endpoint snake_case rather than kebab-case to be consistent with other endpoints

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
