### PR TITLE
[3737] api provider courses endpoint

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -7,6 +7,15 @@ module API
         def jsonapi_404
           render jsonapi: nil, status: :not_found
         end
+
+      private
+
+        def fields_param
+          params.fetch(:fields, {})
+            .permit(:subject_areas, :subjects, :courses, :providers)
+            .to_h
+            .map { |k, v| [k, v.split(",").map(&:to_sym)] }
+        end
       end
     end
   end

--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -25,7 +25,7 @@ module API
         def show
           render json: {
             data: {
-              id: 123,
+              id: "123",
               type: "Course",
               attributes: {
                 code: "3GTY",

--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -1,0 +1,73 @@
+module API
+  module Public
+    module V1
+      module Providers
+        class CoursesController < API::Public::V1::ApplicationController
+          PERMITTED_INCLUSIONS = %w[provider].freeze
+          PERMITTED_SORTS = ["name", "-name"].freeze
+
+          def index
+            render jsonapi: paginate(courses),
+              fields: fields_param,
+              include: include_param,
+              class: API::Public::V1::SerializerService.new.execute
+          end
+
+          def show
+            render json: {
+              data: {
+                id: "123",
+                type: "Course",
+                attributes: {
+                  code: "3GTY",
+                  provider_code: "6CL",
+                  age_minimum: 11,
+                  age_maximum: 14,
+                },
+              },
+              jsonapi: {
+                version: "1.0",
+              },
+            }
+          end
+
+        private
+
+          def courses
+            return @courses if @courses
+
+            search_service = API::Public::V1::CourseSearchService.new(
+              base_scope: provider.courses,
+              filter: filter,
+              sort: sort_param,
+                                              )
+
+            @courses = search_service.call
+          end
+
+          def filter
+            @filter ||= params[:filter] || {}
+          end
+
+          def provider
+            @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
+          end
+
+          def recruitment_cycle
+            @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
+          end
+
+          def include_param
+            (params.fetch(:include, "")
+              .split(",") & PERMITTED_INCLUSIONS)
+              .join(",")
+          end
+
+          def sort_param
+            @sort_param ||= Set.new(params.dig(:sort)&.split(",")) & PERMITTED_SORTS
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -12,6 +12,8 @@ module API
 
         type "courses"
 
+        belongs_to :provider
+
         attributes :accredited_body_code,
                    :age_maximum,
                    :age_minimum,

--- a/app/serializers/api/public/v1/serializer_service.rb
+++ b/app/serializers/api/public/v1/serializer_service.rb
@@ -1,0 +1,14 @@
+module API
+  module Public
+    module V1
+      class SerializerService
+        def execute
+          {
+            Course: API::Public::V1::SerializableCourse,
+            Provider: API::Public::V1::SerializableProvider,
+          }
+        end
+      end
+    end
+  end
+end

--- a/app/services/api/public/v1/course_search_service.rb
+++ b/app/services/api/public/v1/course_search_service.rb
@@ -1,0 +1,79 @@
+module API
+  module Public
+    module V1
+      class CourseSearchService
+        attr_reader :base_scope, :filter, :sort
+
+        def initialize(base_scope:, filter:, sort:)
+          @base_scope = base_scope
+          @filter = filter
+          @sort = sort
+        end
+
+        def call
+          scope = base_scope
+          scope = scope.with_vacancies if has_vacancies?
+          scope = scope.with_funding_types(funding) if funding.any?
+          scope = scope.with_study_modes(study_types) if study_types.any?
+          scope = scope.with_qualifications(qualifications) if qualifications.any?
+          scope = scope.with_subjects(subjects) if subjects.any?
+          scope = scope.with_send if send_courses?
+          scope = scope.order(order)
+          scope
+        end
+
+      private
+
+        def order
+          if sort.empty?
+            default_order
+          else
+            order_string
+          end
+        end
+
+        def order_string
+          sort.map { |string|
+            string.starts_with?("-") ? "#{string[1..-1]} DESC" : "#{string} ASC"
+          }.join(",")
+        end
+
+        def default_order
+          "name"
+        end
+
+        def has_vacancies?
+          filter[:has_vacancies].to_s.downcase == "true"
+        end
+
+        def funding
+          return [] if filter[:funding].blank?
+
+          filter[:funding].split(",")
+        end
+
+        def qualifications
+          return [] if filter[:qualification].blank?
+
+          filter[:qualification].split(",")
+        end
+
+        def study_types
+          return [] if filter[:study_type].blank?
+
+          filter[:study_type].split(",")
+        end
+
+        def subjects
+          return [] if filter[:subjects].blank?
+
+          filter[:subjects].split(",")
+        end
+
+        def send_courses?
+          filter[:send_courses].to_s.downcase == "true"
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,8 +102,10 @@ Rails.application.routes.draw do
     namespace :public do
       namespace :v1 do
         resources :recruitment_cycles, param: :year, only: [:show] do
+          resources :courses, only: %i[index]
+
           resources :providers, only: %i[index show], param: :code do
-            resources :courses, only: %i[index show] do
+            resources :courses, only: %i[index show], module: :providers do
               resources :locations, only: [:index]
             end
           end

--- a/spec/api/courses_spec.rb
+++ b/spec/api/courses_spec.rb
@@ -47,8 +47,13 @@ describe "API" do
                 description: "Pagination options to navigate through the collection."
 
       response "200", "The collection of courses." do
-        let(:year) { "2020" }
-        let(:provider_code) { "ABC" }
+        let(:provider) { create(:provider) }
+        let(:year) { provider.recruitment_cycle.year }
+        let(:provider_code) { provider.provider_code }
+
+        before do
+          2.times { create(:course, provider: provider) }
+        end
 
         schema "$ref": "#/components/schemas/CourseListResponse"
 

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -1,0 +1,287 @@
+require "rails_helper"
+
+RSpec.describe API::Public::V1::Providers::CoursesController do
+  let(:provider) { create(:provider) }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+
+  describe "#index" do
+    context "when there are no courses" do
+      it "returns empty array of data" do
+        get :index, params: {
+          recruitment_cycle_year: recruitment_cycle.year,
+          provider_code: provider.provider_code,
+        }
+        expect(JSON.parse(response.body)["data"]).to eql([])
+      end
+    end
+
+    context "when there are courses" do
+      before do
+        create(:course, provider: provider)
+        create(:course, provider: provider)
+      end
+
+      it "returns correct number of courses" do
+        get :index, params: { recruitment_cycle_year: "2020", provider_code: provider.provider_code }
+        expect(JSON.parse(response.body)["data"].size).to eql(2)
+      end
+    end
+
+    describe "pagination" do
+      let(:courses) do
+        array = []
+
+        7.times { |n| array << build(:course, id: n + 1) }
+
+        array
+      end
+
+      before do
+        allow(controller).to receive(:courses).and_return(courses)
+      end
+
+      it "can pagingate to page 2" do
+        get :index, params: {
+          recruitment_cycle_year: "2020",
+          provider_code: "ABC",
+          page: {
+            page: 2,
+            per_page: 5,
+          },
+        }
+
+        expect(JSON.parse(response.body)["data"].size).to eql(2)
+      end
+    end
+
+    describe "sort" do
+      before do
+        create(:course, provider: provider, name: "french")
+        create(:course, provider: provider, name: "spanish")
+        create(:course, provider: provider, name: "computing")
+      end
+
+      it "returns courses in default name order" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+        }
+
+        expected_names = %w[computing french spanish]
+        actual_names = JSON.parse(response.body)["data"].map { |datum| datum["attributes"]["name"] }
+        expect(actual_names).to eql(expected_names)
+      end
+
+      it "returns courses in name order" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          sort: "name",
+        }
+
+        expected_names = %w[computing french spanish]
+        actual_names = JSON.parse(response.body)["data"].map { |datum| datum["attributes"]["name"] }
+        expect(actual_names).to eql(expected_names)
+      end
+
+      it "returns courses in reverse name order" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          sort: "-name",
+        }
+
+        expected_names = %w[spanish french computing]
+        actual_names = JSON.parse(response.body)["data"].map { |datum| datum["attributes"]["name"] }
+        expect(actual_names).to eql(expected_names)
+      end
+
+      it "ignores unpermitted sorts" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          sort: "foo",
+        }
+
+        expected_names = %w[computing french spanish]
+        actual_names = JSON.parse(response.body)["data"].map { |datum| datum["attributes"]["name"] }
+        expect(actual_names).to eql(expected_names)
+      end
+    end
+
+    describe "field" do
+      let!(:attributes) { API::Public::V1::SerializableCourse.new(object: course).as_jsonapi[:attributes] }
+      let!(:course) { create(:course, provider: provider, name: "german") }
+
+      it "returns all fields when none are specified" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+        }
+
+        expect(JSON.parse(response.body)["data"][0]["attributes"].count).to eql(attributes.size)
+      end
+
+      it "returns course name as the only field" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          fields: { courses: "name,code" },
+        }
+
+        expect(JSON.parse(response.body)["data"][0]["attributes"].keys).to eql(%w[name code])
+      end
+    end
+
+    describe "include" do
+      before do
+        create(:course, provider: provider)
+      end
+
+      it "returns the provider connected to the course" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          include: "provider",
+        }
+
+        expect(JSON.parse(response.body)["data"][0]["relationships"].keys).to eql(%w[provider])
+        expect(JSON.parse(response.body)["included"][0]["id"]).to eql(provider.id.to_s)
+        expect(JSON.parse(response.body)["included"][0]["type"]).to eql("providers")
+      end
+
+      it "doesn't include subjects as they aren't permitted" do
+        get :index, params: {
+          recruitment_cycle_year: provider.recruitment_cycle.year,
+          provider_code: provider.provider_code,
+          include: "subjects",
+        }
+
+        expect(JSON.parse(response.body)["data"][0]["relationships"]).to eql("provider" => { "meta" => { "included" => false } })
+      end
+    end
+
+    describe "filtering" do
+      context "when has_vacancies is true" do
+        before do
+          course1 = create(:course, provider: provider)
+          course2 = create(:course, provider: provider)
+
+          create(:site_status, :with_any_vacancy, course: course1)
+          create(:site_status, :with_no_vacancies, course: course2)
+        end
+
+        it "returns courses that only have vacancies" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              has_vacancies: true,
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(1)
+        end
+      end
+
+      context "funding given" do
+        before do
+          create(:course, :with_salary, provider: provider)
+          create(:course, :with_apprenticeship, provider: provider)
+          create(:course, :fee_type_based, provider: provider)
+        end
+
+        it "returns courses with specified funding" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              funding: "salary,fee",
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(2)
+        end
+      end
+
+      context "qualification given" do
+        before do
+          create(:course, :resulting_in_qts, provider: provider)
+          create(:course, :resulting_in_pgce_with_qts, provider: provider)
+          create(:course, :resulting_in_pgde, provider: provider)
+        end
+
+        it "returns courses with specified qualifications" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              qualification: "qts,pgce_with_qts",
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(2)
+        end
+      end
+
+      context "study_type given" do
+        before do
+          create(:course, :full_time_or_part_time, provider: provider)
+          create(:course, :full_time, provider: provider)
+          create(:course, :part_time, provider: provider)
+        end
+
+        it "returns courses with specified study type" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              study_type: "full_time",
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(2)
+        end
+      end
+
+      context "subjects given" do
+        before do
+          create(:course, :primary, provider: provider)
+          create(:course, :secondary, provider: provider)
+          create(:course, :further_education, provider: provider)
+        end
+
+        it "returns courses with specified subjects" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              subjects: "00,F0",
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(2)
+        end
+      end
+
+      context "send_courses given" do
+        before do
+          create(:course, provider: provider)
+          create(:course, :send, provider: provider)
+        end
+
+        it "returns courses with send specialism" do
+          get :index, params: {
+            recruitment_cycle_year: provider.recruitment_cycle.year,
+            provider_code: provider.provider_code,
+            filter: {
+              send_courses: true,
+            },
+          }
+
+          expect(JSON.parse(response.body)["data"].size).to eql(1)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,6 +22,22 @@ FactoryBot.define do
       )
     }
 
