### PR TITLE
[320] Include course_code in canonical order

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -143,11 +143,11 @@ class Course < ApplicationRecord
   end
 
   scope :ascending_canonical_order, -> do
-    joins(:provider).merge(Provider.by_name_ascending).order("name asc")
+    joins(:provider).merge(Provider.by_name_ascending).order("name asc, course_code asc")
   end
 
   scope :descending_canonical_order, -> do
-    joins(:provider).merge(Provider.by_name_descending).order("name desc")
+    joins(:provider).merge(Provider.by_name_descending).order("name desc, course_code desc")
   end
 
   scope :accredited_body_order, ->(provider_name) do


### PR DESCRIPTION
### Context

This makes ordering of identically named courses deterministic. Without including the course code we get bugs in paging for identically named courses. This is quite common as the course is often named with the subject.

### Changes proposed in this pull request

When ordering canonically (ie provider name and course name) also include the `course_code`.

### Guidance to review

Visit:
https://www.find-postgraduate-teacher-training.service.gov.uk/results?fulltime=false&hasvacancies=false&l=3&parttime=false&qualifications%5B%5D=QtsOnly&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&query=CTSN+-+Cambridge+Teaching+Schools+Network&senCourses=false

There are three computing courses towards the bottom of page one. Click into page two and one of the courses "Computing (28B8)" re-appears at the top of page two. There is another computing course "Computing (3D72)" that doesn't appear as the ordering bug has placed it on page one when page two is viewed. This is visible at the top of page two with this fix applied.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
