### PR TITLE
Change dbServerCpuCores from string to int

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -315,7 +315,7 @@
     },
     "dbServerCpuCores":{
       "type": "int",
-      "defaultValue": "2",
+      "defaultValue": 2,
       "metadata": {
       "description": "Configure Number of database server CPU"
       }


### PR DESCRIPTION
### Context

Change dbServerCpuCores from type string to int

### Changes proposed in this pull request

Change dbServerCpuCores from type string to int

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
