### PR TITLE
Monitor /ping via statusCake

### DIFF
--- a/terraform/resources.tf
+++ b/terraform/resources.tf
@@ -9,4 +9,5 @@ resource statuscake_test alert {
   trigger_rate  = each.value.trigger_rate
   custom_header = each.value.custom_header
   status_codes  = each.value.status_codes
+  confirmations = 1
 }

--- a/terraform/terraform_prod.tfvars
+++ b/terraform/terraform_prod.tfvars
@@ -1,9 +1,9 @@
 alerts =  {
 ttapi = {
     website_name = "prod-teacher-training-api"
-    website_url   = "https://api2.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    website_url   = "https://api.publish-teacher-training-courses.service.gov.uk/ping"
     test_type     = "HTTP"
-    check_rate    = 300
+    check_rate    = 60
     contact_group = [151103]
     trigger_rate  = 0
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"

--- a/terraform/terraform_qa.tfvars
+++ b/terraform/terraform_qa.tfvars
@@ -1,9 +1,9 @@
 alerts =  {
 ttapi = {
     website_name = "qa-teacher-training-api"
-    website_url   = "https://api2.qa.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    website_url   = "https://api.qa.publish-teacher-training-courses.service.gov.uk/ping"
     test_type     = "HTTP"
-    check_rate    = 300
+    check_rate    = 60
     contact_group = [151103]
     trigger_rate  = 0
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"

--- a/terraform/terraform_staging.tfvars
+++ b/terraform/terraform_staging.tfvars
@@ -1,9 +1,9 @@
 alerts =  {
 ttapi = {
     website_name = "staging-teacher-training-api"
-    website_url   = "https://api2.staging.publish-teacher-training-courses.service.gov.uk/healthcheck"
+    website_url   = "https://api.staging.publish-teacher-training-courses.service.gov.uk/ping"
     test_type     = "HTTP"
-    check_rate    = 300
+    check_rate    = 60
     contact_group = [151103]
     trigger_rate  = 0
     custom_header = "{\"Content-Type\": \"application/x-www-form-urlencoded\"}"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "sc_username" {}
 variable "sc_api_key" {}
 variable "alerts" {
-  type = "map"
+  type = map
 }


### PR DESCRIPTION
Add terraform code and configuration to create a
StatusCake check to monitor the /ping every minute
and let us know immediately if the site is down

### Context

Figure out what is causing it to return false, fix it.

### Changes proposed in this pull request

configure statuscake via terraform to /ping instead of healthCheck.

### Guidance to review

### Checklist

- [x ] Make sure all information from the Trello card is in here
- [x ] Attach to Trello card
- [ x] Rebased master
- [ x] Cleaned commit history
- [ x] Tested by running locally
