### PR TITLE
[3742] Implement api endpoint for provider courses#show

### DIFF
--- a/app/controllers/api/public/v1/providers/courses_controller.rb
+++ b/app/controllers/api/public/v1/providers/courses_controller.rb
@@ -10,21 +10,9 @@ module API
           end
 
           def show
-            render json: {
-              data: {
-                id: "123",
-                type: "Course",
-                attributes: {
-                  code: "3GTY",
-                  provider_code: "6CL",
-                  age_minimum: 11,
-                  age_maximum: 14,
-                },
-              },
-              jsonapi: {
-                version: "1.0",
-              },
-            }
+            render jsonapi: course,
+              include: include_param,
+              class: API::Public::V1::SerializerService.new.call
           end
 
         private
@@ -33,8 +21,12 @@ module API
             @courses ||= provider.courses
           end
 
+          def course
+            @course ||= provider.courses.find_by!(course_code: params[:code])
+          end
+
           def provider
-            @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
+            @provider ||= recruitment_cycle.providers.find_by!(provider_code: params[:provider_code])
           end
 
           def recruitment_cycle

--- a/app/serializers/api/public/v1/serializable_recruitment_cycle.rb
+++ b/app/serializers/api/public/v1/serializable_recruitment_cycle.rb
@@ -1,0 +1,16 @@
+module API
+  module Public
+    module V1
+      class SerializableRecruitmentCycle < JSONAPI::Serializable::Resource
+        type "recruitment_cycles"
+
+        attributes :application_start_date,
+                   :application_end_date
+
+        attribute :year do
+          @object.year.to_i
+        end
+      end
+    end
+  end
+end

--- a/app/serializers/api/public/v1/serializer_service.rb
+++ b/app/serializers/api/public/v1/serializer_service.rb
@@ -6,6 +6,7 @@ module API
           {
             Course: API::Public::V1::SerializableCourse,
             Provider: API::Public::V1::SerializableProvider,
+            RecruitmentCycle: API::Public::V1::SerializableRecruitmentCycle,
           }
         end
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,7 +105,7 @@ Rails.application.routes.draw do
           resources :courses, only: %i[index]
 
           resources :providers, only: %i[index show], param: :code do
-            resources :courses, only: %i[index show], module: :providers do
+            resources :courses, only: %i[index show], module: :providers, param: :code do
               resources :locations, only: [:index]
             end
           end

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -88,9 +88,12 @@ describe "API" do
                 example: "X130"
 
       response "200", "The collection of courses offered by the specified provider." do
-        let(:year) { "2020" }
-        let(:provider_code) { "ABC" }
-        let(:course_code) { "DEF" }
+        let(:provider) { create(:provider) }
+        let(:course) { create(:course, course_code: "A123", provider: provider) }
+
+        let(:year) { provider.recruitment_cycle.year }
+        let(:provider_code) { provider.provider_code }
+        let(:course_code) { course.course_code }
 
         schema "$ref": "#/components/schemas/CourseSingleResponse"
 

--- a/spec/serializers/api/public/v1/serializable_recruitment_cycle_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_recruitment_cycle_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe API::Public::V1::SerializableRecruitmentCycle do
+  let(:cycle) { create(:recruitment_cycle) }
+  let(:resource) { described_class.new(object: cycle) }
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it "sets type to courses" do
+    expect(resource.jsonapi_type).to eq(:recruitment_cycles)
+  end
+
+  it { is_expected.to have_type("recruitment_cycles") }
+
+  it { is_expected.to have_attribute(:application_start_date).with_value(cycle.application_start_date.to_s) }
+  it { is_expected.to have_attribute(:application_end_date).with_value(cycle.application_end_date.to_s) }
+  it { is_expected.to have_attribute(:year).with_value(cycle.year.to_i) }
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/ekPzeeJr/3742-s-implement-api-endpoint-api-v3-recruitmentcycles-year-providers-providercode-courses-coursecode
- Adds public/v1 api endpoint for providers courses#show

### Changes proposed in this pull request

- Add `RecruitmentCycle` serialiser
- Add endpoint for courses on providers for public API

### Guidance to review

- Should be able to fetch a course via endpoint
- Should be able to specify includes for endpoint and they should be returned in the response

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
