### PR TITLE
[712] V1 public API smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -11,15 +11,29 @@ jobs:
     name: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Ruby 2.7.2
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.2
+
+      - name: install bundler and gems
+        run: |
+          gem install bundler
+          echo 'gem "httparty"' >> Gemfile
+          echo 'gem "rspec"' >> Gemfile
+          bundle
+
       - uses: softprops/turnstyle@v1
         name: Wait for other runs
         env:
           GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
 
       - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: echo "Nothing to run yet 🚀"
+        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke --format documentation
 
-      - name: 'Nofiy #twd_publish_register_tech on failure'
+      - name: 'Notify #twd_publish_register_tech on failure'
         if: failure()
         uses: rtCamp/action-slack-notify@master
         env:

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "spec_helper_smoke"
+
+describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
+  let(:recruitment_year) { Settings.current_recruitment_cycle_year }
+  let(:base_url) { Settings.publish_url.sub("www", "api") }
+
+  subject(:response) { HTTParty.get(url) }
+
+  context "providers" do
+    describe "GET /v1/recruitment_cycles/:recruitment_year/providers" do
+      let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/providers?[per_page]=1" }
+
+      it "returns a HTTP status code of 200" do
+        expect(response.code).to eq(200)
+      end
+
+      it "returns at least one record" do
+        expect(response.parsed_response["data"].length).to be_positive
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -45,6 +45,8 @@ Dir["./spec/support/**/*.rb"].sort.each { |file| require file }
 RSpec::Matchers.define_negated_matcher :not_change, :change
 
 RSpec.configure do |config|
+  config.filter_run_excluding smoke: true
+
   # Reduce noise in console when running specs in parallel
   config.silence_filter_announcements = true if ENV["TEST_ENV_NUMBER"]
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/spec_helper_smoke.rb
+++ b/spec/spec_helper_smoke.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+ENV["RAILS_ENV"] ||= "test"
+
+require "rspec"
+require "config"
+require "httparty"
+require "active_support/time"
+
+Config.load_and_set_settings(Config.setting_files("config", ENV["RAILS_ENV"]))


### PR DESCRIPTION
### Context
https://trello.com/c/uqDY2T7t/712-m-providers-endpoint-smoke-tests

### Changes proposed in this pull request
- Modify smoke test Github action to dynamically update `Gemfile` so it can use `rspec` and `httparty` in any environment
- New `spec_helper_smoke.rb`
- Smoke test to check V1 providers endpoint returns HTTP status of 200

### Guidance to review
- Copy and paste the following into the existing `Gemfile` and run `bundle`:
```
gem "httparty"
gem "rspec"
```
- run `bundle exec rspec spec/spoke` - the test should pass
- run `RAILS_ENV=qa bundle exec rspec spec/spoke` - the test should pass
- run `RAILS_ENV=staging bundle exec rspec spec/spoke` - the test should pass
- run `RAILS_ENV=production bundle exec rspec spec/spoke` - the test should pass

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
