### PR TITLE
[755] Clean up include examples for public api end points

### DIFF
--- a/spec/docs/provider_suggestions_spec.rb
+++ b/spec/docs/provider_suggestions_spec.rb
@@ -23,12 +23,6 @@ describe "API" do
 
         run_test!
       end
-
-      response "400", "A bad request" do
-        let(:query) { nil }
-
-        run_test!
-      end
     end
   end
 end

--- a/spec/docs/providers/courses/locations_spec.rb
+++ b/spec/docs/providers/courses/locations_spec.rb
@@ -44,7 +44,7 @@ describe "API" do
         let(:course_code) { course.course_code }
         let(:include) { "provider" }
 
-        schema "$ref": "#/components/schemas/LocationListResponse"
+        schema "$ref": "#/components/schemas/CourseLocationListResponse"
 
         before do
           course.sites << build_list(

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -45,6 +45,15 @@ describe "API" do
                 required: false,
                 example: { page: 2, per_page: 10 },
                 description: "Pagination options to navigate through the collection."
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: {
+                  enum: %w[accredited_body provider recruitment_cycle],
+                },
+                example: "recruitment_cycle,provider"
 
       curl_example description: "Get all courses for a provider",
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses"
@@ -56,6 +65,7 @@ describe "API" do
         let(:provider) { create(:provider) }
         let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }
+        let(:include) { "provider" }
 
         before do
           create(:course, provider: provider, course_code: "C100")
@@ -92,6 +102,15 @@ describe "API" do
                 required: true,
                 description: "The code of the course.",
                 example: "X130"
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: {
+                  enum: %w[accredited_body provider recruitment_cycle],
+                },
+                example: "recruitment_cycle,provider"
 
       curl_example description: "Get a course for a provider",
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20/courses/2N22"
@@ -103,6 +122,7 @@ describe "API" do
         let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }
         let(:course_code) { course.course_code }
+        let(:include) { "provider" }
 
         schema "$ref": "#/components/schemas/CourseSingleResponse"
 

--- a/spec/docs/providers/locations_spec.rb
+++ b/spec/docs/providers/locations_spec.rb
@@ -24,9 +24,9 @@ describe "API" do
                 required: false,
                 description: "The associated data for this resource.",
                 schema: {
-                  enum: %w[recruitment_cycle provider],
+                  enum: %w[recruitment_cycle provider course location_status],
                 },
-                example: "recruitment_cycle,provider"
+                example: "recruitment_cycle,provider,course,location_status"
 
       response "200", "The collection of locations for the specified provider." do
         let(:provider) { create(:provider) }
@@ -34,7 +34,7 @@ describe "API" do
         let(:provider_code) { provider.provider_code }
         let(:include) { "provider" }
 
-        schema "$ref": "#/components/schemas/LocationListResponse"
+        schema "$ref": "#/components/schemas/ProviderLocationListResponse"
 
         before do
           provider.sites << build_list(

--- a/spec/docs/providers_spec.rb
+++ b/spec/docs/providers_spec.rb
@@ -74,6 +74,15 @@ describe "API" do
                 required: true,
                 description: "The unique code of the provider.",
                 example: "T92"
+      parameter name: :include,
+                in: :query,
+                type: :string,
+                required: false,
+                description: "The associated data for this resource.",
+                schema: {
+                  enum: %w[recruitment_cycle],
+                },
+                example: "recruitment_cycle"
 
       curl_example description: "Get a specific provider",
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/recruitment_cycles/2020/providers/B20"
@@ -82,6 +91,7 @@ describe "API" do
         let(:provider) { create(:provider, provider_code: "1AT") }
         let(:year) { provider.recruitment_cycle.year }
         let(:provider_code) { provider.provider_code }
+        let(:include) { nil }
 
         schema "$ref": "#/components/schemas/ProviderSingleResponse"
 
@@ -91,6 +101,7 @@ describe "API" do
       response "404", "The non existant provider." do
         let(:year) { "2020" }
         let(:provider_code) { "999" }
+        let(:include) { nil }
 
         schema "$ref": "#/components/schemas/NotFoundResponse"
 

--- a/spec/docs/subject_areas_spec.rb
+++ b/spec/docs/subject_areas_spec.rb
@@ -18,7 +18,7 @@ describe "API" do
                    command: "curl -X GET https://api.publish-teacher-training-courses.service.gov.uk/api/public/v1/subject_areas"
 
       response "200", "The collection of subject areas." do
-        let(:include) { "subjects" }
+        let(:include) { nil }
 
         schema "$ref": "#/components/schemas/SubjectAreaListResponse"
 

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -410,7 +410,56 @@
             }
           },
           "included": {
-            "$ref": "#/components/schemas/Included"
+            "description": "This returns the requested associated data.",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RecruitmentCycleResource"
+                },
+                {
+                  "$ref": "#/components/schemas/ProviderResource"
+                }
+              ]
+            }
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
+      "CourseLocationListResponse": {
+        "description": "This schema is used to return a collection of locations for a specified course.",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocationResource"
+            }
+          },
+          "included": {
+            "description": "This returns the requested associated data.",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RecruitmentCycleResource"
+                },
+                {
+                  "$ref": "#/components/schemas/ProviderResource"
+                },
+                {
+                  "$ref": "#/components/schemas/LocationStatusResource"
+                },
+                {
+                  "$ref": "#/components/schemas/CourseResource"
+                }
+              ]
+            }
           },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
