### PR TITLE
[711] Smoke test for /healthcheck and /courses routes

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
 
       - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: echo "Nothing to run yet 🚀"
+        run: RAILS_ENV=${{ github.event.inputs.environment }} bundle exec rspec --tag smoke
 
       - name: 'Nofiy #twd_publish_register_tech on failure'
         if: failure()

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--require spec_helper
+--tag ~smoke

--- a/.rspec_parallel
+++ b/.rspec_parallel
@@ -2,4 +2,5 @@
 --format progress
 --format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 --no-profile --format RspecJunitFormatter --out rspec-output/rspec-output<%= ENV['TEST_ENV_NUMBER'] %>.xml
+--tag ~smoke
 

--- a/docs/healthcheck_and_ping_endpoints.md
+++ b/docs/healthcheck_and_ping_endpoints.md
@@ -12,7 +12,7 @@ endpoint is activated.
 
 ## Healthcheck
 
-Use the `/healchtheck` to check whether that the app's dependencies are working.
+Use the `/healthcheck` to check whether that the app's dependencies are working.
 This returns a JSON structure that lists the checks it performs and their
 results. For example:
 

--- a/spec/requests/smoke/courses_spec.rb
+++ b/spec/requests/smoke/courses_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "V1 Public API courses smoke test", :smoke do
+  let(:base_url) { Settings.publish_url.sub("www", "api") }
+
+  describe "GET /api/public/v1/courses" do
+    before do
+      get "#{base_url}/api/public/v1/courses"
+    end
+
+    it "returns HTTP success" do
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/spec/requests/smoke/healthcheck_spec.rb
+++ b/spec/requests/smoke/healthcheck_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe "V1 Public API healthcheck smoke test", :smoke do
+  let(:base_url) { Settings.publish_url.sub("www", "api") }
+
+  describe "GET /healthcheck" do
+    before do
+      get "#{base_url}/healthcheck"
+    end
+
+    it "returns HTTP success" do
+      expect(response.status).to eq(200)
+    end
+
+    it "returns JSON" do
+      expect(response.media_type).to eq("application/json")
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq(
+        {
+          checks: {
+            database: true,
+            redis: true,
+            sidekiq_processes: true,
+          },
+        }.to_json,
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/tcSBRSoL/711-m-healthcheck-smoke-test
https://trello.com/c/2EUGHq7k/713-m-courses-endpoint-smoke-tests

### Changes proposed in this pull request

This PR is ⭐inspired⭐  by https://github.com/DFE-Digital/register-trainee-teachers/pull/372:

- Create a new spec directory for smoke tests
- Setup basic healthcheck and courses smoke tests to assert response of system without stubs
- Setup a tag to run specs without smoke tests by default
- Run smoke tests in build workflow

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
