### PR TITLE
SKYLIGHT variable to arm template

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -311,6 +311,13 @@
       "metadata": {
         "description": "Configure Rails to serve out static files from the public folder."
       }
+    },
+    "settingsSkylightAuthentication": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "Skylight auth Key."
+      }
     }
   },
   "variables": {
@@ -551,6 +558,10 @@
               {
                 "name": "RAILS_SERVE_STATIC_FILES",
                 "value": "[parameters('railsServeStaticFiles')]"
+              },
+              {
+                "name": "SETTINGS__SKYLIGHT__AUTHENTICATION",
+                "value": "[parameters('settingsSkylightAuthentication')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

SETTINGS__SKYLIGHT__AUTHENTICATION env variable added to arm template (./azure/template.json)

### Changes proposed in this pull request

In order to allow the Skylight integration, SETTINGS__SKYLIGHT__AUTHENTICATION has been added as parameter to the arm template.

### Guidance to review

We just need to add set the API key to the env var SETTINGS__SKYLIGHT__AUTHENTICATION

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
