### PR TITLE
[3737] Change CourseSearchService base scope

### DIFF
--- a/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
+++ b/app/controllers/api/v2/accredited_provider_training_providers_controller.rb
@@ -28,7 +28,7 @@ module API
           provider_courses = Course.where(provider: [provider.id])
           training_provider_courses = Course.where(provider: training_providers).where(accredited_body_code: provider.provider_code)
 
-          provider_courses.or(training_provider_courses)
+          provider_courses.or(training_provider_courses).findable
         end
 
         def eligible_training_provider_ids

--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -40,9 +40,9 @@ module API
 
       def build_courses
         @courses = if @provider.present?
-                     @provider.courses.includes(:provider)
+                     @provider.courses.includes(:provider).findable
                    else
-                     @recruitment_cycle.courses.includes(:provider)
+                     @recruitment_cycle.courses.includes(:provider).findable
                    end
       end
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -12,7 +12,7 @@ class CourseSearchService
   end
 
   def call
-    scope = course_scope.findable
+    scope = course_scope
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.with_vacancies if has_vacancies?


### PR DESCRIPTION
### Context

- https://trello.com/c/Igxd218k/3737-m-implement-api-endpoint-api-v3-recruitmentcycles-year-providers-providercode-courses
- The CourseSearchService is currently constrained to `findable` courses only
- We want to open up this constraint so the class can also be used to search for non-findable courses too
- This will be required for the public api

### Changes proposed in this pull request

- This allows for greater flexbility and does not limit the class to
only return findable courses
- The onus is on the caller to pass correct base scope
- This means this class can now be used to search non-findable courses
too

### Guidance to review

- v3 api should remain the same. therefore find search functionality should remain the same
- should be able to call CourseSearchService class with a base scope and should return non findable courses too

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
