### PR TITLE
[239] Fix rollover reporting information

### DIFF
--- a/app/services/rollover_reporting_service.rb
+++ b/app/services/rollover_reporting_service.rb
@@ -10,17 +10,25 @@ class RolloverReportingService
   end
 
   def call
-    return {} if @rollover_scope.next.blank?
-
-    {
-      total: {
+    if @rollover_scope.next.blank?
+      { total: {
+          published_courses: 0,
+          new_courses_published: 0,
+          deleted_courses: 0,
+          existing_courses_in_draft: 0,
+          existing_courses_in_review: 0,
+        } }
+    else
+      {
+        total: {
           published_courses: published_courses_count,
           new_courses_published: new_courses_published_count,
           deleted_courses: deleted_courses_count,
           existing_courses_in_draft: existing_courses_in_draft_count,
           existing_courses_in_review: existing_courses_in_review,
-      },
-    }
+        },
+      }
+    end
   end
 
   private_class_method :new

--- a/spec/services/rollover_reporting_service_spec.rb
+++ b/spec/services/rollover_reporting_service_spec.rb
@@ -75,7 +75,15 @@ describe RolloverReportingService do
 
     context "if there is no next recruitment cycle" do
       it "returns an empty object" do
-        expect(result).to eq({})
+        expect(result).to eq({
+                                total: {
+                                  published_courses: 0,
+                                  new_courses_published: 0,
+                                  deleted_courses: 0,
+                                  existing_courses_in_draft: 0,
+                                  existing_courses_in_review: 0,
+                                },
+                              })
       end
     end
   end


### PR DESCRIPTION
## Context
There was an error in Publish performance dashboard where the page failed
to load because the next recruitment cycle is not created until we do
rollover again.

We decided that this should really be handled the api and instead of
attempting to count data that doesn't exist we decided that the guard
would instead return a default data structure with zero out figures.

We tested this locally and this worked with publish because the rollover
tab is hidden from the user until the next cycle is created and we
are in rollover state.

Co-authored-by: SamJamCul <samuel.culley@digital.education.gov.uk>
Co-authored-by: Jonathan Filar <58793682+JonF1@users.noreply.github.com>

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