+    trait :send do
+      is_send { true }
+    end
+
+    trait :full_time do
+      study_mode { :full_time }
+    end
+
+    trait :part_time do
+      study_mode { :part_time }
+    end
+
+    trait :full_time_or_part_time do
+      study_mode { :full_time_or_part_time }
+    end
+
     trait :without_validation do
       to_create { |instance| instance.save(validate: false) }
     end
@@ -34,6 +50,10 @@ FactoryBot.define do
     trait :secondary do
       age_range_in_years { "11_to_18" }
       level { :secondary }
+    end
+
+    trait :further_education do
+      level { :further_education }
     end
 
     transient do

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -37,12 +37,14 @@
         "properties": {
           "about_accredited_body": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Description of the accredited body for this course.",
             "example": "UCL Institute of Education is the world’s leading centre for research and teaching in education and related social sciences."
           },
           "about_course": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Short factual summary of the course.",
             "example": "The Secondary PGCE consists of three core modules: two Master's-level modules, which are assessed through written assignments, and the Professional Practice module, which is assessed by the observation of practical teaching in placement schools."
@@ -73,13 +75,17 @@
           },
           "bursary_amount": {
             "type": "integer",
+            "nullable": true,
             "description": "Bursary amount in GBP for this course.",
             "example": 9000
           },
           "bursary_requirements": {
-            "type": "string",
+            "type": "array",
             "description": "Description of requirements to be eligible for a bursary.",
-            "example": "a degree of 2:2 or above in any subject"
+            "items": {
+              "type": "string",
+              "example": "a degree of 2:2 or above in any subject"
+            }
           },
           "changed_at": {
             "type": "string",
@@ -96,6 +102,7 @@
           },
           "course_length": {
             "type": "string",
+            "nullable": true,
             "description": "Text describing how long the course runs.",
             "example": "OneYear"
           },
