### PR TITLE
[3737] Add course serializer for public/v1 api

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
 
 Rails/HasManyOrHasOneDependent:
   Enabled: false
+Rails/InverseOf:
+  Exclude:
+    - app/models/course.rb
 
 Style/HashEachMethods:
   Enabled: true
@@ -21,3 +24,4 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -1,0 +1,129 @@
+module API
+  module Public
+    module V1
+      class SerializableCourse < JSONAPI::Serializable::Resource
+        class << self
+          def enrichment_attribute(name, enrichment_name = name)
+            attribute name do
+              @object.latest_published_enrichment&.public_send(enrichment_name)
+            end
+          end
+        end
+
+        type "courses"
+
+        attributes :accredited_body_code,
+                   :age_maximum,
+                   :age_minimum,
+                   :bursary_amount,
+                   :bursary_requirements,
+                   :created_at,
+                   :funding_type,
+                   :gcse_subjects_required,
+                   :level,
+                   :name,
+                   :program_type,
+                   :qualifications,
+                   :scholarship_amount,
+                   :study_mode
+
+        attribute :about_accredited_body do
+          @object.accrediting_provider_description
+        end
+
+        attribute :applications_open_from do
+          @object.applications_open_from&.iso8601
+        end
+
+        attribute :changed_at do
+          @object.changed_at&.iso8601
+        end
+
+        attribute :code do
+          @object.course_code
+        end
+
+        attribute :created_at do
+          @object.created_at&.iso8601
+        end
+
+        attribute :findable do
+          @object.findable?
+        end
+
+        attribute :has_early_career_payments do
+          @object.has_early_career_payments?
+        end
+
+        attribute :has_scholarship do
+          @object.has_scholarship?
+        end
+
+        attribute :has_vacancies do
+          @object.has_vacancies?
+        end
+
+        attribute :is_send do
+          @object.is_send?
+        end
+
+        attribute :last_published_at do
+          @object.last_published_at&.iso8601
+        end
+
+        attribute :open_for_applications do
+          @object.open_for_applications?
+        end
+
+        attribute :provider_code do
+          @object.provider.provider_code
+        end
+
+        attribute :recruitment_cycle_year do
+          @object.recruitment_cycle.year
+        end
+
+        attribute :required_qualifications_english do
+          @object.english
+        end
+
+        attribute :required_qualifications_maths do
+          @object.maths
+        end
+
+        attribute :required_qualifications_science do
+          @object.science
+        end
+
+        attribute :running do
+          @object.findable?
+        end
+
+        attribute :start_date do
+          @object.start_date&.strftime("%B %Y")
+        end
+
+        attribute :state do
+          @object.content_status
+        end
+
+        attribute :summary do
+          @object.description
+        end
+
+        enrichment_attribute :about_course
+        enrichment_attribute :course_length
+        enrichment_attribute :fee_details
+        enrichment_attribute :fee_international
+        enrichment_attribute :fee_domestic, :fee_uk_eu
+        enrichment_attribute :financial_support
+        enrichment_attribute :how_school_placements_work
+        enrichment_attribute :interview_process
+        enrichment_attribute :other_requirements
+        enrichment_attribute :personal_qualities
+        enrichment_attribute :required_qualifications
+        enrichment_attribute :salary_details
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
       maths: "Maths GCSE requirement"
       english: "English GCSE requirement"
     values:
+      bursary_requirements:
+        second_degree: "a degree of 2:2 or above in any subject"
+        maths: "at least grade B in maths A-level (or an equivalent)"
       qualification:
         qts: "QTS"
         pgce_with_qts: "PGCE with QTS"

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -41,11 +41,11 @@ FactoryBot.define do
     financial_support do
       [
         "Please get in contact with the school for any further details.",
-        "The course is Non-Salaried only. ",
+        "The course is Non-Salaried only.",
         "Find out more about the financial support available within our [financial information section](http://localhost:5000/about/financial_support)",
         "Bursaries and scholarships are available to trainees",
         "You may be eligible for a government bursary if you are applying to teach one of our secondary subjects",
-        "DfE bursaries are available for select trainees ",
+        "DfE bursaries are available for select trainees",
         "You can find information about tuition fee loans and other financial help on the Gov.uk website - (https://www.gov.uk/student-finance)",
       ].sample
     end

--- a/spec/factories/subjects/secondary_subjects.rb
+++ b/spec/factories/subjects/secondary_subjects.rb
@@ -38,7 +38,8 @@ FactoryBot.define do
     subject_code { sample_subject.second }
 
     after(:build) do |subject, _level|
