### PR TITLE
Add lat long for provider to the public api

### DIFF
--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -11,7 +11,9 @@ module API
                    :region_code,
                    :train_with_disability,
                    :train_with_us,
-                   :website
+                   :website,
+                   :latitude,
+                   :longitude
 
         attribute :accredited_body do
           @object.accredited_body?

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -220,7 +220,9 @@ RSpec.describe API::Public::V1::ProvidersController do
                 created_at
                 name
                 street_address_1
-                street_address_2]
+                street_address_2
+                latitude
+                longitude]
           end
 
           before do
@@ -285,6 +287,8 @@ RSpec.describe API::Public::V1::ProvidersController do
             "created_at" => provider.created_at.iso8601,
             "street_address_1" => provider.address1,
             "street_address_2" => provider.address2,
+            "latitude" => provider.latitude,
+            "longitude" => provider.longitude,
           },
         }
       end

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -28,4 +28,6 @@ describe API::Public::V1::SerializableProvider do
   it { should have_attribute(:name).with_value(provider.provider_name) }
   it { should have_attribute(:street_address_1).with_value(provider.address1) }
   it { should have_attribute(:street_address_2).with_value(provider.address2) }
+  it { should have_attribute(:latitude).with_value(provider.latitude) }
+  it { should have_attribute(:longitude).with_value(provider.longitude) }
 end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -893,6 +893,17 @@
             "maxLength": 8,
             "example": "SK2 6AA"
           },
+          "latitude": {
+            "type": "float",
+            "description": "The latitude of the provider's address",
+            "example": "51.498161"
+          },
+          "longitude": {
+            "type": "float",
+            "description": "The longitude of the provider's address",
+            "example": "-0.129900"
+          },
+
           "name": {
             "type": "string",
             "description": "The name of the training provider.",

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -41,6 +41,14 @@ properties:
     description: "The provider's postcode"
     maxLength: 8
     example: SK2 6AA
+  latitude:
+    type: float
+    description: "The latitude of the provider's address"
+    example: "51.498161"
+  longitude:
+    type: float
+    description: "The longitude of the provider's address"
+    example: "-0.129900"
   name:
     type: string
     description: "The name of the training provider."


### PR DESCRIPTION
### Context

We're now using the public API so I've close the other PR, added lat/long here and updated the docs accordingly.

### Changes proposed in this pull request

- Add lat & long to the provider serialiser
- Update tests
 
### Guidance to review

Are there some docs that need updating somewhere @dankmitchell?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
