### PR TITLE
Expose additional attributes on the V3 API

### DIFF
--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -21,7 +21,7 @@ module API
                  :content_status, :ucas_status, :funding_type,
                  :level, :is_send?, :english, :maths, :science, :gcse_subjects_required,
                  :age_range_in_years, :accrediting_provider,
-                 :accredited_body_code, :level, :changed_at, :uuid
+                 :accredited_body_code, :level, :changed_at, :uuid, :program_type
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/app/serializers/api/v3/serializable_provider.rb
+++ b/app/serializers/api/v3/serializable_provider.rb
@@ -3,7 +3,8 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type "providers"
 
-      attributes :provider_code, :provider_name, :provider_type
+      attributes :provider_code, :provider_name, :provider_type,
+                 :latitude, :longitude
 
       attribute :recruitment_cycle_year do
         @object.recruitment_cycle.year

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -112,6 +112,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "accrediting_provider" => nil,
                 "accredited_body_code" => nil,
                 "uuid" => provider.courses[0].uuid,
+                "program_type" => provider.courses[0].program_type,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -144,6 +144,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "accrediting_provider" => nil,
             "accredited_body_code" => nil,
             "uuid" => course.uuid,
+            "program_type" => course.program_type,
           },
           "relationships" => {
             "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/suggest_provider_spec.rb
+++ b/spec/requests/api/v3/providers/suggest_provider_spec.rb
@@ -4,8 +4,8 @@ describe "GET /provider-suggestions" do
   let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
   let(:courses) { [build(:course, site_statuses: [build(:site_status, :findable)])] }
   let(:courses2) { [build(:course, site_statuses: [build(:site_status, :findable)])] }
-  let(:provider) { create(:provider, provider_name: "PROVIDER 1", courses: courses) }
-  let(:provider2) { create(:provider, provider_name: "PROVIDER 2", courses: courses2) }
+  let(:provider) { create(:provider, provider_name: "PROVIDER 1", courses: courses, latitude: 51.482578, longitude: -0.007659) }
+  let(:provider2) { create(:provider, provider_name: "PROVIDER 2", courses: courses2, latitude: 52.482578, longitude: -0.107659) }
 
   context "current recruitment cycle" do
     before do
@@ -25,6 +25,8 @@ describe "GET /provider-suggestions" do
                                      "provider_code" => provider.provider_code,
                                      "provider_name" => provider.provider_name,
                                      "provider_type" => provider.provider_type,
+                                     "latitude" => provider.latitude,
+                                     "longitude" => provider.longitude,
                                      "recruitment_cycle_year" => provider.recruitment_cycle.year,
                                  },
                              },
@@ -43,6 +45,8 @@ describe "GET /provider-suggestions" do
                                      "provider_code" => provider.provider_code,
                                      "provider_name" => provider.provider_name,
                                      "provider_type" => provider.provider_type,
+                                     "latitude" => provider.latitude,
+                                     "longitude" => provider.longitude,
                                      "recruitment_cycle_year" => provider.recruitment_cycle.year,
                                  },
                              },
@@ -53,6 +57,8 @@ describe "GET /provider-suggestions" do
                                      "provider_code" => provider2.provider_code,
                                      "provider_name" => provider2.provider_name,
                                      "provider_type" => provider2.provider_type,
+                                     "latitude" => provider2.latitude,
+                                     "longitude" => provider2.longitude,
                                      "recruitment_cycle_year" => provider2.recruitment_cycle.year,
                                  },
                              },

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -36,6 +36,7 @@ describe API::V3::SerializableCourse do
   it { is_expected.to have_attribute :provider_code }
   it { is_expected.to have_attribute :age_range_in_years }
   it { is_expected.to have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
+  it { is_expected.to have_attribute :program_type }
 
   context "with a provider" do
     let(:provider) { course.provider }

--- a/spec/serializers/api/v3/serializable_provider_spec.rb
+++ b/spec/serializers/api/v3/serializable_provider_spec.rb
@@ -14,4 +14,6 @@ describe API::V3::SerializableProvider do
   it { should have_attribute(:provider_code).with_value(provider.provider_code) }
   it { should have_attribute(:provider_name).with_value(provider.provider_name) }
   it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
+  it { should have_attribute(:latitude).with_value(provider.latitude) }
+  it { should have_attribute(:longitude).with_value(provider.longitude) }
 end


### PR DESCRIPTION
### Context

Apply needs some additional attributes exposed on the V3 API for research/analysis purposes. 

### Changes proposed in this pull request

- Expose a providers lat/long
- Expose the courses program_type (so we know if it's a `scitt_programme`)

### Guidance for review

https://trello.com/c/YgubEbfX/2577-dev-use-the-v3-api-to-populate-the-latitude-and-longitude-for-providers
https://trello.com/c/yeZRKLYE/2530-dev-locations-persona-data

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
