### PR TITLE
Configure api.publish-teacher-training-courses.service.gov.uk custom domain for PaaS app

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -1,5 +1,9 @@
-data cloudfoundry_domain local {
+data cloudfoundry_domain london_cloudapps_digital {
   name = "london.cloudapps.digital"
+}
+
+data cloudfoundry_domain api_publish_service_gov_uk {
+  name = "api.publish-teacher-training-courses.service.gov.uk"
 }
 
 data cloudfoundry_org org {

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -16,8 +16,11 @@ resource cloudfoundry_app web_app {
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
   }
-  routes {
-    route = cloudfoundry_route.web_app_cloudapps_digital_route.id
+  dynamic "routes" {
+    for_each = local.web_app_routes
+    content {
+      route = routes.value.id
+    }
   }
 }
 
@@ -42,9 +45,15 @@ resource cloudfoundry_app worker_app {
 }
 
 resource cloudfoundry_route web_app_cloudapps_digital_route {
-  domain   = data.cloudfoundry_domain.local.id
+  domain   = data.cloudfoundry_domain.london_cloudapps_digital.id
   space    = data.cloudfoundry_space.space.id
   hostname = local.web_app_name
+}
+
+resource cloudfoundry_route web_app_service_gov_uk_route {
+  domain   = data.cloudfoundry_domain.api_publish_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = var.web_app_host_name
 }
 
 resource cloudfoundry_service_instance postgres {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -4,6 +4,8 @@ variable web_app_instances {}
 
 variable web_app_memory {}
 
+variable web_app_host_name {}
+
 variable worker_app_instances {}
 
 variable worker_app_memory {}
@@ -29,4 +31,5 @@ locals {
   postgres_params = {
     enable_extensions = ["pg_buffercache", "pg_stat_statements", "btree_gin", "btree_gist"]
   }
+  web_app_routes = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -36,6 +36,7 @@ module paas {
   cf_space                  = var.cf_space
   app_environment           = var.paas_app_environment
   docker_image              = var.paas_docker_image
+  web_app_host_name         = var.paas_web_app_host_name
   web_app_memory            = var.paas_web_app_memory
   web_app_instances         = var.paas_web_app_instances
   worker_app_instances      = var.paas_worker_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,6 +22,8 @@ variable paas_redis_service_plan {}
 
 variable paas_app_environment {}
 
+variable paas_web_app_host_name {}
+
 variable paas_app_config { type = map }
 
 variable paas_app_secrets_file { default = "workspace_variables/app_secrets.yml" }

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -1,6 +1,7 @@
 #PaaS
 cf_space                   = "bat-prod"
 paas_app_environment       = "prod"
+paas_web_app_host_name     = "www"
 paas_web_app_instances     = 2
 paas_web_app_memory        = 512
 paas_worker_app_instances  = 2

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -1,6 +1,7 @@
 #PaaS
 cf_space                   = "bat-qa"
 paas_app_environment       = "qa"
+paas_web_app_host_name     = "qa"
 paas_web_app_instances     = 1
 paas_web_app_memory        = 512
 paas_worker_app_instances  = 1

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -1,6 +1,7 @@
 #PaaS
 cf_space                   = "bat-staging"
 paas_app_environment       = "staging"
+paas_web_app_host_name     = "staging"
 paas_web_app_instances     = 1
 paas_web_app_memory        = 512
 paas_worker_app_instances  = 1


### PR DESCRIPTION
### Changes proposed in this pull request
Adds support for `{env}.api.publish-teacher-training-courses.service.gov.uk` as custom route for PaaS web app.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
