### PR TITLE
[3778] Implement inclusion options in locations endpoint

### DIFF
--- a/app/controllers/api/public/v1/providers/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/locations_controller.rb
@@ -3,8 +3,13 @@ module API
     module V1
       module Providers
         class LocationsController < API::Public::V1::ApplicationController
+          PERMITTED_INCLUSIONS = %w[recruitment_cycle provider course].freeze
+
           def index
-            render jsonapi: locations, class: API::Public::V1::SerializerService.call
+            render jsonapi: locations,
+                   include: include_param,
+                   expose: { course: course },
+                   class: API::Public::V1::SerializerService.call
           end
 
         private
@@ -23,6 +28,12 @@ module API
 
           def recruitment_cycle
             @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
+          end
+
+          def include_param
+            (params.fetch(:include, "")
+              .split(",") & PERMITTED_INCLUSIONS)
+              .join(",")
           end
         end
       end

--- a/app/controllers/api/public/v1/providers/locations_controller.rb
+++ b/app/controllers/api/public/v1/providers/locations_controller.rb
@@ -3,8 +3,6 @@ module API
     module V1
       module Providers
         class LocationsController < API::Public::V1::ApplicationController
-          PERMITTED_INCLUSIONS = %w[recruitment_cycle provider course].freeze
-
           def index
             render jsonapi: locations,
                    include: include_param,
@@ -31,9 +29,7 @@ module API
           end
 
           def include_param
-            (params.fetch(:include, "")
-              .split(",") & PERMITTED_INCLUSIONS)
-              .join(",")
+            params.fetch(:include, "")
           end
         end
       end

--- a/app/serializers/api/public/v1/serializable_location.rb
+++ b/app/serializers/api/public/v1/serializable_location.rb
@@ -4,6 +4,13 @@ module API
       class SerializableLocation < JSONAPI::Serializable::Resource
         type "locations"
 
+        belongs_to :recruitment_cycle
+        belongs_to :provider
+
+        belongs_to :course do
+          data { @course }
+        end
+
         attributes :code,
                    :latitude,
                    :location_name,

--- a/app/serializers/api/public/v1/serializable_recruitment_cycle.rb
+++ b/app/serializers/api/public/v1/serializable_recruitment_cycle.rb
@@ -1,0 +1,11 @@
+module API
+  module Public
+    module V1
+      class SerializableRecruitmentCycle < JSONAPI::Serializable::Resource
+        type "recruitment_cycles"
+
+        attributes :year, :application_start_date, :application_end_date
+      end
+    end
+  end
+end

--- a/app/serializers/api/public/v1/serializer_service.rb
+++ b/app/serializers/api/public/v1/serializer_service.rb
@@ -10,6 +10,7 @@ module API
           {
             Course: API::Public::V1::SerializableCourse,
             Provider: API::Public::V1::SerializableProvider,
+            RecruitmentCycle: API::Public::V1::SerializableRecruitmentCycle,
             Site: API::Public::V1::SerializableLocation,
           }
         end

--- a/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/locations_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe API::Public::V1::Providers::LocationsController do
           course_id = json_response["included"][2]["id"].to_i
 
           expect(json_response["data"][0]["relationships"].keys).to eq(
-            API::Public::V1::Providers::LocationsController::PERMITTED_INCLUSIONS,
+            %w[recruitment_cycle provider course],
           )
 
           expect(recruitment_cycle_id).to eq(provider.recruitment_cycle.id)

--- a/spec/docs/locations_spec.rb
+++ b/spec/docs/locations_spec.rb
@@ -39,6 +39,7 @@ describe "API" do
         let(:year) { "2020" }
         let(:provider_code) { provider.provider_code }
         let(:course_code) { course.course_code }
+        let(:include) { "provider" }
 
         schema "$ref": "#/components/schemas/LocationListResponse"
 

--- a/spec/docs/locations_spec.rb
+++ b/spec/docs/locations_spec.rb
@@ -23,6 +23,15 @@ describe "API" do
                 type: :string,
                 description: "The code of the course.",
                 example: "X130"
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: {
+                  enum: %w[recruitment_cycle provider course],
+                },
+                example: "recruitment_cycle,provider"
 
       response "200", "The collection of locations for the specified course." do
         let(:course) { create(:course) }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ end
 RSpec.configure do |config|
   # add `FactoryBot` methods
   config.include FactoryBot::Syntax::Methods
+  config.include RequestHelper, type: :controller
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do

--- a/spec/serializers/api/public/v1/serializable_location_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_location_spec.rb
@@ -12,6 +12,8 @@ describe API::Public::V1::SerializableLocation do
 
   it { should have_type "locations" }
 
+  it { should have_relationships(:course, :provider, :recruitment_cycle) }
+
   it { should have_attribute(:street_address_1).with_value(location.address1) }
   it { should have_attribute(:street_address_2).with_value(location.address2) }
   it { should have_attribute(:city).with_value(location.address3) }

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,5 @@
+module RequestHelper
+  def json_response
+    @json_response ||= JSON.parse(response.body)
+  end
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -650,7 +650,7 @@
           },
           "street_address_2": {
             "type": "string",
-            "description": "Building or street address line one.",
+            "description": "Building or street address line two.",
             "example": "Wath-upon-Dearne"
           },
           "city": {
@@ -702,8 +702,26 @@
               "$ref": "#/components/schemas/LocationResource"
             }
           },
