### PR TITLE
Ignore ConcurrentMigration errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ ADD . $APP_HOME/
 
 COPY --from=middleman /public/ $APP_HOME/public/
 
-CMD bundle exec rails db:migrate && bundle exec rails server -b 0.0.0.0
+CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0

--- a/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
+++ b/lib/tasks/migrate_swallowing_concurrent_migration_exceptions.rake
@@ -1,0 +1,14 @@
+# rubocop:disable Lint/SuppressedException
+namespace :db do
+  namespace :migrate do
+    desc "Run db:migrate but ignore ActiveRecord::ConcurrentMigrationError errors"
+    task ignore_concurrent_migration_exceptions: :environment do
+      begin
+        Rake::Task["db:migrate"].invoke
+      rescue ActiveRecord::ConcurrentMigrationError
+        # Do nothing
+      end
+    end
+  end
+end
+# rubocop:enable Lint/SuppressedException


### PR DESCRIPTION
### Context

We often get concurrent migration errors when the multiple instances we
deploy to all try to migrate the DB.


### Changes proposed in this pull request

Ignore these errors.

[The Apply team have successfully used this approach.](https://github.com/DFE-Digital/apply-for-teacher-training/pull/1058)

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
