### PR TITLE
Clean up duplicate JSON.parse calls into re-usable helper

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,4 +24,7 @@ Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:
   Enabled: true
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
+
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,6 +48,7 @@ end
 RSpec.configure do |config|
   # add `FactoryBot` methods
   config.include FactoryBot::Syntax::Methods
+  config.include RequestHelpers, type: :controller
 
   # start by truncating all the tables but then use the faster transaction strategy the rest of the time.
   config.before(:suite) do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -1,0 +1,5 @@
+module RequestHelpers
+  def json_response
+    @json_response ||= JSON.parse(response.body)
+  end
+end


### PR DESCRIPTION
### Context

- I noticed a lot of duplicated calls to `JSON.parse` for parsing the response body in test files

### Changes proposed in this pull request

- Standardise helper method for parsing JSON responses in test files to avoid duplicating calls. 
- Instead of `JSON.parse` you would just do `json_response` which would also memoize the results.

### Guidance to review

- See the new helper method