### PR TITLE
[342] revert duration/duration_ms formatting for logstash

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -26,12 +26,6 @@ class LogStashFormatter < SemanticLogger::Formatters::Raw
     end
   end
 
-  # The value here appears to break logging to logstash / elasticsearch
-  def format_duration
-    hash[:duration] = hash[:duration_ms]
-    hash[:duration_ms] = nil
-  end
-
   def format_job_data
     hash[:job_id] = RequestStore.store[:job_id] if RequestStore.store[:job_id].present?
     hash[:job_queue] = RequestStore.store[:job_queue] if RequestStore.store[:job_queue].present?
@@ -40,7 +34,6 @@ class LogStashFormatter < SemanticLogger::Formatters::Raw
   def call(log, logger)
     super(log, logger)
     format_job_data
-    format_duration
     format_exception
     format_json_message_context
     format_backtrace


### PR DESCRIPTION
Turns out this approach was not compatible with the standard way of logging and
can result in breaking the indexing for the 'duration' field, breaking
aggregation and other operations reliant on the 'duration' field. The correct
approach is to leave 'duration_ms', fix any discrepencies in the logit filters
to ensure that it's indexed as a number, and then use 'duration_ms' for
aggregation.

### Context

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
