### PR TITLE
Remove unused external contact info

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -216,22 +216,6 @@ class Provider < ApplicationRecord
     sites.size < Site::POSSIBLE_CODES.size
   end
 
-  def external_contact_info
-    attribute_names = %w[
-      address1
-      address2
-      address3
-      address4
-      postcode
-      region_code
-      telephone
-      email
-      website
-    ]
-
-    attributes.slice(*attribute_names)
-  end
-
   # This reflects the fact that organisations should actually be a has_one.
   def organisation
     organisations.first

--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -5,43 +5,8 @@ module API
 
       attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?,
                  :accredited_bodies, :train_with_us, :train_with_disability,
-                 :latitude, :longitude
-
-      attribute :address1 do
-        @object.external_contact_info["address1"]
-      end
-
-      attribute :address2 do
-        @object.external_contact_info["address2"]
-      end
-
-      attribute :address3 do
-        @object.external_contact_info["address3"]
-      end
-
-      attribute :address4 do
-        @object.external_contact_info["address4"]
-      end
-
-      attribute :postcode do
-        @object.external_contact_info["postcode"]
-      end
-
-      attribute :region_code do
-        @object.external_contact_info["region_code"]
-      end
-
-      attribute :telephone do
-        @object.external_contact_info["telephone"]
-      end
-
-      attribute :email do
-        @object.external_contact_info["email"]
-      end
-
-      attribute :website do
-        @object.external_contact_info["website"]
-      end
+                 :latitude, :longitude, :address1, :address2, :address3, :address4,
+                 :postcode, :region_code, :telephone, :email, :website
 
       attribute :recruitment_cycle_year do
         @object.recruitment_cycle.year

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -132,25 +132,6 @@ describe Provider, type: :model do
     end
   end
 
-  describe "#external_contact_info" do
-    it "returns the info from the provider record" do
-      provider = create(:provider)
-      expect(provider.external_contact_info).to(
-        eq(
-          "address1"    => provider.address1,
-          "address2"    => provider.address2,
-          "address3"    => provider.address3,
-          "address4"    => provider.address4,
-          "postcode"    => provider.postcode,
-          "region_code" => provider.region_code,
-          "telephone"   => provider.telephone,
-          "email"       => provider.email,
-          "website"     => provider.website,
-        ),
-      )
-    end
-  end
-
   describe "#update_changed_at" do
     let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 


### PR DESCRIPTION
### Context

This method used to branch between the contact info on the `Provider` 
itself and contact info from an enrichment if one existed.

It no longer does that so is uneeded now as the fields exist on the 
Provider.

### Changes proposed in this pull request

* Remove `Provider#external_contact_info`
* Serialize the fields directly in `V2:SerializableProvider`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally