### PR TITLE
[252] Add includes for course index

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -1,5 +1,9 @@
 class CourseSearchService
-  def initialize(filter:, sort: nil, course_scope: Course)
+  def initialize(
+    filter:,
+    sort: nil,
+    course_scope: Course
+  )
     @filter = filter || {}
     @course_scope = course_scope
     @sort = Set.new(sort&.split(","))
@@ -26,7 +30,12 @@ class CourseSearchService
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
     # This prevents 'PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list'
-    outer_scope = Course.where(id: scope.select(:id))
+    outer_scope = Course.includes(
+      :enrichments,
+      subjects: [:financial_incentive],
+      site_statuses: [:site],
+      provider: %i[recruitment_cycle ucas_preferences],
+    ).where(id: scope.select(:id))
 
     if provider_name.present?
       outer_scope = outer_scope


### PR DESCRIPTION
### Context

Part of work to improve performance of the V3 endpoints.

### Changes proposed in this pull request

Include relationships in the course query in `v3::CoursesController#index`

The CourseSearchService handles this query. This commit adds includes to the outer query scope within the service. This reduces the N+1 issues but doesn't relate to the includes parameters accepted at the controller. This endpoint is used by Find so we probably don't need that kind of flexibility.

The performance improvement we'll get in production is difficult to gauge as we don't have parity on the QA environment but locally there is a significant improvement and query definitely looks better in Skylight. I'll get some better figures from Kibana once it's deployed.

Before:
Local: 2020-10-19 16:44:33.995788 I [27181:puma threadpool 002] (1.447s) API::V3::CoursesController -- Completed #index

![image](https://user-images.githubusercontent.com/5216/96474044-42963a00-122a-11eb-934b-e345ad108429.png)

After: 
2020-10-19 17:08:01.947578 I [27181:puma threadpool 003] (677.6ms) API::V3::CoursesController -- Completed #index

![image](https://user-images.githubusercontent.com/5216/96476956-d4ec0d00-122d-11eb-933f-c835d4b5981f.png)

### Guidance to review

Find should still work. I've run this branch on QA and all seems good.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
