### PR TITLE
Override original swaggerize rake task

### DIFF
--- a/lib/tasks/swaggerize.rake
+++ b/lib/tasks/swaggerize.rake
@@ -1,0 +1,14 @@
+require "rspec/core/rake_task"
+
+Rake::Task["rswag:specs:swaggerize"].clear
+
+namespace :rswag do
+  namespace :specs do
+    desc "Generate Swagger JSON files from integration specs"
+    RSpec::Core::RakeTask.new("swaggerize") do |t|
+      t.pattern = "spec/docs/**/*_spec.rb"
+
+      t.rspec_opts = ["--format OpenApi::Rswag::Specs::SwaggerFormatter", "--dry-run", "--order defined"]
+    end
+  end
+end


### PR DESCRIPTION

### Context

- Fix the rake task `rswag:specs:swaggerize`

### Changes proposed in this pull request

- This fixes the rake task rswag:specs:swaggerize
- We have now move our rswag tests to a non-supported location of
api/docs
- To acheive this we have to override the original rake task

### Guidance to review

- Run the rake task `rswag:specs:swaggerize`
- Open api spec should be generated correctly without the endpoints missing

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
