### PR TITLE
[389] Bump max_per_page value to 500

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -28,7 +28,7 @@ module API
         end
 
         def max_per_page
-          100
+          500
         end
 
         def page

--- a/swagger/public_v1/component_schemas/Pagination.yml
+++ b/swagger/public_v1/component_schemas/Pagination.yml
@@ -8,5 +8,5 @@ properties:
     example: 3
   per_page:
     type: integer
-    description: The number items to display on a page. Defaults to 100. Maximum is 100, if the value is greater that the maximum allowed it will fallback to 100.
+    description: The number items to display on a page. Defaults to 100. Maximum is 500, if the value is greater that the maximum allowed it will fallback to 500.
     example: 10


### PR DESCRIPTION
### Context
https://trello.com/c/JrRxAcy7/389-perpage-query-param-doesnt-do-anything-on-providersindex

### Changes proposed in this pull request
Increase max_per_page to 500 as suggested by @dankmitchell 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
