### PR TITLE
Add SETTINGS__SKYLIGHT__ENABLE env variable

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -312,6 +312,13 @@
       "metadata": {
         "description": "Skylight auth Key."
       }
+    },
+    "settingsSkylightEnable": {
+      "type": "bool",
+      "defaultValue": "true",
+      "metadata": {
+        "description": "Enable Skylight?"
+      }
     }
   },
   "variables": {
@@ -557,6 +564,10 @@
               {
                 "name": "SETTINGS__SKYLIGHT__AUTHENTICATION",
                 "value": "[parameters('settingsSkylightAuthentication')]"
+              },
+              {
+                "name": "SETTINGS__SKYLIGHT__ENABLE",
+                "value": "[parameters('settingsSkylightEnable')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

Add SETTINGS__SKYLIGHT__ENABLE environment variable in Arm template, which will enable skylight tracing

### Changes proposed in this pull request

set SETTINGS__SKYLIGHT__ENABLE environment variable in Arm template

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
