### PR TITLE
Expose the required attributes on the v1 public api, in order to move find over

### DIFF
--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -13,7 +13,9 @@ module API
                    :train_with_us,
                    :website,
                    :latitude,
-                   :longitude
+                   :longitude,
+                   :telephone,
+                   :email
 
         attribute :accredited_body do
           @object.accredited_body?

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -52,6 +52,12 @@ module API
         attribute :street_address_2 do
           @object.address2
         end
+
+        has_many :courses do
+          meta do
+            { count: @object.courses_count }
+          end
+        end
       end
     end
   end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe API::Public::V1::ProvidersController do
           recruitment_cycle_id = relationships.dig("recruitment_cycle", "data", "id").to_i
 
           expect(json_response["data"][0]["relationships"].keys.sort).to eq(
-            %w[recruitment_cycle],
+            %w[courses recruitment_cycle],
           )
 
           expect(recruitment_cycle_id).to eq(provider.recruitment_cycle.id)
@@ -363,7 +363,7 @@ RSpec.describe API::Public::V1::ProvidersController do
             "latitude" => provider.latitude,
             "longitude" => provider.longitude,
             "telephone" => provider.telephone,
-            "email" => provider.email
+            "email" => provider.email,
           },
         }
       end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -293,7 +293,9 @@ RSpec.describe API::Public::V1::ProvidersController do
                 street_address_1
                 street_address_2
                 latitude
-                longitude]
+                longitude
+                telephone
+                email]
           end
 
           before do
@@ -360,6 +362,8 @@ RSpec.describe API::Public::V1::ProvidersController do
             "street_address_2" => provider.address2,
             "latitude" => provider.latitude,
             "longitude" => provider.longitude,
+            "telephone" => provider.telephone,
+            "email" => provider.email
           },
         }
       end

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -30,4 +30,6 @@ describe API::Public::V1::SerializableProvider do
   it { should have_attribute(:street_address_2).with_value(provider.address2) }
   it { should have_attribute(:latitude).with_value(provider.latitude) }
   it { should have_attribute(:longitude).with_value(provider.longitude) }
+  it { should have_attribute(:telephone).with_value(provider.telephone) }
+  it { should have_attribute(:email).with_value(provider.email) }
 end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -669,6 +669,16 @@
             "type": "number",
             "description": "The longitude of the location.",
             "example": -1.3603394
+          },
+          "telephone": {
+            "type": "string",
+            "description": "The provider's telephone number.",
+            "example": "01834 80657"
+          },
+          "email": {
+            "type": "string",
+            "description": "The provider's email address.",
+            "example": "school@example.com"
           }
         }
       },

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -49,6 +49,14 @@ properties:
     type: float
     description: "The longitude of the provider's address"
     example: "-0.129900"
+  telephone:
+    type: string
+    description: "The provider's telephone number."
+    example: "01834 80657"
+  email:
+    type: string
+    description: "The provider's email address."
+    example: "school@example.com"
   name:
     type: string
     description: "The name of the training provider."


### PR DESCRIPTION
### Context
In order to move Find over to the Public API, we need to expose additional attributes on the Public API.

### Changes proposed in this pull request

- Expose a providers phone number and email address on the public API 
- Results count in the meta options

### Guidance to review
Does the course count need to be added to the swagger documentation
<img width="908" alt="meta_count" src="https://user-images.githubusercontent.com/47917431/103777904-77e04600-5029-11eb-9513-f819954d3a9f.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
