### PR TITLE
[3739] curl examples in tech docs

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -19,6 +19,7 @@ module GovukTechDocs
         @template_parameters = get_renderer("parameters.html.erb")
         @template_responses = get_renderer("responses.html.erb")
         @template_any_of = get_renderer("any_of.html.erb")
+        @template_curl_examples = get_renderer("curl_examples.html.erb")
       end
 
       def api_full
@@ -130,6 +131,7 @@ module GovukTechDocs
           text = text
           parameters = parameters(operation, id)
           responses = responses(operation, id)
+          curl_examples = curl_examples(operation, id)
           output += @template_operation.result(binding)
         end
         output
@@ -142,11 +144,16 @@ module GovukTechDocs
         output
       end
 
+      def curl_examples(operation, operation_id)
+        curl_examples = operation.node_data["x-curl-examples"] || []
+        id = "#{operation_id}-curl-examples"
+        @template_curl_examples.result(binding)
+      end
+
       def responses(operation, operation_id)
         responses = operation.responses
         id = "#{operation_id}-responses"
-        output = @template_responses.result(binding)
-        output
+        @template_responses.result(binding)
       end
 
       def markdown(text)

--- a/docs/lib/govuk_tech_docs/open_api/templates/curl_examples.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/curl_examples.html.erb
@@ -1,0 +1,28 @@
+<% if curl_examples.any? %>
+  <h3 id="<%= id %>">Request examples</h3>
+
+  <div class="govuk-!-margin-bottom-5">
+    <% curl_examples.each do |example| %>
+      <% example = example.with_indifferent_access %>
+
+      <details class="govuk-details govuk-!-margin-bottom-1" data-module="govuk-details">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= example[:description] %>
+          </span>
+        </summary>
+
+        <div class="govuk-details__text">
+          <%
+            source = example[:command]
+            formatter = Rouge::Formatters::HTML.new
+            lexer = Rouge::Lexers::Shell.new
+            output = formatter.format(lexer.lex(source))
+          %>
+
+          <pre class="highlight"><code><%= output %></code></pre>
+        </div>
+      </details>
+    <% end %>
+  </div>
+<% end %>

--- a/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
+++ b/docs/lib/govuk_tech_docs/open_api/templates/operation.html.erb
@@ -19,4 +19,6 @@
 
 <%= parameters %>
 
+<%= curl_examples %>
+
 <%= responses %>

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -49,6 +49,12 @@ describe "API" do
                 },
                 example: "recruitment_cycle,provider"
 
+      curl_example description: "Get all courses",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/courses"
+
+      curl_example description: "Get the second page of courses",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/courses?page[page]=2"
+
       response "200", "The collection of courses." do
         let(:year) { "2020" }
         let(:include) { "provider" }

--- a/spec/docs/provider_suggestions_spec.rb
+++ b/spec/docs/provider_suggestions_spec.rb
@@ -13,6 +13,9 @@ describe "API" do
                 description: "The provider's marketing name or code",
                 example: "oxf"
 
+      curl_example description: "Suggest providers with the specified query",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/provider_suggestions?query=oxf"
+
       response "200", "A list of provider suggestions matching the query term" do
         let(:query) { "oxf" }
 

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -33,6 +33,9 @@ describe "API" do
                 },
                 example: "recruitment_cycle,provider"
 
+      curl_example description: "Get the locations of a course",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses/2N22/locations"
+
       response "200", "The collection of locations for the specified course." do
         let(:course) { create(:course) }
         let(:provider) { course.provider }

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -46,6 +46,12 @@ describe "API" do
                 example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
 
+      curl_example description: "Get all courses for a provider",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses"
+
+      curl_example description: "Get the second page of courses for a provider",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/provideers/B20/courses?page[page]=2"
+
       response "200", "The collection of courses." do
         let(:provider) { create(:provider) }
         let(:year) { provider.recruitment_cycle.year }
@@ -86,6 +92,9 @@ describe "API" do
                 required: true,
                 description: "The code of the course.",
                 example: "X130"
+
+      curl_example description: "Get a course for a provider",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses/2N22"
 
       response "200", "The collection of courses offered by the specified provider." do
         let(:provider) { create(:provider) }

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -31,6 +31,12 @@ describe "API" do
                 example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
 
+      curl_example description: "Get all providers",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers"
+
+      curl_example description: "Get second page of providers",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers?page[page]=2"
+
       response "200", "Collection of providers." do
         let(:year) { "2020" }
 
@@ -58,6 +64,9 @@ describe "API" do
                 required: true,
                 description: "The unique code of the provider.",
                 example: "T92"
+
+      curl_example description: "Get a specific provider",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20"
 
       response "200", "The provider." do
         let!(:provider) { create(:provider) }

--- a/spec/docs/subject_areas_spec.rb
+++ b/spec/docs/subject_areas_spec.rb
@@ -7,6 +7,9 @@ describe "API" do
       tags "subject_areas"
       produces "application/json"
 
