### PR TITLE
[203] Mailer queue is 'mailers'

### DIFF
--- a/app/services/generate_and_send_magic_link_service.rb
+++ b/app/services/generate_and_send_magic_link_service.rb
@@ -22,6 +22,6 @@ private
   def send_magic_link(user)
     MagicLinkEmailMailer
       .magic_link_email(user)
-      .deliver_later(queue: "mailer")
+      .deliver_later
   end
 end

--- a/app/services/notification_service/course_published.rb
+++ b/app/services/notification_service/course_published.rb
@@ -14,7 +14,7 @@ module NotificationService
         CoursePublishEmailMailer.course_publish_email(
           course,
           user,
-        ).deliver_later(queue: "mailer")
+        ).deliver_later
       end
     end
 

--- a/app/services/notification_service/course_sites_updated.rb
+++ b/app/services/notification_service/course_sites_updated.rb
@@ -17,7 +17,7 @@ module NotificationService
           previous_site_names: previous_site_names,
           updated_site_names: updated_site_names,
           recipient: user,
-          ).deliver_later(queue: "mailer")
+          ).deliver_later
       end
     end
 

--- a/app/services/notification_service/course_subjects_updated.rb
+++ b/app/services/notification_service/course_subjects_updated.rb
@@ -22,7 +22,7 @@ module NotificationService
           previous_subject_names: previous_subject_names,
           previous_course_name: previous_course_name,
           recipient: user,
-        ).deliver_later(queue: "mailer")
+        ).deliver_later
       end
     end
 

--- a/app/services/notification_service/course_updated.rb
+++ b/app/services/notification_service/course_updated.rb
@@ -19,7 +19,7 @@ module NotificationService
             original_value: original_value,
             updated_value: updated_value,
             recipient: user,
-          ).deliver_later(queue: "mailer")
+          ).deliver_later
         end
       end
     end

--- a/app/services/notification_service/course_vacancies_updated.rb
+++ b/app/services/notification_service/course_vacancies_updated.rb
@@ -30,7 +30,7 @@ module NotificationService
           user: user,
           datetime: DateTime.now,
           vacancies_filled: vacancies_filled,
-          ).deliver_later(queue: "mailer")
+          ).deliver_later
       end
     end
 
@@ -42,7 +42,7 @@ module NotificationService
           datetime: DateTime.now,
           vacancies_opened: vacancies_opened,
           vacancies_closed: vacancies_closed,
-        ).deliver_later(queue: "mailer")
+        ).deliver_later
       end
     end
 

--- a/app/services/notification_service/course_withdrawn.rb
+++ b/app/services/notification_service/course_withdrawn.rb
@@ -15,7 +15,7 @@ module NotificationService
           course,
           user,
           DateTime.now,
-        ).deliver_later(queue: "mailer")
+        ).deliver_later
       end
     end
 

--- a/app/services/send_welcome_email_service.rb
+++ b/app/services/send_welcome_email_service.rb
@@ -10,7 +10,7 @@ class SendWelcomeEmailService
 
     WelcomeEmailMailer.
       send_welcome_email(first_name: current_user.first_name, email: current_user.email).
-      deliver_later(queue: "mailer")
+      deliver_later
 
     current_user.update(
       welcome_email_date_utc: Time.now.utc,

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@
   - geocoding
   - save_statistic
   - mailer
+  - mailers

--- a/spec/requests/api/v2/sessions/create_by_magic_spec.rb
+++ b/spec/requests/api/v2/sessions/create_by_magic_spec.rb
@@ -57,7 +57,7 @@ describe "POST /sessions/create_by_magic" do
       } .to(
         have_enqueued_email(WelcomeEmailMailer, :send_welcome_email)
             .with { user.reload; { first_name: user.first_name, email: user.email } }
-            .on_queue(:mailer),
+            .on_queue(:mailers),
       )
     end
 

--- a/spec/services/generate_and_send_magic_link_service_spec.rb
+++ b/spec/services/generate_and_send_magic_link_service_spec.rb
@@ -19,7 +19,7 @@ describe GenerateAndSendMagicLinkService do
     } .to(
       have_enqueued_email(MagicLinkEmailMailer, :magic_link_email)
         .with { user.reload } # Use block to reload user after queue processing
-        .on_queue(:mailer),
+        .on_queue(:mailers),
     )
   end
 end