@@ -107,22 +114,26 @@
           },
           "fee_details": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Further details about the fees for this course, if applicable.",
             "example": "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable."
           },
           "fee_international": {
             "type": "integer",
+            "nullable": true,
             "description": "Fee in GBP for international students (optional).",
             "example": 13000
           },
           "fee_domestic": {
             "type": "integer",
+            "nullable": true,
             "description": "Fee in GBP for UK and EU students.",
             "example": 9200
           },
           "financial_support": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Details about financial support offered, if any.",
             "example": "You'll get a bursary of £9,000 if you have a degree of 2:2 or above in any subject. You may also be eligible for a loan while you study."
@@ -143,7 +154,7 @@
             ]
           },
           "gcse_subjects_required": {
-            "type": "string",
+            "type": "array",
             "example": [
               "maths",
               "english"
@@ -162,7 +173,11 @@
                 "science"
               ]
             ],
-            "description": "GSCEs, or equivalent, required for this level of course."
+            "description": "GSCEs, or equivalent, required for this level of course.",
+            "items": {
+              "type": "string",
+              "example": "maths"
+            }
           },
           "has_bursary": {
             "type": "boolean",
@@ -186,12 +201,14 @@
           },
           "how_school_placements_work": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Additional information about the schools applicants will be teaching in.",
             "example": "You will spend two-thirds of your time (120 days) in schools, working with art and design mentors who support you through your two school placements."
           },
           "interview_process": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Additional information about how the interview process will work for applicants.",
             "example": "At your interview day you will take part in a combination of group and individual interviews with members of the programme team, and you may also be asked to undertake written or presentation tasks, depending on your subject."
