### PR TITLE
[203] Remove 'mailer' sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,5 +3,4 @@
   - default
   - geocoding
   - save_statistic
-  - mailer
   - mailers


### PR DESCRIPTION
### Context

We were using this queue for mailer jobs but it isn't default so we changed it in a83a0a8.

### Changes proposed in this pull request

This removes the old queue which should now be empty.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