--- a/spec/services/notification_service/course_published_spec.rb
+++ b/spec/services/notification_service/course_published_spec.rb
@@ -80,7 +80,7 @@ module NotificationService
             expect(CoursePublishEmailMailer)
               .to receive(:course_publish_email)
               .with(course, subscribed_user).and_return(mailer = double)
-            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            expect(mailer).to receive(:deliver_later)
             described_class.call(course: course)
           end
 

--- a/spec/services/notification_service/course_sites_updated_spec.rb
+++ b/spec/services/notification_service/course_sites_updated_spec.rb
@@ -95,7 +95,7 @@ module NotificationService
                       previous_site_names: previous_site_names,
                       updated_site_names: updated_site_names,
                     ).and_return(mailer = double)
-            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            expect(mailer).to receive(:deliver_later)
             described_class.call(
               course: course,
               previous_site_names: previous_site_names,

--- a/spec/services/notification_service/course_subjects_updated_spec.rb
+++ b/spec/services/notification_service/course_subjects_updated_spec.rb
@@ -94,8 +94,8 @@ module NotificationService
                 previous_subject_names: previous_subject_names,
                 previous_course_name: previous_course_name,
                 recipient: subscribed_user,
-).and_return(mailer = double)
-            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            ).and_return(mailer = double)
+            expect(mailer).to receive(:deliver_later)
 
             call_service
           end

--- a/spec/services/notification_service/course_updated_spec.rb
+++ b/spec/services/notification_service/course_updated_spec.rb
@@ -74,7 +74,7 @@ module NotificationService
                 updated_value: "7_to_14",
                 recipient: user,
               ).and_return(mailer = double)
-            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            expect(mailer).to receive(:deliver_later)
           end
 
           course.age_range_in_years = "7_to_14"
@@ -93,7 +93,7 @@ module NotificationService
                 updated_value: "must_have_qualification_at_application_time",
                 recipient: subscribed_user1,
               ).and_return(mailer = double)
-            expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+            expect(mailer).to receive(:deliver_later)
           end
 
           course.english = "must_have_qualification_at_application_time"

--- a/spec/services/notification_service/course_vacancies_updated_spec.rb
+++ b/spec/services/notification_service/course_vacancies_updated_spec.rb
@@ -68,7 +68,7 @@ module NotificationService
                     datetime: DateTime.now,
                     vacancies_filled: true,
                   ).and_return(mailer = double)
-          expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+          expect(mailer).to receive(:deliver_later)
         end
 
         service_call

--- a/spec/services/notification_service/course_withdrawn_spec.rb
+++ b/spec/services/notification_service/course_withdrawn_spec.rb
@@ -60,7 +60,7 @@ module NotificationService
               user,
               DateTime.now,
             ).and_return(mailer = double)
-          expect(mailer).to receive(:deliver_later).with(queue: "mailer")
+          expect(mailer).to receive(:deliver_later)
         end
 
         service_call

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -44,7 +44,7 @@ describe SendWelcomeEmailService do
     end
 
     before do
-      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, deliver_later: { queue: "mailer" })
+      allow(WelcomeEmailMailer).to receive_message_chain(:send_welcome_email, :deliver_later)
       described_class.call(current_user: current_user_spy)
     end
 


### PR DESCRIPTION
### Context

The default mailer queue for Rails is ['mailers' not 'mailer'](https://github.com/rails/rails/blob/ced687fe710b2f3d6cf0d0e978bdb531357299e4/actionmailer/lib/action_mailer/delivery_job.rb#L7). We should use that instead of customising the queue every time we send a mail.

### Changes proposed in this pull request

* Remove all of the `queue: mailer` arguments
* Set the queue name to `mailers` in sidekiq.yml
* Leave the old `mailer` queue in sidekiq.yml for now to let that queue drain. I'll remove that in a subsequent PR.

### Guidance to review

Run sidekiq locally and then `WelcomeEmailMailer.send_welcome_email(first_name: "Dave", email: <your email>).deliver_async`. `Sidekiq::Queue.all.map(&:size)` should all be 0. I'll check this again on QA, staging, production when it's deployed.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
