### PR TITLE
Raise exception when Code Climate azure task fails

### DIFF
--- a/lib/tasks/code_climate.rake
+++ b/lib/tasks/code_climate.rake
@@ -8,6 +8,6 @@ namespace :cc do
   desc "Report test coverage to CodeClimate"
   task report: :environment do
     PREVIOUS_TEST_RESULT = ENV.fetch("AGENT_JOBSTATUS") == "Succeeded" ? 0 : 1
-    system("./cc-test-reporter after-build --exit-code #{PREVIOUS_TEST_RESULT}")
+    system("./cc-test-reporter after-build --exit-code #{PREVIOUS_TEST_RESULT}") || exit($?.exitstatus)
   end
 end


### PR DESCRIPTION
### Context
During a recent dependabot bump of simplecov(https://github.com/DFE-Digital/teacher-training-api/pull/1529), all the azure tasks passed and it was only when we inspected the codeclimate task when we noticed the task had failed.

This PR is to ensure that if the task fails then an exception should be raised.

### Changes proposed in this pull request

### Guidance to review

I've cherry picked a commit from the dependabot failing PR to show that the task now fails.
Once this PR has been approved we can removed the cherry picked commit 
and push up the changes. The task should pass once the commit is removed.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