@@ -203,6 +220,7 @@
           },
           "last_published_at": {
             "type": "string",
+            "nullable": true,
             "format": "date-time",
             "description": "Timestamp of when changes to this course's additional information sections were last published.",
             "example": "2019-06-13T10:44:31Z"
@@ -229,12 +247,14 @@
           },
           "other_requirements": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Any non-academic qualifications or documents the applicant may need.",
             "example": "You'll need to provide confirmation you have the health and physical capacity to commence training, and a Disclosure and Barring Service (DBS) certificate."
           },
           "personal_qualities": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "Any skills, motivation and experience the provider is looking for in applicants.",
             "example": "We are looking for applicants who have the potential to become outstanding teachers, and who are able to work independently on their studies while training in a school context."
@@ -259,7 +279,7 @@
             "example": "6CL"
           },
           "qualifications": {
-            "type": "string",
+            "type": "array",
             "description": "The qualifications as an outcome of the course.",
             "example": [
               "qts"
@@ -282,7 +302,11 @@
                 "qts",
                 "pgde"
               ]
-            ]
+            ],
+            "items": {
+              "type": "string",
+              "example": "qts"
+            }
           },
           "recruitment_cycle_year": {
             "type": "string",
@@ -291,6 +315,7 @@
           },
           "required_qualifications": {
             "type": "string",
+            "nullable": true,
             "format": "markdown",
             "description": "The minimum academic qualifications needed for this course.",
             "example": "A first or second-class UK Bachelor's degree in an appropriate subject, or an overseas qualification of an equivalent standard from a recognised higher education institution."
@@ -338,11 +363,13 @@
           },
           "salary_details": {
             "type": "string",
+            "nullable": true,
             "description": "Salary details about this course.",
             "example": "Successful applicants will be employed as unqualified teachers on at least Point 1 of the Unqualified Teachers' Pay Scale for the duration of the programme."
           },
           "scholarship_amount": {
             "type": "integer",
+            "nullable": true,
             "description": "The scholarship amount a candidate may be eligible for for this course.",
             "example": 17000
           },