@@ -421,23 +470,14 @@
         "description": "This schema is used to describe associations that can be returned with a course.",
         "type": "object",
         "properties": {
+          "recruitment_cycle": {
+            "$ref": "#/components/schemas/Relationship"
+          },
           "accredited_body": {
             "$ref": "#/components/schemas/Relationship"
           },
-          "locations": {
-            "$ref": "#/components/schemas/RelationshipList"
-          },
-          "modern_languages": {
-            "$ref": "#/components/schemas/RelationshipList"
-          },
-          "provider_locations": {
-            "$ref": "#/components/schemas/RelationshipList"
-          },
           "provider": {
             "$ref": "#/components/schemas/Relationship"
-          },
-          "subjects": {
-            "$ref": "#/components/schemas/RelationshipList"
           }
         }
       },
@@ -477,7 +517,18 @@
             "$ref": "#/components/schemas/CourseResource"
           },
           "included": {
-            "$ref": "#/components/schemas/Included"
+            "description": "This returns the requested associated data.",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RecruitmentCycleResource"
+                },
+                {
+                  "$ref": "#/components/schemas/ProviderResource"
+                }
+              ]
+            }
           },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
@@ -676,27 +727,6 @@
           }
         }
       },
-      "LocationListResponse": {
-        "description": "This schema is used to return a collection of locations.",
-        "type": "object",
-        "required": [
-          "data"
-        ],
-        "properties": {
-          "data": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LocationResource"
-            }
-          },
-          "included": {
-            "$ref": "#/components/schemas/Included"
-          },
-          "jsonapi": {
-            "$ref": "#/components/schemas/JSONAPI"
-          }
-        }
-      },
       "LocationRelationships": {
         "description": "This schema is used to describe associations that can be returned with locations.",
         "type": "object",
@@ -708,6 +738,9 @@
             "$ref": "#/components/schemas/Relationship"
           },
           "course": {
+            "$ref": "#/components/schemas/Relationship"
+          },
+          "location_status": {
             "$ref": "#/components/schemas/Relationship"
           }
         }
@@ -998,7 +1031,48 @@
             }
           },
           "included": {
-            "$ref": "#/components/schemas/Included"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RecruitmentCycleResource"
+            }
+          },
+          "jsonapi": {
+            "$ref": "#/components/schemas/JSONAPI"
+          }
+        }
+      },
+      "ProviderLocationListResponse": {
+        "description": "This schema is used to return a collection of locations for a specified provider.",
+        "type": "object",
+        "required": [
+          "data"
+        ],
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocationResource"
+            }
+          },
+          "included": {
+            "description": "This returns the requested associated data.",
+            "type": "array",
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/RecruitmentCycleResource"
+                },
+                {
+                  "$ref": "#/components/schemas/ProviderResource"
+                },
+                {
+                  "$ref": "#/components/schemas/LocationStatusResource"
+                },
+                {
+                  "$ref": "#/components/schemas/CourseResource"
+                }
+              ]
+            }
           },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
