### PR TITLE
[2849] - Add findable filter to Public API

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -20,6 +20,7 @@ class CourseSearchService
     scope = scope.with_salary if funding_filter_salary?
     scope = scope.with_qualifications(qualifications) if qualifications.any?
     scope = scope.with_vacancies if has_vacancies?
+    scope = scope.findable if findable?
     scope = scope.with_study_modes(study_types) if study_types.any?
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope = scope.with_provider_name(provider_name) if provider_name.present?
@@ -167,6 +168,10 @@ private
 
   def has_vacancies?
     filter[:has_vacancies].to_s.downcase == "true"
+  end
+
+  def findable?
+    filter[:findable].to_s.downcase == "true"
   end
 
   def study_types

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe CourseSearchService do
       context "when false" do
         let(:filter) { { has_vacancies: false } }
 
-        it "adds the with_vacancies scope" do
+        it "doesn't add the with_vacancies scope" do
           expect(scope).not_to receive(:with_vacancies)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
@@ -299,6 +299,42 @@ RSpec.describe CourseSearchService do
 
         it "doesn't add the with_vacancies scope" do
           expect(scope).not_to receive(:with_vacancies)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+    end
+
+    describe "filter[findable]" do
+      context "when true" do
+        let(:filter) { { findable: true } }
+        let(:expected_scope) { double }
+
+        it "adds the findable scope" do
+          expect(scope).to receive(:findable).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when false" do
+        let(:filter) { { findable: false } }
+
+        it "doesn't add the findable scope" do
+          expect(scope).not_to receive(:findable)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the findable scope" do
+          expect(scope).not_to receive(:findable)
           expect(scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)

--- a/swagger/public_v1/component_schemas/Filter.yml
+++ b/swagger/public_v1/component_schemas/Filter.yml
@@ -6,6 +6,10 @@ properties:
     description: "Return courses that only have vacancies?"
     type: boolean
     example: true
+  findable:
+    description: "Return courses that are currently available on the Find Postgraduate Teacher Training service"
+    type: boolean
+    example: true
   funding_type:
     description: "Return courses depending on how it is funded. This is a comma delimited string. If multiple funding options are provided then any course matching any one of the options provided will be retuned, i.e. the OR operator is used."
     type: string


### PR DESCRIPTION
### Context

The Public API currently returns 'findable' and 'non-findable' courses.

In the V3 API only 'findable' courses are returned.

It has been agreed that Public API clients now need to add a 'findable' filter param to their requests in order to fetch 'findable' courses.

### Changes proposed in this pull request
- Add findable scope to CourseSearchService
- Update v3 CoursesController to merge a 'findable' filter param into filter params before passing courses to the CourseSearchService
- Update 'findable' description in docs

### Trello
https://trello.com/c/S2m1uZtm/2849-add-findable-filter-to-teacher-training-public-api

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