+          "included": {
+            "$ref": "#/components/schemas/Included"
+          },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
+      "LocationRelationships": {
+        "description": "This schema is used to describe associations that can be returned with locations.",
+        "type": "object",
+        "properties": {
+          "recruitment_cycle": {
+            "$ref": "#/components/schemas/Relationship"
+          },
+          "provider": {
+            "$ref": "#/components/schemas/Relationship"
+          },
+          "course": {
+            "$ref": "#/components/schemas/Relationship"
           }
         }
       },
@@ -717,10 +735,13 @@
           },
           "type": {
             "type": "string",
-            "example": "sites"
+            "example": "locations"
           },
           "attributes": {
             "$ref": "#/components/schemas/LocationAttributes"
+          },
+          "relationships": {
+            "$ref": "#/components/schemas/LocationRelationships"
           }
         }
       },
@@ -1143,16 +1164,19 @@
             "$ref": "#/components/schemas/CourseResource"
           },
           {
-            "$ref": "#/components/schemas/RecruitmentCycleResource"
-          },
-          {
-            "$ref": "#/components/schemas/SubjectResource"
-          },
-          {
             "$ref": "#/components/schemas/LocationResource"
           },
           {
             "$ref": "#/components/schemas/LocationStatusResource"
+          },
+          {
+            "$ref": "#/components/schemas/ProviderResource"
+          },
+          {
+            "$ref": "#/components/schemas/RecruitmentCycleResource"
+          },
+          {
+            "$ref": "#/components/schemas/SubjectResource"
           }
         ],
         "discriminator": {
@@ -1421,6 +1445,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "recruitment_cycle",
+                "provider",
+                "course"
+              ]
+            },
+            "example": "recruitment_cycle,provider"
           }
         ],
         "responses": {

--- a/swagger/public_v1/component_schemas/LocationRelationships.yml
+++ b/swagger/public_v1/component_schemas/LocationRelationships.yml
@@ -1,0 +1,10 @@
+---
+description: "This schema is used to describe associations that can be returned with locations."
+type: object
+properties:
+  recruitment_cycle:
+    $ref: "#/components/schemas/Relationship"
+  provider:
+    $ref: "#/components/schemas/Relationship"
+  course:
+    $ref: "#/components/schemas/Relationship"

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -236,9 +236,11 @@ components:
           example: "11214485"
         type:
           type: string
-          example: "sites"
+          example: "locations"
         attributes:
           $ref: "#/components/schemas/LocationAttributes"
+        relationships:
+          $ref: "#/components/schemas/LocationRelationships"
     LocationListResponse:
       description: "This schema is used to return a collection of locations."
       type: object
@@ -249,6 +251,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/LocationResource"
+        included:
+          $ref: "#/components/schemas/Included"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     LocationStatusResource:
@@ -362,10 +366,11 @@ components:
     Resource:
       anyOf:
         - $ref: "#/components/schemas/CourseResource"
-        - $ref: "#/components/schemas/RecruitmentCycleResource"
-        - $ref: "#/components/schemas/SubjectResource"
         - $ref: "#/components/schemas/LocationResource"
         - $ref: "#/components/schemas/LocationStatusResource"
+        - $ref: "#/components/schemas/ProviderResource"
+        - $ref: "#/components/schemas/RecruitmentCycleResource"
+        - $ref: "#/components/schemas/SubjectResource"
       discriminator:
         propertyName: type
     ResourceIdentifier:


### PR DESCRIPTION
### Context

- https://trello.com/c/AZ9Z9cqs/3778-m-implement-includes-to-locations-api-endpoint-api-v3-recruitmentcycles-year-providers-providercode-courses-coursecode-locations

### Changes proposed in this pull request

- Add inclusion options to the locations endpoint
- Dependant on this PR: https://github.com/DFE-Digital/teacher-training-api/pull/1513
- Update v1/public documentation for this endpoint to show inclusion options [WIP]
- Introduce a new test helper module https://github.com/DFE-Digital/teacher-training-api/pull/1523/files#diff-d5206992d9c7232aca19cf9ac241420eR3 which allows us to call `json_response` to interrogate the json response instead of multiple `JSON.parse(response.body)` calls in tests.

### Guidance to review

- Fire off a request for a given provider & course to get a list of that course's locations, passing along some include options. Here is an example request you can use (providing you have the sanitised data available) `curl --location --request GET 'localhost:3001/api/public/v1/recruitment_cycles/2020/providers/2HA/courses/3CW7/locations?include=course,provider,recruitment_cycle' \
--header 'Content-Type: application/json'`
- Assert the correct `recruitment_cycle`, `provider` and `course` are returned accordingly when passed in as include options.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