@@ -1009,9 +1083,6 @@
         "description": "This schema is used to describe associations that can be returned with a provider.",
         "type": "object",
         "properties": {
-          "locations": {
-            "$ref": "#/components/schemas/RelationshipList"
-          },
           "recruitment_cycle": {
             "$ref": "#/components/schemas/Relationship"
           }
@@ -1054,7 +1125,10 @@
             "$ref": "#/components/schemas/ProviderResource"
           },
           "included": {
-            "$ref": "#/components/schemas/Included"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RecruitmentCycleResource"
+            }
           },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
@@ -1102,17 +1176,20 @@
         "properties": {
           "year": {
             "type": "integer",
-            "description": "The year that this recruitment cycle applies to."
+            "description": "The year that this recruitment cycle applies to.",
+            "example": 2021
           },
           "application_start_date": {
             "type": "string",
             "format": "date",
-            "description": "The default date applications start being taken for this recruitment cycle."
+            "description": "The default date applications start being taken for this recruitment cycle.",
+            "example": "2020-10-13"
           },
           "application_end_date": {
             "type": "string",
             "format": "date",
-            "description": "The default date applications stop being taken for this recruitment cycle."
+            "description": "The default date applications stop being taken for this recruitment cycle.",
+            "example": "2021-10-03"
           }
         }
       },
@@ -1126,10 +1203,12 @@
         ],
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "string",
+            "example": "3"
           },
           "type": {
-            "type": "string"
+            "type": "string",
+            "example": "recruitment_cycles"
           },
           "attributes": {
             "$ref": "#/components/schemas/RecruitmentCycleAttributes"
@@ -1242,7 +1321,10 @@
             }
           },
           "included": {
-            "$ref": "#/components/schemas/Included"
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SubjectResource"
+            }
           },
           "jsonapi": {
             "$ref": "#/components/schemas/JSONAPI"
@@ -1284,30 +1366,33 @@
         "properties": {
           "name": {
             "type": "string",
-            "description": "Subject name."
+            "description": "Subject name.",
+            "example": "Primary with science"
           },
           "code": {
             "type": "string",
-            "description": "Unique subject code."
+            "description": "Unique subject code.",
+            "example": "07"
           },
           "bursary_amount": {
-            "type": "integer",
+            "type": "string",
             "description": "Non-repayable sum of money that universities can award to students to incentivise and support their studies",
-            "example": 9000
+            "example": "9000"
           },
           "early_career_payments": {
-            "type": "integer",
+            "type": "string",
             "description": "Eligible subjects teachers can apply for early-career payments of up to £9,000 after tax.",
-            "example": 8388
+            "example": "8388"
           },
           "scholarship": {
-            "type": "integer",
+            "type": "string",
             "description": "A grant or payment made to support a student’s education, awarded on the basis of academic or other achievement.",
-            "example": 3500
+            "example": "3500"
           },
           "subject_knowledge_enhancement_course_available": {
             "type": "boolean",
-            "description": "SKE courses are available in various subjects. Schools or universities will identify your need for an SKE as part of their selection process, usually at interview. If they feel you need to enhance your knowledge, but have potential to be a great teacher, they’ll offer you a teacher training place on the condition that you complete an SKE course."
+            "description": "SKE courses are available in various subjects. Schools or universities will identify your need for an SKE as part of their selection process, usually at interview. If they feel you need to enhance your knowledge, but have potential to be a great teacher, they’ll offer you a teacher training place on the condition that you complete an SKE course.",
+            "example": true
           }
         }
       },
@@ -1321,7 +1406,8 @@
         ],
         "properties": {
           "id": {
-            "type": "integer"
+            "type": "string",
+            "example": "3"
           },
           "type": {
             "type": "string",
@@ -1473,9 +1559,6 @@
                 }
               }
             }
-          },
-          "400": {
-            "description": "A bad request"
           }
         }
       }
@@ -1546,7 +1629,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LocationListResponse"
+                  "$ref": "#/components/schemas/CourseLocationListResponse"
                 }
               }
             }
