### PR TITLE
[88] Age range validation error message no longer display underscores

### DIFF
--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -1,7 +1,7 @@
 module Courses
   class ValidateCustomAgeRangeService
     def execute(age_range_in_years, course)
-      error_message = "#{age_range_in_years} is invalid. You must enter a valid age range."
+      error_message = "#{age_range_in_years.to_s.tr('_', ' ')} is invalid. You must enter a valid age range."
       valid_age_range_regex = Regexp.new(/^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/)
 
       if valid_age_range_regex.match(age_range_in_years)

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -81,41 +81,46 @@ RSpec.describe "POST /providers/:provider_code/courses/:course_code" do
 
     context "with a from value that does not fall within the valid age range" do
       let(:age_range_in_years) { "1_to_15" }
+      let(:age_range_in_years_formatted) { "1 to 15" }
+
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} #{error_message}"
+        expect(response.body).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with a to value that does not fall within the valid age range" do
       let(:age_range_in_years) { "7_to_20" }
+      let(:age_range_in_years_formatted) { "7 to 20" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} #{error_message}"
+        expect(response.body).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with an age range that does not include a valid from age range value" do
       let(:age_range_in_years) { "to_6" }
+      let(:age_range_in_years_formatted) { "to 6" }
 
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} #{error_message}"
+        expect(response.body).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with an age range that does not include a valid to age range value" do
       let(:age_range_in_years) { "2_to" }
+      let(:age_range_in_years_formatted) { "2 to" }
 
       it "should return an error stating that there is an invalid from year" do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(json_data.count).to eq 1
-        expect(response.body).to include "#{age_range_in_years} #{error_message}"
+        expect(response.body).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
   end

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -31,33 +31,37 @@ describe Courses::ValidateCustomAgeRangeService do
 
     context "with a from value that does not fall within the valid age range" do
       let(:age_range_in_years) { "1_to_15" }
+      let(:age_range_in_years_formatted) { "1 to 15" }
 
       it "should return an error" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with a to value that does not fall within the valid age range" do
       let(:age_range_in_years) { "7_to_20" }
+      let(:age_range_in_years_formatted) { "7 to 20" }
 
       it "should return an error stating valid age ranges must be 4 years or greater" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with an age range that does not include a valid from age range value" do
       let(:age_range_in_years) { "to_6" }
+      let(:age_range_in_years_formatted) { "to 6" }
 
       it "should return an error stating that there is an invalid from year" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
 
     context "with an age range that does not include a valid to age range value" do
       let(:age_range_in_years) { "2_to" }
+      let(:age_range_in_years_formatted) { "2 to" }
 
       it "should return an error stating that there is an invalid from year" do
-        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years} #{error_message}"
+        expect(course.errors.messages[:age_range_in_years]).to include "#{age_range_in_years_formatted} #{error_message}"
       end
     end
   end


### PR DESCRIPTION
### Context

The age range validation error message was incorrectly displaying underscores. 

### Changes proposed in this pull request

The underscores no longer appear.

![image](https://user-images.githubusercontent.com/50492247/93095926-a6619c00-f69b-11ea-9972-68f8081a1874.png)


### Guidance to review

- Login to Publish 
- Create a new course 
- On the age range page select 'another age range'
- Enter an invalid range such as 0 to 50
- Click submit 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