+      curl_example description: "Get all subject areas",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas"
+
       response "200", "The collection of subject areas." do
         schema "$ref": "#/components/schemas/SubjectAreaListResponse"
 

--- a/spec/docs/subjects_spec.rb
+++ b/spec/docs/subjects_spec.rb
@@ -16,6 +16,9 @@ describe "API" do
                 example: "name",
                 description: "Sort subjects by name"
 
+      curl_example description: "Get all subjects",
+                   command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subjects"
+
       response "200", "The list of subjects" do
         let(:sort) { "name" }
 

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -36,3 +36,20 @@ RSpec.configure do |config|
     "public_v1/api_spec.json" => swagger_v1_template.with_indifferent_access,
   }
 end
+
+if defined?(OpenApi)
+  module OpenApi
+    module Rswag
+      module Specs
+        module ExampleGroupHelpersExtensions
+          def curl_example(hash)
+            metadata[:operation]["x-curl-examples"] ||= []
+            metadata[:operation]["x-curl-examples"] << hash
+          end
+        end
+      end
+    end
+  end
+
+  OpenApi::Rswag::Specs::ExampleGroupHelpers.include(OpenApi::Rswag::Specs::ExampleGroupHelpersExtensions)
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1403,6 +1403,16 @@
             "example": "recruitment_cycle,provider"
           }
         ],
+        "x-curl-examples": [
+          {
+            "description": "Get all courses",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/courses"
+          },
+          {
+            "description": "Get the second page of courses",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/courses?page[page]=2"
+          }
+        ],
         "responses": {
           "200": {
             "description": "The collection of courses.",
@@ -1434,6 +1444,12 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "x-curl-examples": [
+          {
+            "description": "Suggest providers with the specified query",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/provider_suggestions?query=oxf"
           }
         ],
         "responses": {
@@ -1504,6 +1520,12 @@
               ]
             },
             "example": "recruitment_cycle,provider"
+          }
+        ],
+        "x-curl-examples": [
+          {
+            "description": "Get the locations of a course",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses/2N22/locations"
           }
         ],
         "responses": {
@@ -1591,6 +1613,16 @@
             "description": "Pagination options to navigate through the collection."
           }
         ],
+        "x-curl-examples": [
+          {
+            "description": "Get all courses for a provider",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses"
+          },
+          {
+            "description": "Get the second page of courses for a provider",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/provideers/B20/courses?page[page]=2"
+          }
+        ],
         "responses": {
           "200": {
             "description": "The collection of courses.",
@@ -1642,6 +1674,12 @@
             "schema": {
               "type": "string"
             }
+          }
+        ],
+        "x-curl-examples": [
+          {
+            "description": "Get a course for a provider",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses/2N22"
           }
         ],
         "responses": {
@@ -1760,6 +1798,16 @@
             "description": "Pagination options to navigate through the collection."
           }
         ],
+        "x-curl-examples": [
+          {
+            "description": "Get all providers",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers"
+          },
+          {
+            "description": "Get second page of providers",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers?page[page]=2"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Collection of providers.",
@@ -1803,6 +1851,12 @@
             }
           }
         ],
+        "x-curl-examples": [
+          {
+            "description": "Get a specific provider",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20"
+          }
+        ],
         "responses": {
           "200": {
             "description": "The provider.",
@@ -1833,6 +1887,12 @@
         "operationId": "public_api_v1_subject_areas",
         "tags": [
           "subject_areas"
+        ],
+        "x-curl-examples": [
+          {
+            "description": "Get all subject areas",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas"
+          }
         ],
         "responses": {
           "200": {
@@ -1867,6 +1927,12 @@
             "required": false,
             "example": "name",
             "description": "Sort subjects by name"
+          }
+        ],
+        "x-curl-examples": [
+          {
+            "description": "Get all subjects",
+            "command": "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subjects"
           }
         ],
         "responses": {


### PR DESCRIPTION
### Context

- https://trello.com/c/7jVzT0Uk/3739-add-curl-examples-for-api-requests
- Add curl request examples to api docs so docs can better understand how to use endpoints

### Changes proposed in this pull request

- Monkey patch `open_api-rswag-specs` gem to extend the DSL allowing `curl_example` to be used
- `curl_example` can now be used in rspec DSL with a given `description` and curl `command`
- `curl_example` adds to the generated open api spec under the key of `x-curl-examples` which seems to be permitted by https://swagger.io/docs/specification/openapi-extensions/
- Updated api docs so it pulls in the curl examples from the generated open api spec
- Added template to deal with these examples, see screenshots below

#### Closed state screenshot
![image](https://user-images.githubusercontent.com/92580/90762278-ad83cd00-e2dc-11ea-8dc1-09a4b409520f.png)

#### Open state screenshot
![image](https://user-images.githubusercontent.com/92580/90762347-cee4b900-e2dc-11ea-8470-ad1db9ec72bb.png)

### Guidance to review

- Pull down this branch
- Fire up the tech docs
- Ensure docs show example curl commands

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
