### PR TITLE
[0254] Amended 2020 financial incentives

### DIFF
--- a/app/services/subjects/financial_incentive_creator_service.rb
+++ b/app/services/subjects/financial_incentive_creator_service.rb
@@ -1,51 +1,57 @@
 module Subjects
   class FinancialIncentiveCreatorService
-    def initialize(subject: Subject, financial_incentive: FinancialIncentive)
+    def initialize(subject: Subject, financial_incentive: FinancialIncentive, year:)
       @subject = subject
       @financial_incentive = financial_incentive
+      @year = year
+    end
+
+    def subject_and_financial_incentives
+      subject_and_financial_incentives = {
+        2020 => {
+          ["Primary with mathematics"] => {
+            bursary_amount: "6000",
+          },
+          %w[Biology Classics] => {
+            bursary_amount: "26000",
+          },
+          %w[French German Spanish] => {
+            bursary_amount: "26000",
+            scholarship: "28000",
+            early_career_payments: "2000",
+          },
+          %w[Computing] => {
+            bursary_amount: "26000",
+            scholarship: "28000",
+          },
+          %w[Geography] => {
+            bursary_amount: "15000",
+            scholarship: "17000",
+          },
+          ["Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)"] => {
+            bursary_amount: "26000",
+            early_career_payments: "2000",
+          },
+          ["Art and design", "Business studies", "History", "Music", "Religious education"] => {
+            bursary_amount: "9000",
+          },
+          %w[English] => {
+            bursary_amount: "12000",
+          },
+          ["Design and technology"] => {
+            bursary_amount: "15000",
+          },
+          %w[Chemistry Mathematics Physics] => {
+            bursary_amount: "26000",
+            scholarship: "28000",
+            early_career_payments: "2000",
+          },
+        },
+      }
+      subject_and_financial_incentives[@year] || {}
     end
 
     def execute
-      subject_and_financial_incentives = {
-        ["Primary with mathematics"] => {
-          bursary_amount: "6000",
-        },
-        %w[Biology Classics] => {
-          bursary_amount: "26000",
-        },
-        %w[French German Spanish] => {
-          bursary_amount: "26000",
-          scholarship: "28000",
-          early_career_payments: "2000",
-        },
-        %w[Computing] => {
-          bursary_amount: "26000",
-          scholarship: "28000",
-        },
-        %w[Geography] => {
-          bursary_amount: "15000",
-          scholarship: "17000",
-        },
-        ["Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)"] => {
-          bursary_amount: "26000",
-          early_career_payments: "2000",
-        },
-        ["Art and design", "Business studies", "History", "Music", "Religious education"] => {
-          bursary_amount: "9000",
-        },
-        %w[English] => {
-          bursary_amount: "12000",
-        },
-        ["Design and technology"] => {
-          bursary_amount: "15000",
-        },
-        %w[Chemistry Mathematics Physics] => {
-          bursary_amount: "26000",
-          scholarship: "28000",
-          early_career_payments: "2000",
-        },
-      }
-
       subject_and_financial_incentives.each do |subject_name, financial_incentive_attributes|
         @subject.where(subject_name: subject_name).each do |subject|
           @financial_incentive.find_or_create_by(subject: subject, **financial_incentive_attributes)

--- a/app/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb
+++ b/app/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service.rb
@@ -1,12 +1,18 @@
 module Subjects
   class FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService
-    def initialize(financial_incentive: FinancialIncentive)
+    def initialize(financial_incentive: FinancialIncentive, year:)
       @financial_incentive = financial_incentive
+      @year = year
+    end
+
+    def subject_with_subject_knowledge_enhancement_course_available
+      subject_with_subject_knowledge_enhancement_course_available = {
+        2020 => ["Primary with mathematics", "Biology", "Computing", "English", "Design and technology", "Geography", "Chemistry", "Mathematics", "Physics", "French", "German", "Spanish", "Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)", "Religious education"],
+      }
+      subject_with_subject_knowledge_enhancement_course_available[@year]
     end
 
     def execute
-      subject_with_subject_knowledge_enhancement_course_available = ["Primary with mathematics", "Biology", "Computing", "English", "Design and technology", "Geography", "Chemistry", "Mathematics", "Physics", "French", "German", "Spanish", "Italian", "Japanese", "Mandarin", "Russian", "Modern languages (other)", "Religious education"]
-
       financial_incentives = @financial_incentive.joins(:subject).where(subject: { subject_name: subject_with_subject_knowledge_enhancement_course_available })
       financial_incentives.update_all(subject_knowledge_enhancement_course_available: true)
     end

