### PR TITLE
[372] Fix course enrichment bug

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -94,8 +94,7 @@ class Course < ApplicationRecord
            source: :subject,
            class_name: "ModernLanguagesSubject"
 
-  has_many :enrichments,
-           class_name: "CourseEnrichment" do
+  has_many :enrichments, class_name: "CourseEnrichment" do
     def find_or_initialize_draft
       # This is a ruby search as opposed to an AR search, because calling `draft`
       # will return a new instance of a CourseEnrichment object which is different
@@ -107,7 +106,7 @@ class Course < ApplicationRecord
     end
 
     def new_draft_attributes
-      latest_published_enrichment = latest_first.published.first
+      latest_published_enrichment = most_recent.published.first
 
       if latest_published_enrichment.present?
         latest_published_enrichment_attributes = latest_published_enrichment

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -19,7 +19,7 @@ class CourseEnrichment < ApplicationRecord
 
   belongs_to :course
 
-  scope :latest_first, -> { order(created_at: :desc, id: :desc) }
+  scope :most_recent, -> { order(created_at: :desc, id: :desc) }
   scope :draft, -> { where(status: "draft").or(rolled_over) }
 
   def draft?

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -6,7 +6,7 @@ module API
       class << self
         def enrichment_attribute(name, enrichment_name = name)
           attribute name do
-            @object.enrichments.last&.__send__(enrichment_name)
+            @object.enrichments.most_recent&.first&.public_send(enrichment_name)
           end
         end
       end

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -37,7 +37,7 @@ module Courses
     end
 
     def copy_latest_enrichment_to_course(course, new_course)
-      last_enrichment = course.enrichments.latest_first.first
+      last_enrichment = course.enrichments.most_recent.first
       return if last_enrichment.blank?
 
       @enrichments_copy_to_course.execute(enrichment: last_enrichment, new_course: new_course)

--- a/db/migrate/20191007125535_mark_withdrawn_courses_as_withdrawn.rb
+++ b/db/migrate/20191007125535_mark_withdrawn_courses_as_withdrawn.rb
@@ -10,7 +10,7 @@ class MarkWithdrawnCoursesAsWithdrawn < ActiveRecord::Migration[6.0]
       end
 
       courses_with_all_suspended_no_vacancy_sites.each do |course|
-        course.enrichments.latest_first.first.withdraw
+        course.enrichments.most_recent.first.withdraw
       end
     end
   end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -54,15 +54,12 @@ describe CourseEnrichment, type: :model do
     end
   end
 
-  describe ".latest_first" do
-    let!(:old_enrichment) do
-      create(:course_enrichment, :published, created_at: Date.yesterday)
-    end
+  describe ".most_recent" do
+    let!(:old_enrichment) { create(:course_enrichment, :published, created_at: Date.yesterday) }
     let!(:new_enrichment) { create(:course_enrichment, :published) }
 
-    it "returns the new enrichment first" do
-      expect(CourseEnrichment.latest_first.first).to eq new_enrichment
-      expect(CourseEnrichment.latest_first.last).to eq old_enrichment
+    it "orders by created_at descending" do
+      expect(CourseEnrichment.most_recent).to eq([new_enrichment, old_enrichment])
     end
   end
 


### PR DESCRIPTION
### Context
When users update a course, the changes would sometimes not show up in preview mode. This was because `API::V2::SerializableCourse.enrichment_attribute` didn't explicitly request for the latest course enrichment record (ordered by created_at). Using `last()` on its own doesn't guarantee the order we want.

With regards to performance, since the same query is executed multiple times within the same action, ActiveRecord will cache the query `@object.enrichments.most_recent&.first&.public_send(enrichment_name)`, helping us to avoid the N + 1 problem.

### Changes proposed in this pull request
Use an ordered scope instead of calling `last()` to fetch the latest course enrichment record.

Introducing this fix also caused other tests to fail as they depended on `API::V2::SerializableCourse.enrichment_attribute` using the `last()` approach.

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally