### PR TITLE
[3820] remove PE from edit subjects list for non admins

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -65,8 +65,19 @@ module API
       end
 
       def show
-        # https://github.com/jsonapi-rb/jsonapi-rails/issues/113
-        render jsonapi: @course, include: params[:include], class: CourseSerializersService.new.execute
+        json_data = JSONAPI::Serializable::Renderer.new.render(
+          @course,
+          class: CourseSerializersService.new.execute,
+          include: params[:include],
+        )
+
+        unless @current_user.admin?
+          json_data[:data][:meta][:edit_options][:subjects]&.reject! do |subject|
+            subject[:attributes][:subject_name] == "Physical education"
+          end
+        end
+
+        render json: json_data
       end
 
       def publish

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -142,7 +142,7 @@ describe "/api/v2/build_new_course", type: :request do
       end
 
       context "when the current user is not an admin" do
-        it "should return pe as a potential subject" do
+        it "should not return pe as a potential subject" do
           response = do_get params
           expect(response).to have_http_status(:ok)
           json_response = parse_response(response)

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -71,6 +71,30 @@ describe "Courses API v2", type: :request do
       response
     end
 
+    describe "edit options" do
+      let(:pe) { find_or_create(:secondary_subject, :physical_education) }
+      let(:course) { create(:course, :secondary, provider: provider) }
+
+      context "when the current user is not an admin" do
+        it "should not return pe as a potential subject" do
+          json_response = JSON.parse subject.body
+          expect(json_response["data"]["meta"]["edit_options"]["subjects"].map { |subject|
+            subject["attributes"]["subject_code"]
+          }).not_to include(pe.subject_code)
+        end
+      end
+
+      context "when the current user is an admin" do
+        let(:user) { create(:user, :admin) }
+        it "should return pe as a potential subject" do
+          json_response = JSON.parse subject.body
+          expect(json_response["data"]["meta"]["edit_options"]["subjects"].map { |subject|
+            subject["attributes"]["subject_code"]
+          }).to include(pe.subject_code)
+        end
+      end
+    end
+
     context "with a findable_open_course" do
       let(:course) { findable_open_course }
 
@@ -381,9 +405,6 @@ describe "Courses API v2", type: :request do
                  },
                 },
               },
-            },
-            "jsonapi" => {
-              "version" => "1.0",
             },
             "included" => [
               {


### PR DESCRIPTION
### Context

Removes the PE subject from subject list for non admins as providers require permission to recruit for this course. It is not visible as a subject on the add new course flow.

### Changes proposed in this pull request

Remove the PE subject from subject list for non admins.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
