### PR TITLE
Trigger smoke tests after deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
 
     - name: Trigger QA Deployment
       if: ${{ success() }}
-      uses: benc-uk/workflow-dispatch@v1.1
+      uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: Deploy
         token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN  }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,13 +21,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start ${{ github.event.inputs.environment }} Deployment
-        uses: bobheadxi/deployments@v0.4.2
+        uses: bobheadxi/deployments@master
         id: deployment
         with:
           step: start
           token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ github.event.inputs.environment }}
-          ref: ${{ github.event.inputs.sha }}
+          env:   ${{ github.event.inputs.environment }}
+          ref:   ${{ github.event.inputs.sha }}
 
       - name: Checkout
         uses: actions/checkout@v2
@@ -71,21 +71,38 @@ jobs:
           TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
           TF_VAR_statuscake_password: ${{ secrets.STATUSCAKE_API_KEY }}
 
+      - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Smoke Tests
+          token:    ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          inputs:   '{"environment": "${{ env.DEPLOY_ENV }}"}'
+
+      - name: Wait for smoke tests
+        id: wait_for_smoke_tests
+        uses: fountainhead/action-wait-for-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref:   ${{ github.ref }}
+          checkName: smoke-tests-${{ env.DEPLOY_ENV }} 
+          timeoutSeconds:  300
+          intervalSeconds: 15
+
       - name: Trigger ${{ env.NEXT_ENV }} Deployment
-        if: ${{ success() && env.NEXT_ENV != '' && github.ref == 'refs/heads/master' }}
-        uses: benc-uk/workflow-dispatch@v1.1
+        if: ${{ steps.wait_for_smoke_tests.outputs.conclusion == 'success' && env.NEXT_ENV != '' && github.ref == 'refs/heads/master' }}
+        uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: Deploy
-          token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-          inputs: '{"environment": "${{ env.NEXT_ENV }}", "sha": "${{ github.event.inputs.sha }}"}'
+          token:    ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+          inputs:  '{"environment": "${{ env.NEXT_ENV }}", "sha": "${{ github.event.inputs.sha }}"}'
 
       - name: Update ${{ github.event.inputs.environment }} status
         if: ${{ always() }}
-        uses: bobheadxi/deployments@v0.4.2
+        uses: bobheadxi/deployments@master
         with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: ${{ github.event.inputs.environment }}
+          step:   finish
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    ${{ github.event.inputs.environment }}
+          ref:    ${{ github.event.inputs.sha }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          ref: ${{ github.event.inputs.sha }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,32 @@
+name: Smoke Tests
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'The environment to run tests against (qa, staging or production)'
+        required: true
+
+jobs:
+  smoke_tests:
+    name: smoke-tests-${{ github.event.inputs.environment }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: softprops/turnstyle@v1
+        name: Wait for other runs
+        env:
+          GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
+
+      - name: Smoke Tests ${{ github.event.inputs.environment }}
+        run: echo "Nothing to run yet 🚀"
+
+      - name: 'Nofiy #twd_publish_register_tech on failure'
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Teacher Training API
+          SLACK_TITLE: Smoke tests failure
+          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Trigger smoke tests
Wait for smoke tests to complete and then trigger deployment to next environment.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
