### PR TITLE
[506] Pagination params are nested

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -20,7 +20,7 @@ module API
         end
 
         def per_page
-          [(params[:per_page] || default_per_page).to_i, max_per_page].min
+          [(per_page_parameter || default_per_page).to_i, max_per_page].min
         end
 
         def default_per_page
@@ -32,7 +32,23 @@ module API
         end
 
         def page
-          (params[:page] || 1).to_i
+          (page_parameter || 1).to_i
+        end
+
+        def page_parameter
+          return params[:page][:page] if page_is_nested?
+
+          params[:page]
+        end
+
+        def per_page_parameter
+          return params[:page][:per_page] if page_is_nested?
+
+          params[:per_page]
+        end
+
+        def page_is_nested?
+          params[:page].is_a?(ActionController::Parameters)
         end
       end
     end

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -61,8 +61,10 @@ RSpec.describe API::Public::V1::CoursesController do
           before do
             get :index, params: {
               recruitment_cycle_year: recruitment_cycle.year,
-              page: 2,
-              per_page: 5,
+              page: {
+                page: 2,
+                per_page: 5,
+              },
             }
           end
 
@@ -75,8 +77,10 @@ RSpec.describe API::Public::V1::CoursesController do
           before do
             get :index, params: {
               recruitment_cycle_year: recruitment_cycle.year,
-              page: 5,
-              per_page: 5,
+              page: {
+                page: 5,
+                per_page: 5,
+              },
             }
           end
 


### PR DESCRIPTION
### Context

[Our documentation](https://api.qa.publish-teacher-training-courses.service.gov.uk/api-reference.html#recruitment_cycles-year-courses-get-parameters) defines pagination params as:

`page: { page: <whatevs>, per_page: <whatevs> }`

In `ApplicationController` we don't handle this and expect the `page` and `per_page` to be in the root of the params.

### Changes proposed in this pull request

Handle both cases to behave as documented but not break any clients that have already worked around.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
