### PR TITLE
Only patch swaggerize rake task if RSpec loaded

### DIFF
--- a/lib/tasks/swaggerize.rake
+++ b/lib/tasks/swaggerize.rake
@@ -1,14 +1,16 @@
-require "rspec/core/rake_task"
+if defined?(RSpec)
+  require "rspec/core/rake_task"
 
-Rake::Task["rswag:specs:swaggerize"].clear
+  Rake::Task["rswag:specs:swaggerize"].clear
 
-namespace :rswag do
-  namespace :specs do
-    desc "Generate Swagger JSON files from integration specs"
-    RSpec::Core::RakeTask.new("swaggerize") do |t|
-      t.pattern = "spec/docs/**/*_spec.rb"
+  namespace :rswag do
+    namespace :specs do
+      desc "Generate Swagger JSON files from integration specs"
+      RSpec::Core::RakeTask.new("swaggerize") do |t|
+        t.pattern = "spec/docs/**/*_spec.rb"
 
-      t.rspec_opts = ["--format OpenApi::Rswag::Specs::SwaggerFormatter", "--dry-run", "--order defined"]
+        t.rspec_opts = ["--format OpenApi::Rswag::Specs::SwaggerFormatter", "--dry-run", "--order defined"]
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

- Fixes build

### Changes proposed in this pull request

- Only patch swaggerize rake task if RSpec is loaded

### Guidance to review

- locally run `RAILS_ENV=staging be rake -T` without this patch should throw error
- locally run `RAILS_ENV=staging be rake -T` with this patch should no longer throw error

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
