### PR TITLE
Read COMMIT_SHA from ENV hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,9 @@ jobs:
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           ${{ env.DOCKER_IMAGE}}-middleman:master
           ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
-        build-args: BUILDKIT_INLINE_CACHE=1
+        build-args: |
+          BUILDKIT_INLINE_CACHE=1 
+          COMMIT_SHA=paas-${{ github.sha }}
 
     - name: Setup tests
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN bundle exec middleman build --build-dir=../public
 
 FROM ruby:2.7.2-alpine
 
+ARG COMMIT_SHA
+
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
     echo "Europe/London" > /etc/timezone
@@ -25,6 +27,7 @@ RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses
 
 ENV APP_HOME /app
+
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 
@@ -39,5 +42,7 @@ RUN apk add --update --no-cache --virtual build-dependances \
 ADD . $APP_HOME/
 
 COPY --from=middleman /public/ $APP_HOME/public/
+
+ENV COMMIT_SHA=${COMMIT_SHA}
 
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0

--- a/app/controllers/heartbeat_controller.rb
+++ b/app/controllers/heartbeat_controller.rb
@@ -21,9 +21,7 @@ class HeartbeatController < ActionController::API
   end
 
   def sha
-    commit_sha_path = Rails.root.join(Settings.commit_sha_file)
-    sha = File.read(commit_sha_path).strip
-    render json: { sha: sha }
+    render json: { sha: ENV["COMMIT_SHA"] }
   end
 
 private

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,6 @@ steps:
     set +x # We confuse VSTS if we trace these commands
     echo "##vso[build.updatebuildnumber]$GIT_SHORT_SHA"
     echo "##vso[task.setvariable variable=docker_path;]$docker_path"
-    echo $(Build.SourceVersion) > COMMIT_SHA
   displayName: 'Set version number'
 
 - script: |
@@ -37,7 +36,7 @@ steps:
 - script: |
     set -x
     $DOCKER_OVERRIDE build middleman
-    $DOCKER_OVERRIDE build
+    $DOCKER_OVERRIDE build --build-arg COMMIT_SHA=$(Build.SourceVersion)
   displayName: Build Docker Images
   env:
     DOCKER_OVERRIDE: $(dockerOverride)

--- a/config/initializers/logstash.rb
+++ b/config/initializers/logstash.rb
@@ -1,8 +1,7 @@
 LogStashLogger.configure do |config|
-  commit_sha = File.read(Rails.root.join("COMMIT_SHA")).strip
   config.customize_event do |event|
     event["application"] = Settings.application
     event["environment"] = Rails.env
-    event["release"] = commit_sha
+    event["release"] = ENV["COMMIT_SHA"]
   end
 end

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -8,6 +8,5 @@ Raven.configure do |config|
 
   config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
 
-  commit_sha = File.read(Rails.root.join("COMMIT_SHA")).strip
-  config.release = commit_sha
+  config.release = ENV["COMMIT_SHA"]
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -34,7 +34,6 @@ logstash:
 log_level: info
 magic_link:
   max_token_age: <%= 1.hour %>
-commit_sha_file: COMMIT_SHA
 skylight:
   enable: false
   authentication: please_change_me

--- a/spec/requests/heartbeat_spec.rb
+++ b/spec/requests/heartbeat_spec.rb
@@ -113,13 +113,11 @@ describe "heartbeat requests" do
 
   describe "GET /sha" do
     it "returns the sha from the file COMMIT_SHA" do
-      allow(File).to receive(:read)
-                       .with(Rails.root.join("COMMIT_SHA"))
-                       .and_return("deadbeef\n")
+      ENV["COMMIT_SHA"] = "my-commit-sha"
 
       get "/sha"
 
-      expect(response.body).to eq '{"sha":"deadbeef"}'
+      expect(response.body).to eq '{"sha":"my-commit-sha"}'
     end
   end
 end


### PR DESCRIPTION
Set COMMIT_SHA as docker build argument


Stop writing to and reading COMMIT_SHA to a file.
Set COMMIT_SHA as build arg to docker build

COMMIT_SHA is prefixed with `paas-` in the app hosted in PaaS for identification while we are running on two platforms.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
