### PR TITLE
[3805] - Implement sorting and filtering for public courses endpoint

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -9,7 +9,11 @@ module API
       private
 
         def courses
-          @courses ||= recruitment_cycle.courses
+          @courses ||= CourseSearchService.call(
+            filter: params[:filter],
+            sort: params[:sort],
+            course_scope: recruitment_cycle.courses,
+          )
         end
 
         def recruitment_cycle


### PR DESCRIPTION
### Context

- https://trello.com/c/u8s9har0/3805-s-linked-to-3789-add-sorting-to-api-public-v1-recruitmentcycles-year-courses
https://trello.com/c/t0UwzFDt/3806-s-linked-to-3789-add-filtering-to-api-public-v1-recruitmentcycles-year-courses
- Dependent on this PR https://github.com/DFE-Digital/teacher-training-api/pull/1534

### Changes proposed in this pull request

- Implements sorting/filtering via the CourseSearchService in `/api/public/v1/:recruitment_cycle_year/courses`

### Guidance to review

-  Fire off the example request below and add your sorting and filtering options in the request.
- Assert the courses returned match provided sorting/filtering params

CURL:

```
curl --location --request GET 'localhost:3001/api/public/v1/recruitment_cycles/2020/courses?sort=name,provider.provider_name&filter[funding_type]=salary' \
--header 'Content-Type: application/json'
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
