### PR TITLE
[3790] api courses endpoint include

### DIFF
--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -5,6 +5,7 @@ module API
         class CoursesController < API::Public::V1::ApplicationController
           def index
             render jsonapi: paginate(courses),
+              include: include_param,
               class: API::Public::V1::SerializerService.new.call
           end
 
@@ -38,6 +39,10 @@ module API
 
           def recruitment_cycle
             @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
+          end
+
+          def include_param
+            params.fetch(:include, "")
           end
         end
       end

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -12,6 +12,13 @@ module API
 
         type "courses"
 
+        belongs_to :accredited_body do
+          data { @object.accrediting_provider }
+        end
+
+        belongs_to :provider
+        belongs_to :recruitment_cycle
+
         attributes :accredited_body_code,
                    :age_maximum,
                    :age_minimum,


### PR DESCRIPTION
### Context
https://trello.com/c/iIyuBytF/3790-add-inclusion-to-public-api-courses-endpoints

### Changes proposed in this pull request
* Add belongs_to relationships for course endpoint for accredited bodies, providers, and recruitment cycles

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
