### PR TITLE
[130] service status dashboard rollover data

### DIFF
--- a/app/services/rollover_reporting_service.rb
+++ b/app/services/rollover_reporting_service.rb
@@ -1,0 +1,69 @@
+class RolloverReportingService
+  def initialize
+    @rollover_scope = RecruitmentCycle.current_recruitment_cycle
+  end
+
+  class << self
+    def call
+      new.call
+    end
+  end
+
+  def call
+    return {} if @rollover_scope.next.blank?
+
+    {
+      total: {
+          published_courses: published_courses_count,
+          new_courses_published: new_courses_published_count,
+          deleted_courses: deleted_courses_count,
+          existing_courses_in_draft: existing_courses_in_draft_count,
+          existing_courses_in_review: existing_courses_in_review,
+      },
+    }
+  end
+
+  private_class_method :new
+
+private
+
+  def next_findable
+    @rollover_scope.next.courses.findable
+  end
+
+  def published_courses
+    next_findable
+  end
+
+  def published_courses_count
+    published_courses.distinct.count
+  end
+
+  def new_courses_published
+    next_findable.distinct.created_at_since(RecruitmentCycle.next.created_at + 1.day)
+  end
+
+  def new_courses_published_count
+    new_courses_published.count
+  end
+
+  def deleted_courses
+    Course.discarded.where(provider: Provider.where(recruitment_cycle: RecruitmentCycle.next))
+  end
+
+  def deleted_courses_count
+    deleted_courses.count
+  end
+
+  def existing_courses_in_draft
+    @rollover_scope.next.courses.changed_since(RecruitmentCycle.next.created_at + 1.day).where.not(id: published_courses)
+  end
+
+  def existing_courses_in_draft_count
+    existing_courses_in_draft.distinct.count
+  end
+
+  def existing_courses_in_review
+    @rollover_scope.next.courses.where.not(id: published_courses).where.not(id: deleted_courses).where.not(id: existing_courses_in_draft).count
+  end
+end

--- a/app/services/statistic_service.rb
+++ b/app/services/statistic_service.rb
@@ -5,6 +5,7 @@ class StatisticService
       courses: CourseReportingService.call(courses_scope: recruitment_cycle.courses),
       publish: PublishReportingService.call(recruitment_cycle_scope: recruitment_cycle),
       allocations: AllocationReportingService.call(recruitment_cycle_scope: recruitment_cycle),
+      rollover: RolloverReportingService.call,
     }
   end
 

--- a/spec/requests/api/v2/recruitment_cycle_spec.rb
+++ b/spec/requests/api/v2/recruitment_cycle_spec.rb
@@ -100,14 +100,14 @@ describe "/api/v2/recruitment_cycle", type: :request do
     }
 
     describe "the JSON response" do
-      it "displays che correct jsonapi response" do
+      it "displays the correct jsonapi response" do
         provider
         next_provider
         provider2
 
         perform_request
 
-        json_response["data"].sort_by! { |cycle| cycle["id"] }
+        json_response["data"].sort_by! { |cycle| cycle["attributes"]["year"] }
 
         expect(json_response)
           .to(eq(

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -171,6 +171,15 @@ describe "GET /reporting" do
           },
         },
       },
+      rollover: {
+        total: {
+          published_courses: 0,
+          new_courses_published: 0,
+          deleted_courses: 0,
+          existing_courses_in_draft: 0,
+          existing_courses_in_review: 0,
+        },
+      },
     }.with_indifferent_access
   end
 
@@ -178,8 +187,13 @@ describe "GET /reporting" do
     find_or_create(:recruitment_cycle, :previous)
   }
 
+  let(:next_recruitment_cycle) {
+    find_or_create(:recruitment_cycle, :next)
+  }
+
   it "returns status success" do
     previous_recruitment_cycle
+    next_recruitment_cycle
     get "/reporting"
     expect(response.status).to eq(200)
     expect(JSON.parse(response.body)).to eq(expected)

