### PR TITLE
[3748] - Document subject areas

### DIFF
--- a/app/controllers/api/public/v1/subject_areas_controller.rb
+++ b/app/controllers/api/public/v1/subject_areas_controller.rb
@@ -1,0 +1,33 @@
+module API
+  module Public
+    module V1
+      class SubjectAreasController < API::Public::V1::ApplicationController
+        def index
+          render json: {
+            data: [
+              {
+                id: "PrimarySubject",
+                type: "subject_areas",
+                attributes: {
+                  name: "Primary",
+                  typename: "PrimarySubject",
+                },
+              },
+              {
+                id: "SecondarySubject",
+                type: "subject_areas",
+                attributes: {
+                  name: "Secondary",
+                  typename: "SecondarySubject",
+                },
+              },
+            ],
+            jsonapi: {
+              version: "1.0",
+            },
+          }
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,7 @@ Rails.application.routes.draw do
         end
 
         get "provider_suggestions", to: "provider_suggestions#index"
+        resources :subject_areas, only: :index
       end
     end
   end

--- a/spec/api/subject_areas_spec.rb
+++ b/spec/api/subject_areas_spec.rb
@@ -1,0 +1,17 @@
+require "swagger_helper"
+
+describe "API" do
+  path "/subject_areas" do
+    get "Returns a list of subject areas used to organise subjects." do
+      operationId :public_api_v1_subject_areas
+      tags "subject_areas"
+      produces "application/json"
+
+      response "200", "The collection of subject areas." do
+        schema "$ref": "#/components/schemas/SubjectAreaListResponse"
+
+        run_test!
+      end
+    end
+  end
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1142,6 +1142,72 @@
           "description": "A comma delimited string of fields to sort the collection by."
         }
       },
+      "SubjectAreaAttributes": {
+        "description": "This schema is used to describe a subject area.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the subject area.",
+            "example": "Primary"
+          },
+          "typename": {
+            "type": "string",
+            "description": "A unique identifier for the subject area.",
+            "example": "PrimarySubject"
+          }
+        }
+      },
+      "SubjectAreaListResponse": {
+        "description": "This schema is used to return a collection of subject areas.",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectAreaResource"
+            }
+          },
+          "included": {
+            "$ref": "#/components/schemas/Included"
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
+      "SubjectAreaRelationships": {
+        "description": "This schema is used to describe associations that can be returned with a subject area.",
+        "type": "object",
+        "properties": {
+          "subjects": {
+            "$ref": "#/components/schemas/RelationshipList"
+          }
+        }
+      },
+      "SubjectAreaResource": {
+        "description": "This schema provides metadata about a subject area.",
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "PrimarySubject"
+          },
+          "type": {
+            "type": "string",
+            "example": "subject_areas"
+          },
+          "attributes": {
+            "$ref": "#/components/schemas/SubjectAreaAttributes"
+          },
+          "relationships": {
+            "$ref": "#/components/schemas/SubjectAreaRelationships"
+          }
+        }
+      },
       "SubjectAttributes": {
         "description": "This schema is used to describe a subject.",
         "type": "object",
@@ -1453,7 +1519,7 @@
             "explode": false,
             "required": false,
             "example": "name",
-            "description": "Field(s) to sort the provider by."
+            "description": "Field(s) to sort the providers by."
           },
           {
             "name": "page",
@@ -1521,6 +1587,27 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProviderSingleResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subject_areas": {
+      "get": {
+        "summary": "Returns a list of subject areas used to organise subjects.",
+        "operationId": "public_api_v1_subject_areas",
+        "tags": [
+          "subject_areas"
+        ],
+        "responses": {
+          "200": {
+            "description": "The collection of subject areas.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubjectAreaListResponse"
                 }
               }
             }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1519,7 +1519,7 @@
             "explode": false,
             "required": false,
             "example": "name",
-            "description": "Field(s) to sort the providers by."
+            "description": "Field(s) to sort the provider by."
           },
           {
             "name": "page",

--- a/swagger/public_v1/component_schemas/SubjectAreaAttributes.yml
+++ b/swagger/public_v1/component_schemas/SubjectAreaAttributes.yml
@@ -8,5 +8,5 @@ properties:
     example: "Primary"
   typename:
     type: string
-    description: "A unique identifier for the subject area."
+    description: "A type name for the subject area."
     example: "PrimarySubject"

--- a/swagger/public_v1/component_schemas/SubjectAreaAttributes.yml
+++ b/swagger/public_v1/component_schemas/SubjectAreaAttributes.yml
@@ -1,0 +1,12 @@
+---
+description: "This schema is used to describe a subject area."
+type: object
+properties:
+  name:
+    type: string
+    description: "The name of the subject area."
+    example: "Primary"
+  typename:
+    type: string
+    description: "A unique identifier for the subject area."
+    example: "PrimarySubject"

--- a/swagger/public_v1/component_schemas/SubjectAreaRelationships.yml
+++ b/swagger/public_v1/component_schemas/SubjectAreaRelationships.yml
@@ -1,0 +1,6 @@
+---
+description: "This schema is used to describe associations that can be returned with a subject area."
+type: object
+properties:
+  subjects:
+    $ref: "#/components/schemas/RelationshipList"

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -415,6 +415,7 @@ components:
       type: object
       required:
         - data
+        - jsonapi
       properties:
         data:
           type: array

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -387,7 +387,7 @@ components:
       required:
         - id
         - type
-        - attributes
+        - attributes      
       properties:
         id:
           type: integer
@@ -396,3 +396,31 @@ components:
           example: subjects
         attributes:
           $ref: "#/components/schemas/SubjectAttributes"
+    SubjectAreaResource:
+      description: "This schema provides metadata about a subject area."
+      type: object
+      properties:
+        id:
+          type: string
+          example: "PrimarySubject"
+        type:
+          type: string
+          example: "subject_areas"
+        attributes:
+          $ref: "#/components/schemas/SubjectAreaAttributes"
+        relationships:
+          $ref: "#/components/schemas/SubjectAreaRelationships"
+    SubjectAreaListResponse:
+      description: "This schema is used to return a collection of subject areas."
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/SubjectAreaResource"
+        included:
+          $ref: "#/components/schemas/Included"
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPI"

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -387,7 +387,7 @@ components:
       required:
         - id
         - type
-        - attributes      
+        - attributes
       properties:
         id:
           type: integer


### PR DESCRIPTION
### Context

- https://trello.com/c/QJAGE2SD/3748-document-api-endpoint-api-public-v1-subjectareas
- Document `/api/public/v1/subject_areas`

### Changes proposed in this pull request

- Document the subject areas endpoint in the new public api docs

### Guidance to review

- Run the middleman docs, see the new endpoint documentation for subject areas

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
