### PR TITLE
Read application secrets from yaml file in terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,12 @@ jobs:
           DOCKER_IMAGE: ${{ format('dfedigital/teacher-training-api:paas-{0}', github.event.inputs.sha) }}
           DEPLOY_ENV: ${{ github.event.inputs.environment }}
 
+      - name: Download app secrets file
+        working-directory: terraform/workspace_variables
+        run: echo $APP_SECRETS | base64 -d >> app_secrets.yml
+        env:
+          APP_SECRETS: ${{ secrets[format('APP_SECRETS_{0}', env.DEPLOY_ENV)] }}      
+
       - name: Terraform init, plan & apply
         working-directory: terraform
         run: |
@@ -58,14 +64,10 @@ jobs:
             terraform plan -var-file workspace_variables/${{ env.DEPLOY_ENV }}.tfvars -out tfplan
             terraform apply -auto-approve -input=false "tfplan"
         env:
-          ARM_ACCESS_KEY: ${{ secrets[format('ARM_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_paas_docker_image: ${{ env.DOCKER_IMAGE }}
-          TF_VAR_cf_user: ${{ secrets.TF_VAR_user }}
-          TF_VAR_cf_user_password: ${{ secrets.TF_VAR_password }}
-          TF_VAR_SECRET_KEY_BASE: ${{ secrets.TF_VAR_SECRET_KEY_BASE }}
-          TF_VAR_SENTRY_DSN: ${{ secrets.TF_VAR_SENTRY_DSN }}
-          TF_VAR_GOVUK_NOTIFY_API_KEY: ${{ secrets.SETTINGS__GOVUK_NOTIFY__API_KEY }}
-          TF_VAR_LOGSTASH_HOST: ${{ secrets.SETTINGS__LOGSTASH__HOST }}
+          ARM_ACCESS_KEY:             ${{ secrets[format('ARM_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
+          TF_VAR_paas_docker_image:   ${{ env.DOCKER_IMAGE }}
+          TF_VAR_cf_user:             ${{ secrets.TF_VAR_user }}
+          TF_VAR_cf_user_password:    ${{ secrets.TF_VAR_password }}
           TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_password: ${{ secrets.STATUSCAKE_API_KEY }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ terraform.tfstate.d/
 lock.json
 *secret*.tfvars
 .terraform/
+!terraform/workspace_variables/app_config.yml
+terraform/workspace_variables/*.yml
+terraform/workspace_variables/*.base64

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,13 +24,7 @@ variable paas_app_environment {}
 
 variable paas_app_config { type = map }
 
-variable SECRET_KEY_BASE {}
-
-variable SENTRY_DSN {}
-
-variable LOGSTASH_HOST {}
-
-variable GOVUK_NOTIFY_API_KEY {}
+variable paas_app_secrets_file { default = "workspace_variables/app_secrets.yml" }
 
 variable statuscake_alerts { type = map }
 
@@ -39,12 +33,7 @@ variable statuscake_username {}
 variable statuscake_password {}
 
 locals {
-  cf_api_url = "https://api.london.cloud.service.gov.uk"
-  paas_app_secrets = {
-    SETTINGS__LOGSTASH__HOST        = var.LOGSTASH_HOST
-    SECRET_KEY_BASE                 = var.SECRET_KEY_BASE
-    SENTRY_DSN                      = var.SENTRY_DSN
-    SETTINGS__GOVUK_NOTIFY__API_KEY = var.GOVUK_NOTIFY_API_KEY
-  }
+  cf_api_url                     = "https://api.london.cloud.service.gov.uk"
+  paas_app_secrets               = yamldecode(file(var.paas_app_secrets_file))
   paas_app_environment_variables = merge(local.paas_app_secrets, var.paas_app_config)
 }

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -10,7 +10,6 @@ paas_redis_service_plan    = "tiny-5_x"
 paas_app_config = {
   RAILS_ENV                = "production"
   RAILS_SERVE_STATIC_FILES = true
-  SETTINGS__LOGSTASH__PORT = 22135
 }
 
 #StatusCake

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -11,7 +11,6 @@ paas_redis_service_plan    = "tiny-5_x"
 paas_app_config = {
   RAILS_ENV                = "qa_paas"
   RAILS_SERVE_STATIC_FILES = true
-  SETTINGS__LOGSTASH__PORT = 22135
 }
 
 # StatusCake

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -10,7 +10,6 @@ paas_redis_service_plan    = "tiny-5_x"
 paas_app_config = {
   RAILS_ENV                = "staging"
   RAILS_SERVE_STATIC_FILES = true
-  SETTINGS__LOGSTASH__PORT = 22135
 }
 
 #StatusCake


### PR DESCRIPTION
### Context
Make application secrets easier to manage in GitHub actions / terraform,

### Changes proposed in this pull request

Read application secrets from a yml file.
base64 encoded yaml file is stored as secret in GitHub Secrets.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
