### PR TITLE
[3801] - Tidy up Notify template config

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -157,48 +157,6 @@
         "description": "The API Key for GOV.UK Notify"
       }
     },
-    "govukNotifyWelcomeEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the find welcome email"
-      }
-    },
-    "govukNotifyCourseUpdateEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the course update email"
-      }
-    },
-    "govukNotifyCoursePublishEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the course publish email"
-      }
-    },
-    "govukNotifyCourseWithdrawEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the course withdraw email"
-      }
-    },
-    "govukNotifyCourseVacanciesFilledEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the course vacancies filled email"
-      }
-    },
-    "govukNotifyMagicLinkEmailTemplateId": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "The GOV.UK Notify template id for the magic signin link"
-      }
-    },
     "containerInstanceName": {
       "type": "array",
       "metadata": {

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -12,7 +12,6 @@ govuk_notify:
   course_publish_email_template_id: c4944115-6e73-4b30-9bc2-bf784c0e9aaa
   magic_link_email_template_id: 26a4c7f2-3caa-4770-8b2e-d7baf6342dd1
   course_withdraw_email_template_id: f7fee829-f0e7-40d1-9bd7-299f673e8c24
-  course_vacancies_filled_email_template_id: 0a6058b7-62d1-41e7-a5a9-f4a13ef86cbe
   course_sites_update_email_template_id: d5c8da46-9aa6-4c0a-8fad-ee782e89dbd3
   course_subjects_updated_email_template_id: b65aef1a-5847-44e6-90e0-88e0ea7898ec
   course_vacancies_updated_email_template_id: 3ae884e9-8495-44cf-9928-907b89a9f356

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,11 +1,5 @@
 govuk_notify:
   api_key: cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe
-  welcome_email_template_id: please_change_me
-  course_update_email_template_id: please_change_me
-  course_publish_email_template_id: please_change_me
-  course_withdraw_email_template_id: please_change_me
-  course_vacancies_filled_email_template_id: please_change_me
-  course_sites_update_email_template_id: please_change_me
 system_authentication_token: "Ge32"
 gcp_api_key: please_change_me
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk


### PR DESCRIPTION
### Context
As we are no longer storing template ids in Azure we should update the app config accordingly

### Changes proposed in this pull request
- template id entries removed from `config/settings/test.yml`
- template id entries removed from `template.json` (Azure config)
- `course_vacancies_filled_template_id` removed

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
