### PR TITLE
[3789] - Create endpoint for courses based on recruitment cycle

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -3,23 +3,21 @@ module API
     module V1
       class CoursesController < API::Public::V1::ApplicationController
         def index
-          render json: {
-            data: [
-              {
-                id: "124",
-                type: "Course",
-                attributes: {
-                  code: "3GTY",
-                  provider_code: "066",
-                  age_minimum: 10,
-                  age_maximum: 14,
-                },
-              },
-            ],
-            jsonapi: {
-              version: "1.0",
-            },
-          }
+          render jsonapi: paginate(courses), include: include_param, class: API::Public::V1::SerializerService.call
+        end
+
+      private
+
+        def courses
+          @courses ||= recruitment_cycle&.courses
+        end
+
+        def recruitment_cycle
+          @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
+        end
+
+        def include_param
+          params.fetch(:include, "")
         end
       end
     end

--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -9,11 +9,11 @@ module API
       private
 
         def courses
-          @courses ||= recruitment_cycle&.courses
+          @courses ||= recruitment_cycle.courses
         end
 
         def recruitment_cycle
-          @recruitment_cycle ||= RecruitmentCycle.find_by(year: params[:recruitment_cycle_year])
+          @recruitment_cycle ||= RecruitmentCycle.find_by!(year: params[:recruitment_cycle_year])
         end
 
         def include_param

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe API::Public::V1::CoursesController do
+  let(:provider) { create(:provider) }
+  let(:recruitment_cycle) { provider.recruitment_cycle }
+
+  describe "#index" do
+    context "when there are no courses" do
+      before do
+        get :index, params: {
+          recruitment_cycle_year: recruitment_cycle.year,
+        }
+      end
+
+      it "returns empty array of data" do
+        expect(json_response["data"]).to eql([])
+      end
+    end
+
+    context "when there are courses" do
+      before do
+        provider.courses << build_list(:course, 2, provider: provider)
+
+        get :index, params: {
+          recruitment_cycle_year: "2020",
+        }
+      end
+
+      it "returns correct number of courses" do
+        expect(json_response["data"].size).to eql(2)
+      end
+
+      context "with pagination" do
+        before do
+          provider.courses << build_list(:course, 5, provider: provider)
+
+          get :index, params: {
+            recruitment_cycle_year: "2020",
+            page: {
+              page: 2,
+              per_page: 5,
+            },
+          }
+        end
+
+        it "can pagingate to page 2" do
+          expect(json_response["data"].size).to eql(2)
+        end
+      end
+
+      context "with includes" do
+        before do
+          get :index, params: {
+            recruitment_cycle_year: "2020",
+            include: "recruitment_cycle,provider",
+          }
+        end
+
+        it "returns the requested associated data in the response" do
+          relationships = json_response["data"][0]["relationships"]
+
+          recruitment_cycle_id = relationships.dig("recruitment_cycle", "data", "id").to_i
+          provider_id = relationships.dig("provider", "data", "id").to_i
+
+          expect(json_response["data"][0]["relationships"].keys.sort).to eq(
+            %w[accredited_body provider recruitment_cycle],
+          )
+
+          expect(recruitment_cycle_id).to eq(provider.recruitment_cycle.id)
+          expect(provider_id).to eq(provider.id)
+        end
+      end
+    end
+  end
+end

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -53,6 +53,10 @@ describe "API" do
         let(:year) { "2020" }
         let(:include) { "provider" }
 
+        before do
+          create(:course)
+        end
+
         schema "$ref": "#/components/schemas/CourseListResponse"
 
         run_test!

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -39,9 +39,19 @@ describe "API" do
                 required: false,
                 example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: {
+                  enum: %w[accredited_body provider recruitment_cycle],
+                },
+                example: "recruitment_cycle,provider"
 
       response "200", "The collection of courses." do
         let(:year) { "2020" }
+        let(:include) { "provider" }
 
         schema "$ref": "#/components/schemas/CourseListResponse"
 

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -54,7 +54,7 @@ describe "API" do
         let(:include) { "provider" }
 
         before do
-          create(:course)
+          create(:course, course_code: "C100")
         end
 
         schema "$ref": "#/components/schemas/CourseListResponse"

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1387,6 +1387,20 @@
               "per_page": 10
             },
             "description": "Pagination options to navigate through the collection."
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "accredited_body",
+                "provider",
+                "recruitment_cycle"
+              ]
+            },
+            "example": "recruitment_cycle,provider"
           }
         ],
         "responses": {


### PR DESCRIPTION
### Context

- https://trello.com/c/VD20nCHv/3789-implement-api-endpoint-api-public-v1-recruitmentcycles-year-courses

### Changes proposed in this pull request

- Add `recruitment_cycle/:recruitment_cycle_year/courses` endpoint
- Update v1/public documentation for this endpoint

### Guidance to review

- Fire off a request for a given recruitment_cycle year to get a list of that cycle's courses. Here is an example request you can use (providing you have the sanitised data available):

`curl --location --request GET 'localhost:3001/api/public/v1/recruitment_cycles/2020/courses?include=provider,recruitment_cycle&page[page]=1&page[per_page]=10' \
--header 'Content-Type: application/json'`

- Assert the list of courses are returned correctly for that year. You can compare with the results from a rails console
- Assert you can pass paginate the results

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
