### PR TITLE
[54] - Implement api/public/v1/courses

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -19,7 +19,9 @@ module API
         end
 
         def recruitment_cycle
-          @recruitment_cycle ||= RecruitmentCycle.find_by!(year: params[:recruitment_cycle_year])
+          @recruitment_cycle = RecruitmentCycle.find_by(
+            year: params[:recruitment_cycle_year],
+          ) || RecruitmentCycle.current_recruitment_cycle
         end
 
         def include_param

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -114,9 +114,11 @@ Rails.application.routes.draw do
           end
         end
 
-        get "provider_suggestions", to: "provider_suggestions#index"
         resources :subjects, only: %i[index]
         resources :subject_areas, only: :index
+
+        get "provider_suggestions", to: "provider_suggestions#index"
+        get "/courses", to: "courses#index"
       end
     end
   end

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -22,10 +22,28 @@ RSpec.describe API::Public::V1::CoursesController do
         provider.courses << build_list(:course, 2, provider: provider)
       end
 
+      context "with no recruitment cycle provided" do
+        let(:next_cycle) { create :recruitment_cycle, :next }
+
+        before do
+          next_cycle
+
+          get :index, params: {
+            include: "recruitment_cycle",
+          }
+        end
+
+        it "returns courses for the current cycle" do
+          parsed_recruitment_cycle_id = json_response["data"][0].dig("relationships", "recruitment_cycle", "data", "id").to_i
+          expect(parsed_recruitment_cycle_id).to eq(recruitment_cycle.id)
+          expect(json_response["data"].size).to eql(2)
+        end
+      end
+
       context "default response" do
         before do
           get :index, params: {
-            recruitment_cycle_year: "2020",
+            recruitment_cycle_year: recruitment_cycle.year,
           }
         end
 
@@ -39,7 +57,7 @@ RSpec.describe API::Public::V1::CoursesController do
           provider.courses << build_list(:course, 5, provider: provider)
 
           get :index, params: {
-            recruitment_cycle_year: "2020",
+            recruitment_cycle_year: recruitment_cycle.year,
             page: 2,
             per_page: 5,
           }
@@ -53,7 +71,7 @@ RSpec.describe API::Public::V1::CoursesController do
       context "with includes" do
         before do
           get :index, params: {
-            recruitment_cycle_year: "2020",
+            recruitment_cycle_year: recruitment_cycle.year,
             include: "recruitment_cycle,provider",
           }
         end
@@ -80,7 +98,7 @@ RSpec.describe API::Public::V1::CoursesController do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
 
           get :index, params: {
-            recruitment_cycle_year: "2020",
+            recruitment_cycle_year: recruitment_cycle.year,
             sort: sort_attribute,
           }
         end
@@ -99,7 +117,7 @@ RSpec.describe API::Public::V1::CoursesController do
           allow(CourseSearchService).to receive(:call).and_return(Course.all)
 
           get :index, params: {
-            recruitment_cycle_year: "2020",
+            recruitment_cycle_year: recruitment_cycle.year,
             filter: {
               funding_type: "salary",
             },


### PR DESCRIPTION
### Context

- https://trello.com/c/bqY8jqRL/54-add-api-endpoint-api-public-v1-courses

### Changes proposed in this pull request

- This is the actual courses endpoint that is used by Find and Apply, it defaults to the current recruitment cycle when retrieving courses, and is nearly identical to `/api/public/v1/recruitment_cycles/:year/courses`

### Guidance to review

- Implement `api/public/v1/courses`
- Use curl command below to assert courses for current cycle are returned when no cycle is provided in the request

Curl:

```
curl --location --request GET 'localhost:3001/api/public/v1/courses?include=provider,recruitment_cycle&page[page]=1&page[per_page]=3' \
--header 'Content-Type: application/json'
```
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
