### PR TITLE
[3810] and [3807] Remove recruitment_cycle_year and provider_code

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -82,14 +82,6 @@ module API
           @object.open_for_applications?
         end
 
-        attribute :provider_code do
-          @object.provider.provider_code
-        end
-
-        attribute :recruitment_cycle_year do
-          @object.recruitment_cycle.year
-        end
-
         attribute :required_qualifications_english do
           @object.english
         end

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -79,7 +79,7 @@ describe "API" do
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20"
 
       response "200", "The provider." do
-        let!(:provider) { create(:provider) }
+        let(:provider) { create(:provider, provider_code: "1AT") }
         let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }
 

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -62,9 +62,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:other_requirements).with_value(course.latest_published_enrichment.other_requirements) }
   it { is_expected.to have_attribute(:personal_qualities).with_value(course.latest_published_enrichment.personal_qualities) }
   it { is_expected.to have_attribute(:program_type).with_value(course.program_type) }
-  it { is_expected.to have_attribute(:provider_code).with_value(course.provider.provider_code) }
   it { is_expected.to have_attribute(:qualifications).with_value(%w{qts pgce}) }
-  it { is_expected.to have_attribute(:recruitment_cycle_year).with_value("2020") }
   it { is_expected.to have_attribute(:required_qualifications).with_value(course.latest_published_enrichment.required_qualifications) }
   it { is_expected.to have_attribute(:required_qualifications_english).with_value("must_have_qualification_at_application_time") }
   it { is_expected.to have_attribute(:required_qualifications_maths).with_value("must_have_qualification_at_application_time") }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -271,13 +271,6 @@
               "pg_teaching_apprenticeship"
             ]
           },
-          "provider_code": {
-            "type": "string",
-            "description": "Unique code for the provider of this course.",
-            "maxLength": 3,
-            "minLength": 3,
-            "example": "6CL"
-          },
           "qualifications": {
             "type": "array",
             "description": "The qualifications as an outcome of the course.",
@@ -307,11 +300,6 @@
               "type": "string",
               "example": "qts"
             }
-          },
-          "recruitment_cycle_year": {
-            "type": "string",
-            "description": "The recruitment cycle that this course is available in.",
-            "example": 2020
           },
           "required_qualifications": {
             "type": "string",

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -3,7 +3,6 @@ description: "This schema presents the information about a course."
 type: object
 required:
   - code
-  - provider_code
   - age_maximum
   - age_minimum
 properties:
@@ -234,12 +233,6 @@ properties:
       - school_direct_training_programme
       - school_direct_salaried_training_programme
       - pg_teaching_apprenticeship
-  provider_code:
-    type: string
-    description: "Unique code for the provider of this course."
-    maxLength: 3
-    minLength: 3
-    example: 6CL
   qualifications:
     type: array
     description: >-
@@ -254,10 +247,6 @@ properties:
     items:
       type: string
       example: "qts"
-  recruitment_cycle_year:
-    type: string
-    description: The recruitment cycle that this course is available in.
-    example: 2020
   required_qualifications:
     type: string
     nullable: true


### PR DESCRIPTION
### Context

Including this data forces the endpoint to include `recruitment_cycles` and `provider` into the SQL query. Instead of doing this we should allow the client to include the `recruitment_cycle` and `provider` if they need to get this data.

- https://trello.com/c/c1VBUUXP/3810-s-remove-providercode-from-the-public-apis-courses-endpoint
- https://trello.com/c/JaOlx4mc/3807-s-remove-recruitmentcycleyear-from-the-public-apis-courses-endpoint

### Changes proposed in this pull request

- Remove from API v1 courses endpoint documentation.
- Remove from API v1 courses serialiser.
- Remove from API v1 courses endpoint tests.

### Guidance to review

- Fire up the public api docs locally and assert the the `recruitment_cycle_year` and `provider_code` has been removed from the Courses OpenAPI schema
- Use the curl request below to assert the `recruitment_cycle_year` and `provider_code` is not included in the json response, unless explicitly set in the `include` query string

CURL:

courses for the recruitment cycle:

```
curl --location --request GET 'localhost:3001/api/public/v1/recruitment_cycles/2020/courses?include=provider,recruitment_cycle&page[page]=1&page[per_page]=3' \
--header 'Content-Type: application/json'
```

courses for a provider:

```
curl --location --request GET 'localhost:3001/api/public/v1/recruitment_cycles/2020/providers/2HA/courses?include=provider,recruitment_cycle' \
--header 'Content-Type: application/json'
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
