### PR TITLE
Fix failing spec relating to rollover

### DIFF
--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -17,13 +17,12 @@ describe "Courses API v2", type: :request do
   let(:next_year)     { current_year + 1 }
   let(:subjects) { [course_subject_mathematics] }
 
-  let(:applications_open_from) { Time.now.utc }
+
   let(:findable_open_course) do
     create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
            level: "primary",
            name: "Mathematics",
            provider: provider,
-           start_date: Time.now.utc,
            study_mode: :full_time,
            subjects: subjects,
            is_send: true,
@@ -32,8 +31,7 @@ describe "Courses API v2", type: :request do
            maths: :must_have_qualification_at_application_time,
            english: :must_have_qualification_at_application_time,
            science: :must_have_qualification_at_application_time,
-           age_range_in_years: "3_to_7",
-           applications_open_from: applications_open_from)
+           age_range_in_years: "3_to_7")
   end
 
   let(:courses_site_statuses) {


### PR DESCRIPTION
### Context
We are currently in a weird state between closing the current_recruitment_cycle
and opening up the next_recruitment cycle. This caused a problem with
one test failing when it tried to save a findable open course. It
was failing because the tests were setting the start date and the
application_from_date as today (using a date outside the
current current_recruitment_cycle) instead of using the date set
by the factories.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