--- a/db/migrate/20191024143538_add_financial_incentive_to_subjects.rb
+++ b/db/migrate/20191024143538_add_financial_incentive_to_subjects.rb
@@ -1,7 +1,7 @@
 class AddFinancialIncentiveToSubjects < ActiveRecord::Migration[6.0]
   def up
     say_with_time "populating subjects finanical" do
-      Subjects::FinancialIncentiveCreatorService.new.execute
+      Subjects::FinancialIncentiveCreatorService.new(year: 2020).execute
     end
   end
 

--- a/db/migrate/20200115141035_add_subject_knowledge_enhancement_available_to_financial_incentive.rb
+++ b/db/migrate/20200115141035_add_subject_knowledge_enhancement_available_to_financial_incentive.rb
@@ -3,7 +3,7 @@ class AddSubjectKnowledgeEnhancementAvailableToFinancialIncentive < ActiveRecord
     add_column :financial_incentive, :subject_knowledge_enhancement_course_available, :boolean, null: false, default: false
 
     say_with_time "populating finanical incentive subject knowledge enhancement course available" do
-      Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+      Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new(year: 2020).execute
     end
   end
 end

--- a/db/migrate/20201005132433_remove_all_financial_incentive_records.rb
+++ b/db/migrate/20201005132433_remove_all_financial_incentive_records.rb
@@ -7,8 +7,8 @@ class RemoveAllFinancialIncentiveRecords < ActiveRecord::Migration[6.0]
 
   def down
     say_with_time "populating finanical incentive" do
-      Subjects::FinancialIncentiveCreatorService.new.execute
-      Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+      Subjects::FinancialIncentiveCreatorService.new(year: 2020).execute
+      Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new(year: 2020).execute
     end
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -21,8 +21,8 @@ next_recruitment_cycle = RecruitmentCycle.create(year: (current_recruitment_year
 
 Subjects::SubjectAreaCreatorService.new.execute
 Subjects::CreatorService.new.execute
-Subjects::FinancialIncentiveCreatorService.new.execute
-Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+Subjects::FinancialIncentiveCreatorService.new(year: 2020).execute
+Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new(year: 2020).execute
 
 superuser = User.create!(
   first_name: "Super",

--- a/spec/services/subjects/financial_incentive_creator_service_spec.rb
+++ b/spec/services/subjects/financial_incentive_creator_service_spec.rb
@@ -6,6 +6,7 @@ describe Subjects::FinancialIncentiveCreatorService do
     described_class.new(
       subject: subject_spy,
       financial_incentive: financial_incentive_spy,
+      year: 2020,
     )
   end
 

--- a/spec/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
+++ b/spec/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
@@ -5,6 +5,7 @@ describe Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailab
   let(:service) do
     described_class.new(
       financial_incentive: financial_incentive_spy,
+      year: 2020,
     )
   end
 

--- a/spec/support/reference_data.rb
+++ b/spec/support/reference_data.rb
@@ -25,8 +25,8 @@ RSpec.configure do |config|
   config.before(:all) do
     Subjects::SubjectAreaCreatorService.new.execute
     Subjects::CreatorService.new.execute
-    Subjects::FinancialIncentiveCreatorService.new.execute
-    Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new.execute
+    Subjects::FinancialIncentiveCreatorService.new(year: 2020).execute
+    Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new(year: 2020).execute
     if ENV["TEST_DATA_CACHE"]
       TestDataCache.create_and_cache_test_records
     end


### PR DESCRIPTION


### Context
2020 financial incentives

### Changes proposed in this pull request
Amended 2020 financial incentives
Retained and move it to its own chain

### Guidance to review
Nothing breaks, prep work before introducing 2021 financial incentives

#### Usage
##### Before
```ruby
Subjects::FinancialIncentiveCreatorService.new().execute
Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new().execute
```

##### After
```ruby
whatever = year
Subjects::FinancialIncentiveCreatorService.new(year: whatever).execute
Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService.new(year: whatever).execute
```

```ruby
FinancialIncentiveCreatorService
FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService
```
Retained the above two services with the ability to select any other year based financial incentives

### Checklist


- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
