### PR TITLE
[3788] Move GOV.UK Notify template id out of azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 If you are going to login with a user who hasn't recieved the welcome email - you will need to set the following settings to their correct values in `config/settings/development.local.yml`:
 
 - `govuk_notify.api_key`
-- `govuk_notify.welcome_email_template_id`
 
 ### Native
 

--- a/azure/template.json
+++ b/azure/template.json
@@ -510,34 +510,6 @@
                 "value": "[parameters('settingsAuthenticationSecret')]"
               },
               {
-                "name": "SETTINGS__GOVUK_NOTIFY__API_KEY",
-                "value": "[parameters('govukNotifyApiKey')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__WELCOME_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyWelcomeEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_UPDATE_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseUpdateEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_VACANCIES_FILLED_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseVacanciesFilledEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_PUBLISH_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCoursePublishEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_WITHDRAW_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__MAGIC_LINK_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyMagicLinkEmailTemplateId')]"
-              },
-              {
                 "name": "SETTINGS__SYSTEM_AUTHENTICATION_TOKEN",
                 "value": "[parameters('mcbeSystemAuthenticationToken')]"
               },
@@ -1007,30 +979,6 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__API_KEY",
                 "value": "[parameters('govukNotifyApiKey')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__WELCOME_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyWelcomeEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_UPDATE_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseUpdateEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_PUBLISH_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCoursePublishEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_WITHDRAW_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseWithdrawEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__COURSE_VACANCIES_FILLED_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyCourseVacanciesFilledEmailTemplateId')]"
-              },
-              {
-                "name": "SETTINGS__GOVUK_NOTIFY__MAGIC_LINK_EMAIL_TEMPLATE_ID",
-                "value": "[parameters('govukNotifyMagicLinkEmailTemplateId')]"
               }
             ]
           },

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,12 +7,12 @@ current_recruitment_cycle_year: 2020
 allocation_cycle_year: 2020
 govuk_notify:
   api_key: please_change_me
-  welcome_email_template_id: please_change_me
-  course_update_email_template_id: please_change_me
-  course_publish_email_template_id: please_change_me
-  magic_link_email_template_id: please_change_me
-  course_withdraw_email_template_id: please_change_me
-  course_vacancies_filled_email_template_id: please_change_me
+  welcome_email_template_id: 42a9723d-b5a1-413a-89e6-bbdd073373ab
+  course_update_email_template_id: ebd252cf-21b2-48b6-b00c-ab6493189001
+  course_publish_email_template_id: c4944115-6e73-4b30-9bc2-bf784c0e9aaa
+  magic_link_email_template_id: 26a4c7f2-3caa-4770-8b2e-d7baf6342dd1
+  course_withdraw_email_template_id: f7fee829-f0e7-40d1-9bd7-299f673e8c24
+  course_vacancies_filled_email_template_id: 0a6058b7-62d1-41e7-a5a9-f4a13ef86cbe
   course_sites_update_email_template_id: d5c8da46-9aa6-4c0a-8fad-ee782e89dbd3
   course_subjects_updated_email_template_id: b65aef1a-5847-44e6-90e0-88e0ea7898ec
   course_vacancies_updated_email_template_id: 3ae884e9-8495-44cf-9928-907b89a9f356


### PR DESCRIPTION
-https://trello.com/c/sZ4woLkJ/3788-remove-govuk-notify-template-ids-into-repository-settings 


There is no reason for us to hide our template ID and use Azure to set
them. We can leave them in our source code so long as we still key the
api key secure then a potential attacker will not be able to use that
template.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
