### PR TITLE
[2829] - Add courses count to Public API

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -5,6 +5,7 @@ module API
         def index
           render jsonapi: paginate(courses),
                  include: include_param,
+                 meta: { count: courses.count("course.id") },
                  class: API::Public::V1::SerializerService.call
         end
 

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -52,12 +52,6 @@ module API
         attribute :street_address_2 do
           @object.address2
         end
-
-        has_many :courses do
-          meta do
-            { count: @object.courses_count }
-          end
-        end
       end
     end
   end

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -202,6 +202,19 @@ RSpec.describe API::Public::V1::CoursesController do
           )
         end
       end
+
+      context "courses count" do
+        it "returns the course count in a meta object" do
+          get :index, params: {
+            recruitment_cycle_year: recruitment_cycle.year,
+          }
+
+          json_response = JSON.parse(response.body)
+          meta = json_response["meta"]
+
+          expect(meta["count"]).to be(2)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe API::Public::V1::ProvidersController do
           recruitment_cycle_id = relationships.dig("recruitment_cycle", "data", "id").to_i
 
           expect(json_response["data"][0]["relationships"].keys.sort).to eq(
-            %w[courses recruitment_cycle],
+            %w[recruitment_cycle],
           )
 
           expect(recruitment_cycle_id).to eq(provider.recruitment_cycle.id)


### PR DESCRIPTION
### Context

- We accidentally added the Provider courses count from the v2 API in https://github.com/DFE-Digital/teacher-training-api/pull/1713 (soz)
- What we actually want to do is add the _courses_ count to the meta object when the Public API receives course search queries (which is currently the behaviour in v3)

### Changes proposed in this pull request
- Remove Provider courses count from the Public API
- Return the (search) courses count in the meta object from the Courses Controller. This matches the behaviour in the v3 API.

### Trello
https://trello.com/c/e5NdFola/2829-dev-expose-required-attributes-on-the-v1-public-api

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
