### PR TITLE
Add additional missing attributes to the teacher training public API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -33,7 +33,8 @@ module API
                    :qualifications,
                    :scholarship_amount,
                    :study_mode,
-                   :uuid
+                   :uuid,
+                   :description
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:running).with_value(course.findable?) }
   it { is_expected.to have_attribute(:salary_details).with_value(course.latest_published_enrichment.salary_details) }
   it { is_expected.to have_attribute(:scholarship_amount).with_value(nil) }
+  it { is_expected.to have_attribute(:description).with_value(course.description) }
 
   context "when bursary amount is present" do
     let(:course) { create(:course, :with_accrediting_provider, :secondary, enrichments: [enrichment], subjects: [find_or_create(:secondary_subject, :classics)]) }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -394,6 +394,11 @@
             "type": "string",
             "description": "Generated summary of the course.",
             "example": "PGCE with QTS full time"
+          },
+          "description": {
+            "type": "string",
+            "description": "A combined string of qualification, study mode & programme type.",
+            "example": "PGCE with QTS full time teaching apprenticeship."
           }
         }
       },


### PR DESCRIPTION
### Context

There are some further attributes that need to be added to the Public API

### Changes proposed in this pull request

Add `:description`, `:provider_code` and `:provider_type`   to SerializableCourse

### Trello

https://trello.com/c/wsR2MIzj/2841-add-more-missing-attributes-to-teacher-training-public-api

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