@@ -437,7 +464,7 @@
         ],
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "string"
           },
           "type": {
             "type": "string",
@@ -481,9 +508,9 @@
             "example": true
           },
           "funding": {
-            "description": "Return courses that are salary funded.",
+            "description": "Return courses depending on how it is funded. This is a comma delimited string. If multiple funding options are provided then any course matching any one of the options provided will be retuned, i.e. the OR operator is used.",
             "type": "string",
-            "example": "salary",
+            "example": "salary,fee",
             "enum": [
               "salary",
               "apprenticeship",
@@ -491,8 +518,8 @@
             ]
           },
           "qualification": {
-            "description": "Search courses based on the award given on course completion.",
-            "type": "array",
+            "description": "Search courses based on the award given on course completion. This is a comma delimited string. If multiple qualifications are given then any course matching any one of the qualifications provided will be returned, i.e. the OR operator is used.",
+            "type": "string",
             "example": "qts,pgce,pgde",
             "enum": [
               "qts",
@@ -500,29 +527,21 @@
               "pgde",
               "pgce",
               "pgde_with_qts"
-            ],
-            "items": {
-              "type": "string",
-              "example": "qts"
-            }
+            ]
           },
           "study_type": {
-            "description": "Search full time or part time courses or both.",
-            "type": "array",
+            "description": "Search full time or part time courses or both. This is a comma delimited string. If both full_time and part_time is specified we return courses that are either full time or part time.",
+            "type": "string",
             "example": "full_time,part_time",
             "enum": [
               "full_time",
               "part_time",
               "full_time_or_part_time"
-            ],
-            "items": {
-              "type": "string",
-              "example": "full_time"
-            }
+            ]
           },
           "subjects": {
-            "description": "Returns courses that include at least one of the given subjects.",
-            "type": "array",
+            "description": "Returns courses that include at least one of the given subjects. This is a comma delimied string. If multiple subjects are given a course that has any one of the subjects specified will be returned, i.e. the OR operator is used.",
+            "type": "string",
             "example": "00,01,W1",
             "enum": [
               "00",
@@ -567,11 +586,7 @@
               "22",
               "41",
               "24"
-            ],
-            "items": {
-              "type": "string",
-              "example": "W1"
-            }
+            ]
           },
           "send_courses": {
             "description": "Only return courses that have a SEND specialism.",

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -9,6 +9,7 @@ required:
 properties:
   about_accredited_body:
     type: string
+    nullable: true
     format: markdown
     description: Description of the accredited body for this course.
     example: >-
@@ -16,6 +17,7 @@ properties:
       research and teaching in education and related social sciences.
   about_course:
     type: string
+    nullable: true
     format: markdown
     description: Short factual summary of the course.
     example: >-
@@ -51,12 +53,15 @@ properties:
     example: "2019-10-08"
   bursary_amount:
     type: integer
+    nullable: true
     description: "Bursary amount in GBP for this course."
     example: 9000
   bursary_requirements:
-    type: string
+    type: array
     description: "Description of requirements to be eligible for a bursary."
-    example: "a degree of 2:2 or above in any subject"
+    items:
+      type: string
+      example: "a degree of 2:2 or above in any subject"
   changed_at:
     type: string
     format: date-time
@@ -72,6 +77,7 @@ properties:
     example: 3GTY
   course_length:
     type: string
+    nullable: true
     description: >-
       Text describing how long the course runs.
     example: "OneYear"
@@ -82,19 +88,23 @@ properties:
     example: "2019-06-13T10:44:31Z"
   fee_details:
     type: string
+    nullable: true
     format: markdown
     description: "Further details about the fees for this course, if applicable."
     example: "For those wishing to top up their qualification to the full PGCE, a further £1800 will be payable."
   fee_international:
     type: integer
+    nullable: true
     description: "Fee in GBP for international students (optional)."
     example: 13000
   fee_domestic:
     type: integer
+    nullable: true
     description: "Fee in GBP for UK and EU students."
     example: 9200
   financial_support:
     type: string
+    nullable: true
     format: markdown
     description: "Details about financial support offered, if any."
     example: >-
@@ -116,7 +126,7 @@ properties:
       - apprenticeship
       - fee
   gcse_subjects_required:
-    type: string
+    type: array
     example: [maths, english]
     enum:
       - []
@@ -124,6 +134,9 @@ properties:
       - [maths, english, science]
     description: >-
       GSCEs, or equivalent, required for this level of course.
+    items:
+      type: string
+      example: "maths"
   has_bursary:
     type: boolean
     description: "Are any bursaries available for this course?"
@@ -142,6 +155,7 @@ properties:
     example: true
   how_school_placements_work:
     type: string
+    nullable: true
     format: markdown
     description: >-
       Additional information about the schools applicants will be teaching in.
@@ -151,6 +165,7 @@ properties:
       two school placements.
   interview_process:
     type: string
+    nullable: true
     format: markdown
     description: >-
       Additional information about how the interview process will work for applicants.
@@ -165,6 +180,7 @@ properties:
     example: true
   last_published_at:
     type: string
+    nullable: true
     format: date-time
     description: >-
       Timestamp of when changes to this course's additional information
@@ -189,6 +205,7 @@ properties:
     example: true
   other_requirements:
     type: string
+    nullable: true
     format: markdown
     description: >-
       Any non-academic qualifications or documents the applicant may need.
@@ -198,6 +215,7 @@ properties:
       Barring Service (DBS) certificate.
   personal_qualities:
     type: string
+    nullable: true
     format: markdown
     description: >-
       Any skills, motivation and experience the provider is looking for in applicants.
@@ -223,7 +241,7 @@ properties:
     minLength: 3
     example: 6CL
   qualifications:
-    type: string
+    type: array
     description: >-
       The qualifications as an outcome of the course.
     example: [qts]
@@ -233,12 +251,16 @@ properties:
       - [pgde]
       - [qts, pgce]
       - [qts, pgde]
+    items:
+      type: string
+      example: "qts"
   recruitment_cycle_year:
     type: string
     description: The recruitment cycle that this course is available in.
     example: 2020
   required_qualifications:
     type: string
+    nullable: true
     format: markdown
     description: >-
       The minimum academic qualifications needed for this course.
@@ -282,6 +304,7 @@ properties:
     example: true
   salary_details:
     type: string
+    nullable: true
     description: "Salary details about this course."
     example: >-
       Successful applicants will be employed as unqualified teachers on
@@ -289,6 +312,7 @@ properties:
       duration of the programme.
   scholarship_amount:
     type: integer
+    nullable: true
     description: >-
       The scholarship amount a candidate may be eligible for for this course.
     example: 17000

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -35,16 +35,16 @@ components:
           type: boolean
           example: true
         funding:
-          description: "Return courses that are salary funded."
+          description: "Return courses depending on how it is funded. This is a comma delimited string. If multiple funding options are provided then any course matching any one of the options provided will be retuned, i.e. the OR operator is used."
           type: string
-          example: "salary"
+          example: "salary,fee"
           enum:
             - salary
             - apprenticeship
             - fee
         qualification:
-          description: "Search courses based on the award given on course completion."
-          type: array
+          description: "Search courses based on the award given on course completion. This is a comma delimited string. If multiple qualifications are given then any course matching any one of the qualifications provided will be returned, i.e. the OR operator is used."
+          type: string
           example: "qts,pgce,pgde"
           enum:
             - qts
@@ -52,23 +52,17 @@ components:
             - pgde
             - pgce
             - pgde_with_qts
-          items:
-            type: string
-            example: "qts"
         study_type:
-          description: "Search full time or part time courses or both."
-          type: array
+          description: "Search full time or part time courses or both. This is a comma delimited string. If both full_time and part_time is specified we return courses that are either full time or part time."
+          type: string
           example: "full_time,part_time"
           enum:
             - full_time
             - part_time
             - full_time_or_part_time
-          items:
-            type: string
-            example: "full_time"
         subjects:
-          description: "Returns courses that include at least one of the given subjects."
-          type: array
+          description: "Returns courses that include at least one of the given subjects. This is a comma delimied string. If multiple subjects are given a course that has any one of the subjects specified will be returned, i.e. the OR operator is used."
+          type: string
           example: "00,01,W1"
           enum:
             - "00"
@@ -113,9 +107,6 @@ components:
             - "22"
             - "41"
             - "24"
-          items:
-            type: string
-            example: "W1"
         send_courses:
           description: "Only return courses that have a SEND specialism."
           type: boolean
@@ -141,7 +132,7 @@ components:
         - attributes
       properties:
         id:
-          type: integer
+          type: string
         type:
           type: string
           example: "courses"


### PR DESCRIPTION
### Context

- https://trello.com/c/Igxd218k/3737-m-implement-api-endpoint-api-v3-recruitmentcycles-year-providers-providercode-courses
- This implements the provider courses public/v1 api
- This does not include sorting by distance which will be done in another PR

### Changes proposed in this pull request

* Add provider/course endpoint
* Add v1/public course search service
* Update v1/public documentation

### Guidance to review

- Test coverage has dropped substantially as app/controllers/api/public/v1/courses_controller.rb is not tested as it mostly contains dummy data which will be implemented and tested at a later stage
- For a given provider hit the endpoint
- Should return their courses
- Should be able to sort
- Should be able to filter

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
