### PR TITLE
Update 'with_salary' scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !/tmp/.keep
 
 .byebug_history
+.ruby-version
 coverage/
 
 config/settings.local.yml

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -184,7 +184,7 @@ class Course < ApplicationRecord
   scope :with_recruitment_cycle, ->(year) { joins(provider: :recruitment_cycle).where(recruitment_cycle: { year: year }) }
   scope :findable, -> { joins(:site_statuses).merge(SiteStatus.findable) }
   scope :with_vacancies, -> { joins(:site_statuses).merge(SiteStatus.with_vacancies) }
-  scope :with_salary, -> { where(program_type: :school_direct_salaried_training_programme) }
+  scope :with_salary, -> { where(program_type: %i[school_direct_salaried_training_programme pg_teaching_apprenticeship]) }
   scope :with_study_modes, ->(study_modes) do
     where(study_mode: Array(study_modes) << "full_time_or_part_time")
   end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -167,6 +167,10 @@ FactoryBot.define do
       program_type { %i[pg_teaching_apprenticeship school_direct_salaried_training_programme].sample }
     end
 
+    trait :non_salary_type_based do
+      program_type { %i[scitt_programme higher_education_programme school_direct_training_programme].sample }
+    end
+
     trait :applications_open_from_not_set do
       applications_open_from { nil }
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -848,7 +848,7 @@ describe Course, type: :model do
       end
 
       it "only returns salaried training programme" do
-        expect(subject).to contain_exactly(course_school_direct_salaried_training_programme)
+        expect(subject).to contain_exactly(course_school_direct_salaried_training_programme, course_pg_teaching_apprenticeship)
       end
     end
 

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -272,7 +272,7 @@ describe "GET v3/courses" do
     let(:request_path) { "/api/v3/courses?filter[funding]=salary" }
 
     context "with a salaried course" do
-      let(:course_with_salary) { create(:course, :with_salary, site_statuses: [findable_status], enrichments: [published_enrichment]) }
+      let(:course_with_salary) { create(:course, :salary_type_based, site_statuses: [findable_status], enrichments: [published_enrichment]) }
 
       before do
         course_with_salary
@@ -287,7 +287,7 @@ describe "GET v3/courses" do
     end
 
     context "with a non-salaried course" do
-      let(:non_salary_course) { create(:course, site_statuses: [findable_status], enrichments: [published_enrichment]) }
+      let(:non_salary_course) { create(:course, :non_salary_type_based, site_statuses: [findable_status], enrichments: [published_enrichment]) }
 
       before do
         non_salary_course


### PR DESCRIPTION
### Context
_Apply_ trello card: https://trello.com/c/LvY0EtlQ/2332-bug-salaried-courses-filter 
Slack thread: https://ukgovernmentdfe.slack.com/archives/CQA64BETU/p1602522466230000

London Metropolitan University is an accredited body for some courses. When a user searches by provider ('London Metropolitan University') and then filters the results by 'courses with salary' then any courses that are apprenticeships are not being returned.

Find considers salaried courses to include apprenticeships.
https://github.com/DFE-Digital/find-teacher-training/blob/master/app/decorators/course_decorator.rb#L78

### Changes proposed in this pull request
Return apprenticeship courses when calling the `with_salary` scope on the Course model

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
