### PR TITLE
[177] enable skylight in qa and disable in prod

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -7,4 +7,4 @@ bg_jobs:
     class: "SaveStatisticJob"
     queue: save_statistic
 skylight:
-  enable: true
+  enable: false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -4,5 +4,7 @@ find_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight
-    class: "SaveStatisticJob" 
+    class: "SaveStatisticJob"
     queue: save_statistic
+skylight:
+  enable: true


### PR DESCRIPTION
To test it's functioning before we ask skylight.io to enable our OSS account.

### Context

We're trying to sort out Skylight and would like to ask them to enable our OSS account. However, we'd like to demonstrate that we have it working in qa first.

### Changes proposed in this pull request

Enable skylight in qa and disable it in production (since our prod receives too many requests for the current free tier anyway).

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
