### PR TITLE
Add nested Arm template for App service plan metric

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -319,7 +319,15 @@
       "metadata": {
       "description": "Configure Number of database server CPU"
       }
-    }
+    },
+  "actionGroupName": {
+      "type": "string",
+      "defaultValue": "",
+      "minLength": 1,
+      "metadata": {
+          "description": "Name of ActionGroup to send notification"
+      }
+  }
   },
   "variables": {
     "deploymentUrlBase": "https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/templates/",
@@ -1038,6 +1046,36 @@
             "value": [
               "[resourceId(parameters('vnetResourceGroup'),'Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('vnetSubnetName'))]"
             ]
+          }
+        }
+      }
+    },
+    {
+      "name": "app-service-metric-rule-alart",
+      "condition": "[greater(length(variables('appServicePlanName')), 0)]",
+      "type": "Microsoft.Resources/deployments",
+      "apiVersion": "2017-05-10",
+      "dependsOn": [
+        "app-service-plan"
+      ],
+      "properties": {
+        "mode": "Incremental",
+        "templateLink": {
+          "uri": "[concat(variables('deploymentUrlBase'), 'metric-alert.json')]",
+          "contentVersion": "1.0.0.0"
+        },
+        "parameters": {
+          "subscription": {
+            "value": "[subscription().subscriptionId]"
+          },
+          "actionGroupName": {
+            "value": "[parameters('actionGroupName')]"
+          },
+          "resourceInstance": {
+            "value": "[variables('appServicePlanName')]"
+          },
+          "resourceGroup": {
+            "value": "[resourceGroup().name]"
           }
         }
       }


### PR DESCRIPTION
### Context

Add nested arm template for App Service Plan metric alert. This allows alert to be sent, when certain threshold is reached e.g. CPU utilisation reaches over 80%

### Changes proposed in this pull request

Add nested arm template for App Service Plan metric alert

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