@@ -1623,6 +1706,20 @@
               "per_page": 10
             },
             "description": "Pagination options to navigate through the collection."
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "accredited_body",
+                "provider",
+                "recruitment_cycle"
+              ]
+            },
+            "example": "recruitment_cycle,provider"
           }
         ],
         "x-curl-examples": [
@@ -1686,6 +1783,20 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "accredited_body",
+                "provider",
+                "recruitment_cycle"
+              ]
+            },
+            "example": "recruitment_cycle,provider"
           }
         ],
         "x-curl-examples": [
@@ -1744,10 +1855,12 @@
             "schema": {
               "enum": [
                 "recruitment_cycle",
-                "provider"
+                "provider",
+                "course",
+                "location_status"
               ]
             },
-            "example": "recruitment_cycle,provider"
+            "example": "recruitment_cycle,provider,course,location_status"
           }
         ],
         "responses": {
@@ -1756,7 +1869,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LocationListResponse"
+                  "$ref": "#/components/schemas/ProviderLocationListResponse"
                 }
               }
             }
@@ -1873,6 +1986,18 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "required": false,
+            "description": "The associated data for this resource.",
+            "schema": {
+              "enum": [
+                "recruitment_cycle"
+              ]
+            },
+            "example": "recruitment_cycle"
           }
         ],
         "x-curl-examples": [

--- a/swagger/public_v1/component_schemas/CourseRelationships.yml
+++ b/swagger/public_v1/component_schemas/CourseRelationships.yml
@@ -2,15 +2,9 @@
 description: "This schema is used to describe associations that can be returned with a course."
 type: object
 properties:
+  recruitment_cycle:
+    $ref: "#/components/schemas/Relationship"
   accredited_body:
     $ref: "#/components/schemas/Relationship"
-  locations:
-    $ref: "#/components/schemas/RelationshipList"
-  modern_languages:
-    $ref: "#/components/schemas/RelationshipList"
-  provider_locations:
-    $ref: "#/components/schemas/RelationshipList"
   provider:
     $ref: "#/components/schemas/Relationship"
-  subjects:
-    $ref: "#/components/schemas/RelationshipList"

--- a/swagger/public_v1/component_schemas/LocationRelationships.yml
+++ b/swagger/public_v1/component_schemas/LocationRelationships.yml
@@ -8,3 +8,5 @@ properties:
     $ref: "#/components/schemas/Relationship"
   course:
     $ref: "#/components/schemas/Relationship"
+  location_status:
+    $ref: "#/components/schemas/Relationship"

--- a/swagger/public_v1/component_schemas/ProviderRelationships.yml
+++ b/swagger/public_v1/component_schemas/ProviderRelationships.yml
@@ -2,7 +2,5 @@
 description: "This schema is used to describe associations that can be returned with a provider."
 type: object
 properties:
-  locations:
-    $ref: "#/components/schemas/RelationshipList"
   recruitment_cycle:
     $ref: "#/components/schemas/Relationship"

--- a/swagger/public_v1/component_schemas/RecruitmentCycleAttributes.yml
+++ b/swagger/public_v1/component_schemas/RecruitmentCycleAttributes.yml
@@ -7,13 +7,16 @@ properties:
   year:
     type: integer
     description: "The year that this recruitment cycle applies to."
+    example: 2021
   application_start_date:
     type: string
     format: date
     description: >-
       The default date applications start being taken for this recruitment cycle.
+    example: "2020-10-13"
   application_end_date:
     type: string
     format: date
     description: >-
       The default date applications stop being taken for this recruitment cycle.
+    example: "2021-10-03"

--- a/swagger/public_v1/component_schemas/SubjectAttributes.yml
+++ b/swagger/public_v1/component_schemas/SubjectAttributes.yml
@@ -5,21 +5,24 @@ properties:
   name:
     type: string
     description: "Subject name."
+    example: "Primary with science"
   code:
     type: string
     description: "Unique subject code."
+    example: "07"
   bursary_amount:
-    type: integer
+    type: string
     description: "Non-repayable sum of money that universities can award to students to incentivise and support their studies"
-    example: 9000
+    example: "9000"
   early_career_payments:
-    type: integer
+    type: string
     description: "Eligible subjects teachers can apply for early-career payments of up to £9,000 after tax."
-    example: 8388
+    example: "8388"
   scholarship:
-    type: integer
+    type: string
     description: "A grant or payment made to support a student’s education, awarded on the basis of academic or other achievement."
-    example: 3500
+    example: "3500"
   subject_knowledge_enhancement_course_available:
     type: boolean
     description: "SKE courses are available in various subjects. Schools or universities will identify your need for an SKE as part of their selection process, usually at interview. If they feel you need to enhance your knowledge, but have potential to be a great teacher, they’ll offer you a teacher training place on the condition that you complete an SKE course."
+    example: true

--- a/swagger/public_v1/template.yml
+++ b/swagger/public_v1/template.yml
@@ -53,7 +53,12 @@ components:
           items:
             $ref: "#/components/schemas/CourseResource"
         included:
-          $ref: "#/components/schemas/Included"
+          description: "This returns the requested associated data."
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/RecruitmentCycleResource"
+              - $ref: "#/components/schemas/ProviderResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     CourseSingleResponse:
@@ -66,7 +71,12 @@ components:
         data:
           $ref: "#/components/schemas/CourseResource"
         included:
-          $ref: "#/components/schemas/Included"
+          description: "This returns the requested associated data."
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/RecruitmentCycleResource"
+              - $ref: "#/components/schemas/ProviderResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     Included:
@@ -139,8 +149,8 @@ components:
           $ref: "#/components/schemas/LocationAttributes"
         relationships:
           $ref: "#/components/schemas/LocationRelationships"
-    LocationListResponse:
-      description: "This schema is used to return a collection of locations."
+    ProviderLocationListResponse:
+      description: "This schema is used to return a collection of locations for a specified provider."
       type: object
       required:
         - data
@@ -150,7 +160,35 @@ components:
           items:
             $ref: "#/components/schemas/LocationResource"
         included:
-          $ref: "#/components/schemas/Included"
+          description: "This returns the requested associated data."
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/RecruitmentCycleResource"
+              - $ref: "#/components/schemas/ProviderResource"
+              - $ref: "#/components/schemas/LocationStatusResource"
+              - $ref: "#/components/schemas/CourseResource"
+        jsonapi:
+          $ref: "#/components/schemas/JSONAPI"
+    CourseLocationListResponse:
+      description: "This schema is used to return a collection of locations for a specified course."
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/LocationResource"
+        included:
+          description: "This returns the requested associated data."
+          type: array
+          items:
+            anyOf:
+              - $ref: "#/components/schemas/RecruitmentCycleResource"
+              - $ref: "#/components/schemas/ProviderResource"
+              - $ref: "#/components/schemas/LocationStatusResource"
+              - $ref: "#/components/schemas/CourseResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     LocationStatusResource:
@@ -195,7 +233,9 @@ components:
           items:
             $ref: "#/components/schemas/ProviderResource"
         included:
-          $ref: "#/components/schemas/Included"
+          type: array
+          items:
+            $ref: "#/components/schemas/RecruitmentCycleResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     NotFoundResponse:
@@ -220,7 +260,9 @@ components:
         data:
           $ref: "#/components/schemas/ProviderResource"
         included:
-          $ref: "#/components/schemas/Included"
+          type: array
+          items:
+            $ref: "#/components/schemas/RecruitmentCycleResource"          
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"
     ProviderSuggestion:
@@ -291,9 +333,11 @@ components:
         - attributes
       properties:
         id:
-          type: integer
+          type: string
+          example: "3"
         type:
           type: string
+          example: "recruitment_cycles"
         attributes:
           $ref: "#/components/schemas/RecruitmentCycleAttributes"
     SubjectResource:
@@ -305,7 +349,8 @@ components:
         - attributes
       properties:
         id:
-          type: integer
+          type: string
+          example: "3"
         type:
           type: string
           example: subjects
@@ -337,6 +382,8 @@ components:
           items:
             $ref: "#/components/schemas/SubjectAreaResource"
         included:
-          $ref: "#/components/schemas/Included"
+          type: array
+          items:
+            $ref: "#/components/schemas/SubjectResource"
         jsonapi:
           $ref: "#/components/schemas/JSONAPI"


### PR DESCRIPTION
### Context

- https://trello.com/c/Hpj3nXtX/755-m-refactor-include-schema-definition-setup

### Changes proposed in this pull request

- Refactors some of the documented public endpoint examples to correctly show their relationships/include options
- Previously, any endpoint with an optional include query parameter would return a random `Resource` defined in the swagger template, this change makes it more explicit what to render in that file.

### Guidance to review

- Fire up the API docs locally
- Assert any endpoint with optional includes shows the correct structure in the response example

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
