### PR TITLE
Split Build & Deploy GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,150 +1,91 @@
-name: Build, test and push Docker images
+name: Build
 
 on:
   push:
     branches:
       - master
 
-env:
-  DOCKER_COMPOSE: docker-compose -f docker-compose.yml
-  DOCKER_IMAGE: dfedigital/teacher-training-api
-  DOCKER_IMAGE_MAILER: dfedigital/teacher-training-bg-mailer
-  DOCKER_IMAGE_GEOCODE: dfedigital/teacher-training-bg-geocode
-  DOCKER_IMAGE_JOBS: dfedigital/teacher-training-bg-jobs
-  CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-  # Below settings are for compatibility with the azure pipeline. Currently
-  # used by docker-compose.yml until we change the variable names.
-  dockerHubUsername: dfedigital
-  dockerHubImageName: teacher-training-api
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_IMAGE: dfedigital/teacher-training-api
 
     steps:
     - uses: actions/checkout@v2
-    - name: Pin Terraform version
-      uses: hashicorp/setup-terraform@v1
-      with:
-        terraform_version: 0.12.29
 
     - name: Get values for current commit
       run: |
         GIT_SHA_SHORT=$(echo ${{github.sha}} | cut -c 1-7)
         GIT_REF=${{github.ref}}
         GIT_BRANCH=${GIT_REF##*/}
-        echo "::set-env name=GIT_SHA_SHORT::$GIT_SHA_SHORT"
-        echo "::set-env name=GIT_BRANCH::$GIT_BRANCH"
-        echo "::set-env name=SHA_TAG::paas-$GIT_SHA_SHORT"
-        echo "::set-env name=BRANCH_TAG::paas-$GIT_BRANCH"
 
-    - name: Login to docker hub
-      run: echo "${{secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN}}" | docker login -u ${{secrets.DOCKERHUB_USERNAME}} --password-stdin
+        echo "GIT_SHA_SHORT=$GIT_SHA_SHORT" >> $GITHUB_ENV
+        echo "GIT_BRANCH=$GIT_BRANCH" >> $GITHUB_ENV
+        echo "SHA_TAG=paas-$GIT_SHA_SHORT" >> $GITHUB_ENV
+        echo "BRANCH_TAG=paas-$GIT_BRANCH" >> $GITHUB_ENV
 
-    - name: "docker pull ${{env.DOCKER_IMAGE}}:${{env.BRANCH_TAG}}"
-      run: docker pull $DOCKER_IMAGE:BRANCH_TAG || true
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
 
-    - name: "docker pull ${{env.DOCKER_IMAGE}}-middleman:master"
-      run: docker pull $DOCKER_IMAGE-middleman:master || true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
 
-    - name: "docker-compose build middleman"
-      run: $DOCKER_COMPOSE build middleman
-      env:
-        GIT_BRANCH: ${{env.BRANCH_TAG}}
+    - name: Build Teacher-Training-Api-Middleman
+      uses: docker/build-push-action@v2.1.0
+      with:
+        tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+        pull: true
+        push: true
+        target: middleman
+        cache-from: |
+          ${{ env.DOCKER_IMAGE}}-middleman:master
+          ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+        build-args: BUILDKIT_INLINE_CACHE=1
 
-    - name: "docker-compose build"
-      run: $DOCKER_COMPOSE build web
-      env:
-        GIT_BRANCH: ${{env.BRANCH_TAG}}
+    - name: Build Teacher-Training-Api
+      uses: docker/build-push-action@v2.1.0
+      with:
+        tags: |
+          ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          ${{ env.DOCKER_IMAGE}}:${{ env.SHA_TAG }}
+        pull: true
+        push: true
+        cache-from: |
+          ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          ${{ env.DOCKER_IMAGE}}-middleman:master
+          ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+        build-args: BUILDKIT_INLINE_CACHE=1
 
     - name: Setup tests
       run: |
-        $DOCKER_COMPOSE up --no-build -d
-        $DOCKER_COMPOSE exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
-        $DOCKER_COMPOSE exec -T web /bin/sh -c "bundle exec rails db:setup"
-        $DOCKER_COMPOSE exec -T web /bin/sh -c "apk --no-cache add curl"
-        $DOCKER_COMPOSE exec -T web /bin/sh -c "bundle exec rake cc:setup"
+        docker pull ${DOCKER_IMAGE}:${BRANCH_TAG}
+        docker pull ${DOCKER_IMAGE}-middleman:${BRANCH_TAG}
+
+        docker-compose up --no-build -d
+        docker-compose exec -T web /bin/sh -c "./wait-for-command.sh -c 'nc -z db 5432' -s 0 -t 20"
+        docker-compose exec -T web /bin/sh -c "bundle exec rails db:setup"
+        docker-compose exec -T web /bin/sh -c "apk --no-cache add curl"
+        docker-compose exec -T web /bin/sh -c "bundle exec rake cc:setup"
       env:
         GIT_BRANCH: ${{env.BRANCH_TAG}}
 
     - name: Run tests
       run: |
-        $DOCKER_COMPOSE exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
-        $DOCKER_COMPOSE exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
-        $DOCKER_COMPOSE exec -T web /bin/sh -c 'bundle exec rake "parallel:spec[,, -O .azure_parallel]"'
+        docker-compose exec -T web /bin/sh -c 'bundle config --local disable_exec_load true'
+        docker-compose exec -T web /bin/sh -c 'bundle exec rake parallel:setup'
+        docker-compose exec -T web /bin/sh -c 'bundle exec rake "parallel:spec[,, -O .azure_parallel]"'
       env:
         GIT_BRANCH: ${{env.BRANCH_TAG}}
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
-    - name: Tag docker images
-      run: |
-        docker tag $DOCKER_IMAGE:$BRANCH_TAG $DOCKER_IMAGE:$SHA_TAG
-
-    - name: Push docker images to Docker Hub
-      run: |
-        docker push $DOCKER_IMAGE:$SHA_TAG
-        docker push $DOCKER_IMAGE:$BRANCH_TAG
-        [[ "$BRANCH_TAG" == "paas-master" ]] && docker push $DOCKER_IMAGE-middleman:$BRANCH_TAG
-
-    - name: Install Terraform CloudFoundry Provider
-      run: |
-        mkdir -p $HOME/.terraform.d/plugins/linux_amd64
-        cd $HOME/.terraform.d/plugins/linux_amd64
-        wget -q -O zipfile https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.4/terraform-provider-cloudfoundry_0.12.4_linux_amd64.zip && unzip zipfile && rm zipfile
-
-      env:
-        CF_PROVIDER: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
-
-    - name: Terraform init
-      run: |
-          terraform init \
-           -backend-config=storage_account_name=${{ env.BACKEND_STORAGE_ACCOUNT_NAME }} \
-           -backend-config=access_key=${{ env.BACKEND_ACCESS_KEY }} \
-           -backend-config=key=${{ env.BACKEND_KEY }} \
-            ${{ env.PAAS_TF_DIR }}
-      env:
-        BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
-        BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
-        BACKEND_KEY: paas-ttapi.tfstate
-        PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
-
-    - name: Terraform plan
-      run: |
-          terraform plan -var-file=${{ env.PAAS_TF_DIR }}/${{ env.TERRAFORM_VAR_FILE }} \
-            ${{ env.PAAS_TF_DIR }}
-      env:
-        BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
-        BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
-        BACKEND_KEY: paas-ttapi.tfstate
-        PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
-        TERRAFORM_VAR_FILE: terraform_qa.tfvars
-        TF_VAR_ttapi_image_tag: ${{env.SHA_TAG}}
-        TF_VAR_api_url: https://api.london.cloud.service.gov.uk
-        TF_VAR_docker_image: ${{ env.DOCKER_IMAGE }}:${{ env.SHA_TAG }}
-        TF_VAR_user: ${{ secrets.TF_VAR_user }}
-        TF_VAR_password: ${{ secrets.TF_VAR_password }}
-        TF_VAR_SECRET_KEY_BASE: ${{ secrets.TF_VAR_SECRET_KEY_BASE }}
-        TF_VAR_SENTRY_DSN: ${{ secrets.TF_VAR_SENTRY_DSN }}
-        TF_VAR_SETTINGS__GOVUK_NOTIFY__API_KEY: ${{ secrets.SETTINGS__GOVUK_NOTIFY__API_KEY }}
-        TF_VAR_SETTINGS__LOGSTASH__HOST: ${{ secrets.SETTINGS__LOGSTASH__HOST }}
-
-
-    - name: Terraform apply
-      run: |
-          terraform apply -var-file=${{ env.PAAS_TF_DIR }}/${{ env.TERRAFORM_VAR_FILE }} \
-           -auto-approve ${{ env.PAAS_TF_DIR }}
-      env:
-        BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
-        BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
-        BACKEND_KEY: paas-ttapi.tfstate
-        PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
-        TERRAFORM_VAR_FILE: terraform_qa.tfvars
-        TF_VAR_ttapi_image_tag: ${{env.SHA_TAG}}
-        TF_VAR_api_url: https://api.london.cloud.service.gov.uk
-        TF_VAR_docker_image: ${{ env.DOCKER_IMAGE }}:${{ env.SHA_TAG }}
-        TF_VAR_user: ${{ secrets.TF_VAR_user }}
-        TF_VAR_password: ${{ secrets.TF_VAR_password }}
-        TF_VAR_SECRET_KEY_BASE: ${{ secrets.TF_VAR_SECRET_KEY_BASE }}
-        TF_VAR_SENTRY_DSN: ${{ secrets.TF_VAR_SENTRY_DSN }}
-        TF_VAR_SETTINGS__GOVUK_NOTIFY__API_KEY: ${{ secrets.SETTINGS__GOVUK_NOTIFY__API_KEY }}
-        TF_VAR_SETTINGS__LOGSTASH__HOST: ${{ secrets.SETTINGS__LOGSTASH__HOST }}
-
+    - name: Trigger QA Deployment
+      if: ${{ success() }}
+      uses: benc-uk/workflow-dispatch@v1.1
+      with:
+        workflow: Deploy
+        token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}
+        inputs: '{"environment": "qa", "sha": "${{ env.GIT_SHA_SHORT }}"}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,119 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment to deploy to eg: qa, staging or production'
+        required: true
+      sha:
+        description: Commit sha to be deployed
+        required: true
+
+jobs:
+  deploy: 
+    name: deploy ${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/turnstyle@v1
+        name: Wait for other inprogress deployment runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Start ${{ github.event.inputs.environment }} Deployment
+        uses: bobheadxi/deployments@v0.4.2
+        id: deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ github.event.inputs.environment }}
+          ref: ${{ github.event.inputs.sha }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set Environment variable
+        run: |
+          case $DEPLOY_ENV in
+            qa) next_env=staging ;;
+            staging) next_env=production ;;
+          esac
+
+          echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
+          echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
+          echo "NEXT_ENV=$next_env" >> $GITHUB_ENV
+        env:
+          DOCKER_IMAGE: ${{ format('dfedigital/teacher-training-api:paas-{0}', github.event.inputs.sha) }}
+          DEPLOY_ENV: ${{ github.event.inputs.environment }}
+
+      - name: Install Terraform CloudFoundry Provider
+        run: |
+          mkdir -p $HOME/.terraform.d/plugins/linux_amd64
+          cd $HOME/.terraform.d/plugins/linux_amd64
+          wget -q -O zipfile https://github.com/cloudfoundry-community/terraform-provider-cloudfoundry/releases/download/v0.12.6/terraform-provider-cloudfoundry_0.12.6_linux_amd64.zip && unzip zipfile && rm zipfile
+        env:
+          CF_PROVIDER: $HOME/.terraform.d/plugins/linux_amd64/terraform-provider-cloudfoundry
+
+      - name: Terraform init
+        run: |
+            terraform init \
+             -backend-config=storage_account_name=${{ env.BACKEND_STORAGE_ACCOUNT_NAME }} \
+             -backend-config=access_key=${{ env.BACKEND_ACCESS_KEY }} \
+             -backend-config=key=${{ env.BACKEND_KEY }} \
+              ${{ env.PAAS_TF_DIR }}
+        env:
+          BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
+          BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
+          BACKEND_KEY: paas-ttapi.tfstate
+          PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
+
+      - name: Terraform plan
+        run: |
+            terraform plan -var-file=${{ env.PAAS_TF_DIR }}/${{ env.TERRAFORM_VAR_FILE }} \
+              ${{ env.PAAS_TF_DIR }}
+        env:
+          BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
+          BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
+          BACKEND_KEY: paas-ttapi.tfstate
+          PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
+          TERRAFORM_VAR_FILE: terraform_qa.tfvars
+          TF_VAR_ttapi_image_tag: ${{env.SHA_TAG}}
+          TF_VAR_api_url: https://api.london.cloud.service.gov.uk
+          TF_VAR_docker_image: ${{ env.DOCKER_IMAGE }}:${{ env.SHA_TAG }}
+          TF_VAR_user: ${{ secrets.TF_VAR_user }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_SECRET_KEY_BASE: ${{ secrets.TF_VAR_SECRET_KEY_BASE }}
+          TF_VAR_SENTRY_DSN: ${{ secrets.TF_VAR_SENTRY_DSN }}
+          TF_VAR_SETTINGS__GOVUK_NOTIFY__API_KEY: ${{ secrets.SETTINGS__GOVUK_NOTIFY__API_KEY }}
+          TF_VAR_SETTINGS__LOGSTASH__HOST: ${{ secrets.SETTINGS__LOGSTASH__HOST }}
+
+      - name: Terraform apply
+        run: |
+            terraform apply -var-file=${{ env.PAAS_TF_DIR }}/${{ env.TERRAFORM_VAR_FILE }} \
+             -auto-approve ${{ env.PAAS_TF_DIR }}
+        env:
+          BACKEND_STORAGE_ACCOUNT_NAME: s121d01tfstatestr
+          BACKEND_ACCESS_KEY: ${{ secrets.BACKEND_ACCESS_KEY }}
+          BACKEND_KEY: paas-ttapi.tfstate
+          PAAS_TF_DIR: $HOME/work/teacher-training-api/teacher-training-api/terraform/paas
+          TERRAFORM_VAR_FILE: terraform_qa.tfvars
+          TF_VAR_ttapi_image_tag: ${{env.SHA_TAG}}
+          TF_VAR_api_url: https://api.london.cloud.service.gov.uk
+          TF_VAR_docker_image: ${{ env.DOCKER_IMAGE }}:${{ env.SHA_TAG }}
+          TF_VAR_user: ${{ secrets.TF_VAR_user }}
+          TF_VAR_password: ${{ secrets.TF_VAR_password }}
+          TF_VAR_SECRET_KEY_BASE: ${{ secrets.TF_VAR_SECRET_KEY_BASE }}
+          TF_VAR_SENTRY_DSN: ${{ secrets.TF_VAR_SENTRY_DSN }}
+          TF_VAR_SETTINGS__GOVUK_NOTIFY__API_KEY: ${{ secrets.SETTINGS__GOVUK_NOTIFY__API_KEY }}
+          TF_VAR_SETTINGS__LOGSTASH__HOST: ${{ secrets.SETTINGS__LOGSTASH__HOST }}
+
+      - name: Update ${{ github.event.inputs.environment }} status
+        if: ${{ always() }}
+        uses: bobheadxi/deployments@v0.4.2
+        with:
+          step: finish
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env: ${{ github.event.inputs.environment }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          ref: ${{ github.event.inputs.sha }}


### PR DESCRIPTION
### Context
Split workflows to make it easy to reuse the deploy workflow.

next steps: update `tf 0.13.x` 

### Changes proposed in this pull request

Split build and deploy workflows.
Use latest docker/actions.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
