### PR TITLE
[633] Implement api/public/v1/subject_areas

### DIFF
--- a/app/controllers/api/public/v1/subject_areas_controller.rb
+++ b/app/controllers/api/public/v1/subject_areas_controller.rb
@@ -3,29 +3,11 @@ module API
     module V1
       class SubjectAreasController < API::Public::V1::ApplicationController
         def index
-          render json: {
-            data: [
-              {
-                id: "PrimarySubject",
-                type: "subject_areas",
-                attributes: {
-                  name: "Primary",
-                  typename: "PrimarySubject",
-                },
-              },
-              {
-                id: "SecondarySubject",
-                type: "subject_areas",
-                attributes: {
-                  name: "Secondary",
-                  typename: "SecondarySubject",
-                },
-              },
-            ],
-            jsonapi: {
-              version: "1.0",
-            },
-          }
+          render(
+            jsonapi: SubjectArea.active.includes(subjects: [:financial_incentive]),
+            include: params[:include],
+            class: API::Public::V1::SerializerService.call,
+          )
         end
       end
     end

--- a/app/serializers/api/public/v1/serializable_subject_area.rb
+++ b/app/serializers/api/public/v1/serializable_subject_area.rb
@@ -1,0 +1,13 @@
+module API
+  module Public
+    module V1
+      class SerializableSubjectArea < JSONAPI::Serializable::Resource
+        type "subject_areas"
+
+        has_many :subjects
+
+        attributes :name, :typename
+      end
+    end
+  end
+end

--- a/app/serializers/api/public/v1/serializer_service.rb
+++ b/app/serializers/api/public/v1/serializer_service.rb
@@ -12,6 +12,7 @@ module API
             Site: API::Public::V1::SerializableLocation,
             SiteStatus: API::Public::V1::SerializableLocationStatus,
             Subject: API::Public::V1::SerializableSubject,
+            SubjectArea: API::Public::V1::SerializableSubjectArea,
             PrimarySubject: API::Public::V1::SerializableSubject,
             SecondarySubject: API::Public::V1::SerializableSubject,
             ModernLanguagesSubject: API::Public::V1::SerializableSubject,

--- a/spec/controllers/api/public/v1/subject_areas_controller_spec.rb
+++ b/spec/controllers/api/public/v1/subject_areas_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe API::Public::V1::SubjectAreasController do
+  describe "#index" do
+    context "when there are no subject areas" do
+      before do
+        allow(SubjectArea).to receive(:active).and_return(double(includes: []))
+
+        get :index
+      end
+
+      it "returns empty array of data" do
+        expect(json_response["data"]).to eql([])
+      end
+    end
+
+    context "when subject areas exist" do
+      before do
+        get :index
+      end
+
+      it "returns the correct number of subject areas" do
+        expected_count = SubjectArea.active.count
+        expect(json_response["data"].size).to eql(expected_count)
+      end
+
+      context "with includes" do
+        before do
+          get :index, params: { include: "subjects" }
+        end
+
+        it "returns the requested associated data in the response" do
+          subject_area = json_response["data"][0]
+          subject_area_relationships = subject_area["relationships"]
+          subjects_count = subject_area_relationships.dig("subjects", "data").size
+
+          expect(SubjectArea.find(subject_area["id"]).subjects.count).to eq(subjects_count)
+          expect(subject_area_relationships.keys.sort).to eq(%w[subjects])
+        end
+      end
+    end
+  end
+end

--- a/spec/docs/subject_areas_spec.rb
+++ b/spec/docs/subject_areas_spec.rb
@@ -6,11 +6,20 @@ describe "API" do
       operationId :public_api_v1_subject_areas
       tags "subject_areas"
       produces "application/json"
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: { enum: %w[subjects] },
+                example: "subjects"
 
       curl_example description: "Get all subject areas",
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas"
 
       response "200", "The collection of subject areas." do
+        let(:include) { "subjects" }
+
         schema "$ref": "#/components/schemas/SubjectAreaListResponse"
 
         run_test!

--- a/spec/serializers/api/public/v1/serializable_subject_area_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_subject_area_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe API::Public::V1::SerializableSubjectArea do
+  let(:subject_area) { find_or_create(:subject_area, :primary) }
+  let(:resource) { described_class.new(object: subject_area) }
+
+  it "sets type to subject_areas" do
+    expect(resource.jsonapi_type).to eq(:subject_areas)
+  end
+
+  subject { JSON.parse(resource.as_jsonapi.to_json) }
+
+  it { should have_type "subject_areas" }
+
+  it { should have_attribute(:name).with_value(subject_area.name) }
+  it { should have_attribute(:typename).with_value(subject_area.typename) }
+
+  context "relationships" do
+    context "default" do
+      it { should have_relationships(:subjects) }
+    end
+  end
+end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -1916,6 +1916,20 @@
         "tags": [
           "subject_areas"
         ],
+        "parameters": [
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "subjects"
+              ]
+            },
+            "example": "subjects"
+          }
+        ],
         "x-curl-examples": [
           {
             "description": "Get all subject areas",


### PR DESCRIPTION
### Context

- https://trello.com/c/6Kr40mh9/633-s-implement-public-v1-subject-areas

### Changes proposed in this pull request

- Replace hard coded response with real code!

### Guidance to review

Fire the following curl command in your shell locally (after running the server):

```sh
curl --location --request GET 'localhost:3001/api/public/v1/subject_areas?include=subjects' \
--header 'Content-Type: application/json'
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
