### PR TITLE
Add healthCheck monitor to app service

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -513,6 +513,9 @@
           "runtimeStack": {
             "value": "[variables('appServiceRuntimeStack')]"
           },
+          "healthCheckPath":{
+            "value": "/ping"
+          },
           "appServiceAppSettings": {
             "value": [
               {
@@ -606,6 +609,10 @@
               {
                   "name": "DOCKER_REGISTRY_SERVER_PASSWORD",
                   "value": "[parameters('dockerRegistryPassword')]"
+              },
+              {
+                "name": "WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
+                "value": "5"
               }
             ]
           },


### PR DESCRIPTION
This will automatically truncate web requests from reaching faulting app plan instance(s)

### Context

Health Check Monitor for probing faulty app plan instances by checking app service endpoints

### Changes proposed in this pull request

Introduce one new parameters `"healthcheckpath":{
+                                                                             "value": "/ping"
                                                                              },`

Add new key\value pair to appServiceAppSetting parameters:-

`{
 "name": "WEBSITE_HEALTHCHECK_MAXPINGFAILURES",
  "value": "5"
 }`

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