-      find_or_create(:financial_incentive, subject: subject)
+      financial_incentive = find_or_create(:financial_incentive, subject: subject)
+      subject.update(financial_incentive: financial_incentive)
     end
 
     trait :art_and_design do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2104,4 +2104,87 @@ describe Course, type: :model do
       )
     end
   end
+
+  describe "#age_minimum" do
+    context "when age_range_in_years set" do
+      it "returns lower age_range_in_years bound" do
+        expect(subject.age_minimum).to eql(3)
+      end
+    end
+
+    context "when age_range_in_years not set" do
+      subject { Course.new }
+
+      it "returns nil" do
+        expect(subject.age_minimum).to be_nil
+      end
+    end
+  end
+
+  describe "#age_maximum" do
+    context "when age_range_in_years set" do
+      it "returns upper age_range_in_years bound" do
+        expect(subject.age_maximum).to eql(7)
+      end
+    end
+
+    context "when age_range_in_years not set" do
+      subject { Course.new }
+
+      it "returns nil" do
+        expect(subject.age_maximum).to be_nil
+      end
+    end
+  end
+
+  describe "#bursary_requirements" do
+    context "when there is no bursary" do
+      subject do
+        create(
+          :course,
+          level: "primary",
+          name: "Primary with english",
+          course_code: "AAAA",
+          subjects: [find_or_create(:primary_subject, :primary_with_english)],
+        )
+      end
+
+      it "returns no requirements" do
+        expect(subject.bursary_requirements).to be_empty
+      end
+    end
+
+    context "when there is a bursary" do
+      subject do
+        create(
+          :course,
+          level: "secondary",
+          name: "Art and design",
+          course_code: "AAAA",
+          subjects: [find_or_create(:secondary_subject, :art_and_design)],
+        )
+      end
+
+      it "returns default requirements" do
+        expect(subject.bursary_requirements).to eql(["a degree of 2:2 or above in any subject"])
+      end
+    end
+
+    context "when primary with maths" do
+      subject { Course.new(subjects: [PrimarySubject.find_by(subject_code: "03")]) }
+      subject do
+        create(
+          :course,
+          level: "primary",
+          name: "Primary with mathematics",
+          course_code: "AAAA",
+          subjects: [find_or_create(:primary_subject, :primary_with_mathematics)],
+        )
+      end
+
+      it "includes additional requirements" do
+        expect(subject.bursary_requirements).to eql(["a degree of 2:2 or above in any subject", "at least grade B in maths A-level (or an equivalent)"])
+      end
+    end
+  end
 end

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -1,0 +1,86 @@
+require "rails_helper"
+
+RSpec.describe API::Public::V1::SerializableCourse do
+  let(:enrichment) { build(:course_enrichment, :published) }
+  let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment]) }
+  let(:resource) { described_class.new(object: course) }
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it "sets type to courses" do
+    expect(resource.jsonapi_type).to eq(:courses)
+  end
+
+  it { is_expected.to have_type("courses") }
+
+  context "when there is an accredited body with enrichments" do
+    before do
+      course.provider.update(accrediting_provider_enrichments: [{ Description: "foo", UcasProviderCode: course.accrediting_provider.provider_code }])
+    end
+
+    it { is_expected.to have_attribute(:about_accredited_body).with_value(course.provider.accrediting_provider_enrichments.first.Description) }
+  end
+
+  it { is_expected.to have_attribute(:about_accredited_body).with_value(nil) }
+  it { is_expected.to have_attribute(:about_course).with_value(course.latest_published_enrichment.about_course) }
+  it { is_expected.to have_attribute(:accredited_body_code).with_value(course.accredited_body_code) }
+  it { is_expected.to have_attribute(:age_minimum).with_value(3) }
+  it { is_expected.to have_attribute(:age_maximum).with_value(7) }
+  it { is_expected.to have_attribute(:applications_open_from).with_value(course.applications_open_from.iso8601) }
+  it { expect(subject["attributes"]["applications_open_from"]).to match(/\d{4}-\d{2}-\d{2}/) }
+  it { is_expected.to have_attribute(:bursary_amount).with_value(nil) }
+
+  context "when financial_incentives are present" do
+    let(:course) { create(:course, :with_accrediting_provider, enrichments: [enrichment], level: "secondary", subjects: [create(:secondary_subject, :physics)]) }
+
+    it { is_expected.to have_attribute(:bursary_amount).with_value("6000") }
+  end
+
+  it { is_expected.to have_attribute(:bursary_requirements).with_value(course.bursary_requirements) }
+  it { is_expected.to have_attribute(:changed_at).with_value(course.changed_at.iso8601) }
+  it { is_expected.to have_attribute(:code).with_value(course.course_code) }
+  it { is_expected.to have_attribute(:course_length).with_value(course.latest_published_enrichment.course_length) }
+  it { is_expected.to have_attribute(:created_at).with_value(course.created_at.iso8601) }
+  it { is_expected.to have_attribute(:fee_details).with_value(course.latest_published_enrichment.fee_details) }
+  it { is_expected.to have_attribute(:fee_international).with_value(course.latest_published_enrichment.fee_international) }
+  it { is_expected.to have_attribute(:fee_domestic).with_value(course.latest_published_enrichment.fee_uk_eu) }
+  it { is_expected.to have_attribute(:financial_support).with_value(course.latest_published_enrichment.financial_support) }
+  it { is_expected.to have_attribute(:findable).with_value(course.findable?) }
+  it { is_expected.to have_attribute(:funding_type).with_value("apprenticeship") }
+  it { is_expected.to have_attribute(:gcse_subjects_required).with_value(%w{maths english science}) }
+  it { is_expected.to have_attribute(:has_early_career_payments).with_value(false) }
+  it { is_expected.to have_attribute(:financial_support).with_value(course.latest_published_enrichment.financial_support) }
+  it { is_expected.to have_attribute(:has_scholarship).with_value(course.has_scholarship?) }
+  it { is_expected.to have_attribute(:has_vacancies).with_value(course.has_vacancies?) }
+  it { is_expected.to have_attribute(:how_school_placements_work).with_value(course.latest_published_enrichment.how_school_placements_work) }
+  it { is_expected.to have_attribute(:interview_process).with_value(course.latest_published_enrichment.interview_process) }
+  it { is_expected.to have_attribute(:is_send).with_value(course.is_send?) }
+  it { is_expected.to have_attribute(:last_published_at).with_value(course.last_published_at.iso8601) }
+  it { is_expected.to have_attribute(:level).with_value(course.level) }
+  it { is_expected.to have_attribute(:name).with_value(course.name) }
+  it { is_expected.to have_attribute(:open_for_applications).with_value(course.open_for_applications?) }
+  it { is_expected.to have_attribute(:other_requirements).with_value(course.latest_published_enrichment.other_requirements) }
+  it { is_expected.to have_attribute(:personal_qualities).with_value(course.latest_published_enrichment.personal_qualities) }
+  it { is_expected.to have_attribute(:program_type).with_value(course.program_type) }
+  it { is_expected.to have_attribute(:provider_code).with_value(course.provider.provider_code) }
+  it { is_expected.to have_attribute(:qualifications).with_value(%w{qts pgce}) }
+  it { is_expected.to have_attribute(:recruitment_cycle_year).with_value("2020") }
+  it { is_expected.to have_attribute(:required_qualifications).with_value(course.latest_published_enrichment.required_qualifications) }
+  it { is_expected.to have_attribute(:required_qualifications_english).with_value("must_have_qualification_at_application_time") }
+  it { is_expected.to have_attribute(:required_qualifications_maths).with_value("must_have_qualification_at_application_time") }
+  it { is_expected.to have_attribute(:required_qualifications_science).with_value("must_have_qualification_at_application_time") }
+  it { is_expected.to have_attribute(:running).with_value(course.findable?) }
+  it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
+  it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
+
+  context "when scholarship amount is present" do
+    let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :geography)]) }
+
+    it { is_expected.to have_attribute(:scholarship_amount).with_value("17000") }
+  end
+
+  it { is_expected.to have_attribute(:start_date).with_value("September 2020") }
+  it { is_expected.to have_attribute(:state).with_value("published") }
+  it { is_expected.to have_attribute(:study_mode).with_value("full_time") }
+  it { is_expected.to have_attribute(:summary).with_value("PGCE with QTS full time teaching apprenticeship") }
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/Igxd218k/3737-mimplement-api-endpoint-api-v3-recruitmentcycles-year-providers-providercode-courses
- First step to implement public/v1 api for courses

### Changes proposed in this pull request

- Add `Course` serializer for public/v1 api
- Some additional code to support extra data compared to previous serializers

### Guidance to review

- Should map with the API docs

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