--- a/spec/services/rollover_reporting_service_spec.rb
+++ b/spec/services/rollover_reporting_service_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+describe RolloverReportingService do
+  let(:published_running_site) { create(:site_status, :published, :running) }
+  let(:provider) { create(:provider, :next_recruitment_cycle) }
+  let(:published_course) { create(:course, provider: provider, site_statuses: [published_running_site]) }
+  let(:new_published_course) { create(:course, age: provider.recruitment_cycle.created_at + 28.hours, provider: provider, site_statuses: [published_running_site]) }
+  let(:deleted_course) { create(:course, :deleted, provider: provider) }
+  let(:course_in_draft) { create(:course, age: provider.recruitment_cycle.created_at + 25.hours, provider: provider) }
+  let(:second_course_in_draft) { create(:course, age: provider.recruitment_cycle.created_at + 26.hours, provider: provider) }
+
+  describe ".call" do
+    subject(:result) { described_class.call }
+
+    context "number of published courses after rollover" do
+      before do
+        provider
+        published_course
+      end
+
+      it "returns the correct published courses" do
+        expect(result[:total][:published_courses]).to eq 1
+      end
+    end
+
+    context "number of new published courses after rollover" do
+      before do
+        provider
+        new_published_course
+      end
+
+      it "returns the correct newly published courses" do
+        expect(result[:total][:new_courses_published]).to eq 1
+      end
+    end
+
+    context "number of deleted courses after rollover" do
+      before do
+        provider
+        deleted_course
+      end
+
+      it "returns the correct deleted courses" do
+        deleted_course
+        expect(result[:total][:deleted_courses]).to eq 1
+      end
+    end
+
+    context "number of courses after rollover that are in draft" do
+      before do
+        provider
+        course_in_draft
+        second_course_in_draft
+        new_published_course
+      end
+
+      it "returns the correct courses in draft" do
+        expect(result[:total][:existing_courses_in_draft]).to eq 2
+      end
+    end
+
+    context "number of courses after rollover that are in review" do
+      before do
+        provider
+        course_in_draft
+        new_published_course
+        deleted_course
+        published_course
+      end
+
+      it "it returns the correct courses in review" do
+        expect(result[:total][:existing_courses_in_review]).to eq 1
+      end
+    end
+
+    context "if there is no next recruitment cycle" do
+      it "returns an empty object" do
+        expect(result).to eq({})
+      end
+    end
+  end
+end

--- a/spec/services/statistic_service_spec.rb
+++ b/spec/services/statistic_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe StatisticService do
   let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
   let!(:previous_recruitment_cycle) { find_or_create(:recruitment_cycle, :previous) }
@@ -22,6 +24,11 @@ describe StatisticService do
 
     it "calls the allocation reporting service" do
       expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      subject
+    end
+
+    it "calls the rollover reporting service" do
+      expect(RolloverReportingService).to receive(:call)
       subject
     end
   end
@@ -52,6 +59,11 @@ describe StatisticService do
 
     it "calls the allocation reporting service" do
       expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      subject
+    end
+
+    it "calls the rollover reporting service" do
+      expect(RolloverReportingService).to receive(:call)
       subject
     end
   end


### PR DESCRIPTION
### Context
* https://trello.com/c/3C81CAYu/130-service-status-dashboard-rollover-data

Rollover data is needed for the new rollover tab on the performance dashboard as per the prototype. As a result, data needs to be added to the reporting endpoint on the API.

### Changes proposed in this pull request

At the /reporting endpoint
<img width="475" alt="Screenshot 2020-09-18 at 17 33 28" src="https://user-images.githubusercontent.com/58793682/93622444-142c0180-f9d5-11ea-8de1-e79fae936f8c.png">

### Guidance to review
* https://publish-dashboard-prototype.herokuapp.com/with-tables#rollover  

N.B There's been a copy change to new courses 'published' instead of created.

### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
