### PR TITLE
Update the provider show endpoint to use the V3 ProviderSerializer

### DIFF
--- a/app/controllers/api/v3/provider_suggestions_controller.rb
+++ b/app/controllers/api/v3/provider_suggestions_controller.rb
@@ -14,6 +14,8 @@ module API
         render(
           jsonapi: found_providers,
           class: { Provider: SerializableProvider },
+          fields: { providers: %i[provider_code provider_name provider_type
+                                  latitude longitude recruitment_cycle_year] },
         )
       end
 

--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -25,13 +25,7 @@ module API
 
         render jsonapi: @provider,
                class: CourseSerializersServiceV3.new.execute,
-               include: params[:include],
-               fields: { providers: %i[provider_code provider_name courses
-                                       recruitment_cycle_year address1 address2
-                                       address3 address4 postcode region_code
-                                       email website telephone train_with_us
-                                       train_with_disability sites
-                                       accredited_bodies accredited_body?] }
+               include: params[:include]
       end
 
     private

--- a/app/serializers/api/v3/serializable_provider.rb
+++ b/app/serializers/api/v3/serializable_provider.rb
@@ -3,11 +3,24 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type "providers"
 
-      attributes :provider_code, :provider_name, :provider_type,
+      attributes :provider_code, :provider_name,
+                 :provider_type, :address1, :address2,
+                 :address3, :address4, :postcode, :region_code,
+                 :email, :website, :telephone,
+                 :train_with_us, :train_with_disability,
+                 :accredited_bodies, :accredited_body?,
                  :latitude, :longitude
 
       attribute :recruitment_cycle_year do
         @object.recruitment_cycle.year
+      end
+
+      has_many :sites
+
+      has_many :courses do
+        meta do
+          { count: @object.courses_count }
+        end
       end
     end
   end

--- a/app/services/course_serializers_service_v3.rb
+++ b/app/services/course_serializers_service_v3.rb
@@ -8,7 +8,7 @@ class CourseSerializersServiceV3
     further_education_subject_serializer: API::V2::SerializableSubject,
     site_status_serializer: API::V2::SerializableSiteStatus,
     site_serializer: API::V2::SerializableSite,
-    provider_serializer: API::V2::SerializableProvider,
+    provider_serializer: API::V3::SerializableProvider,
     provider_enrichment_serializer: API::V2::SerializableProviderEnrichment,
     recruitment_cycle_serializer: API::V2::SerializableRecruitmentCycle
   )

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -42,6 +42,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
         "attributes" => {
           "provider_code" => provider.provider_code,
           "provider_name" => provider.provider_name,
+          "provider_type" => provider.provider_type,
           "accredited_body?" => false,
           "train_with_us" => provider.train_with_us,
           "train_with_disability" => provider.train_with_disability,
@@ -114,6 +115,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
           "attributes" => {
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
+            "provider_type" => provider.provider_type,
             "accredited_body?" => false,
             "train_with_us" => provider.train_with_us,
             "train_with_disability" => provider.train_with_disability,

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -27,7 +27,9 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
            accrediting_provider_enrichments: accrediting_provider_enrichments,
            courses: courses,
            contacts: [contact],
-           ucas_preferences: ucas_preferences)
+           ucas_preferences: ucas_preferences,
+           latitude: 0.1,
+           longitude: 0.2)
   end
   let(:contact) { build(:contact) }
   let(:ucas_preferences) { build(:provider_ucas_preference) }
@@ -58,6 +60,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "provider_name" => accrediting_provider.provider_name,
             "description" => description,
           }],
+          "latitude" => provider.latitude,
+          "longitude" => provider.longitude,
         },
         "relationships" => {
           "sites" => {
@@ -128,6 +132,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
               "provider_name" => accrediting_provider.provider_name,
               "description" => description,
             }],
+            "latitude" => provider.latitude,
+            "longitude" => provider.longitude,
           },
           "relationships" => {
             "sites" => {

--- a/spec/serializers/api/v3/serializable_provider_spec.rb
+++ b/spec/serializers/api/v3/serializable_provider_spec.rb
@@ -1,8 +1,17 @@
 require "rails_helper"
 
 describe API::V3::SerializableProvider do
-  let(:provider) { create :provider }
+  let(:accrediting_provider) { create(:provider, :accredited_body) }
+  let(:course) { create(:course, accrediting_provider: accrediting_provider) }
+  let(:site) { create(:site) }
+  let(:provider) do
+    create :provider,
+           courses: [course],
+           sites: [site]
+  end
+
   let(:resource) { described_class.new object: provider }
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
 
   it "sets type to providers" do
     expect(resource.jsonapi_type).to eq :providers
@@ -13,7 +22,48 @@ describe API::V3::SerializableProvider do
   it { should have_type "providers" }
   it { should have_attribute(:provider_code).with_value(provider.provider_code) }
   it { should have_attribute(:provider_name).with_value(provider.provider_name) }
+  it { should have_attribute(:provider_type).with_value(provider.provider_type) }
+  it { should have_attribute(:address1).with_value(provider.address1) }
+  it { should have_attribute(:address2).with_value(provider.address2) }
+  it { should have_attribute(:address3).with_value(provider.address3) }
+  it { should have_attribute(:address4).with_value(provider.address4) }
+  it { should have_attribute(:postcode).with_value(provider.postcode) }
+  it { should have_attribute(:region_code).with_value(provider.region_code) }
+  it { should have_attribute(:email).with_value(provider.email) }
+  it { should have_attribute(:website).with_value(provider.website) }
+  it { should have_attribute(:telephone).with_value(provider.telephone) }
+  it { should have_attribute(:accredited_body?).with_value(false) }
   it { should have_attribute(:recruitment_cycle_year).with_value(provider.recruitment_cycle.year) }
+  it { should have_attribute(:train_with_us).with_value(provider.train_with_us) }
+  it { should have_attribute(:train_with_disability).with_value(provider.train_with_disability) }
   it { should have_attribute(:latitude).with_value(provider.latitude) }
   it { should have_attribute(:longitude).with_value(provider.longitude) }
+
+  it do
+    should have_attribute(:accredited_bodies).with_value([
+      {
+        "provider_name" => accrediting_provider.provider_name,
+        "provider_code" => accrediting_provider.provider_code,
+        "description" => "",
+      },
+    ])
+  end
+
+  describe "includes" do
+    subject do
+      jsonapi_renderer.render(
+        provider,
+        class: {
+          Provider: API::V3::SerializableProvider,
+          Site: API::V2::SerializableSite,
+        },
+        include: %i[sites],
+      )
+    end
+
+    it "includes the sites relationship" do
+      expect(subject.dig(:data, :relationships, :sites, :data).count).to eq(1)
+      expect(subject.dig(:data, :relationships, :sites, :data).first).to eq({ type: :sites, id: site.id.to_s })
+    end
+  end
 end


### PR DESCRIPTION
### Context

At the moment the CourseSerializersServiceV3 uses the V2 ProviderSerializer. It should really be using the V3 ProviderSerializer. This PR uses the v3 serializer and updates it to include all the requisite attributes for Find and Apply.

### Changes proposed in this pull request

- Updates the CourseSerializersServiceV3 to use the V3 ProviderSerializer
- Updates the attrs used in the V3 ProviderSerializer
- Updates the provider show and V3 Provider Serializer tests
- Return a limited number of provider attrs on the provider suggestions endpoint

### Guidance to review

Is this everything that needs to be done?

I've tested find locally and it all seems to be working as expected.
 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
