### PR TITLE
[711] Smoke test for healthcheck and courses index routes

### DIFF
--- a/docs/healthcheck_and_ping_endpoints.md
+++ b/docs/healthcheck_and_ping_endpoints.md
@@ -12,7 +12,7 @@ endpoint is activated.
 
 ## Healthcheck
 
-Use the `/healchtheck` to check whether that the app's dependencies are working.
+Use the `/healthcheck` to check whether that the app's dependencies are working.
 This returns a JSON structure that lists the checks it performs and their
 results. For example:
 

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "spec_helper_smoke"
+
+describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
+  let(:base_url) { Settings.publish_url.sub("www", "api") }
+
+  subject(:response) { HTTParty.get(url) }
+
+  context "courses" do
+    describe "GET /api/public/v1/recruitment_cycles/:recruitment_year/courses" do
+      let(:recruitment_year) { Settings.current_recruitment_cycle_year }
+      let(:url) { "#{base_url}/api/public/v1/recruitment_cycles/#{recruitment_year}/courses?page[per_page]=1" }
+
+      it "returns HTTP success" do
+        expect(response.code).to eq(200)
+      end
+
+      it "returns at least one record" do
+        expect(response.parsed_response["data"].length).to be_positive
+      end
+
+      it "returns at positive record count within meta" do
+        expect(response.parsed_response["meta"]["count"]).to be_positive
+      end
+    end
+  end
+end

--- a/spec/smoke/api/v1/healthcheck_spec.rb
+++ b/spec/smoke/api/v1/healthcheck_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "spec_helper_smoke"
+
+describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
+  let(:base_url) { Settings.publish_url.sub("www", "api") }
+
+  subject(:response) { HTTParty.get(url) }
+
+  describe "GET /healthcheck" do
+    let(:url) { "#{base_url}/healthcheck" }
+
+    it "returns HTTP success" do
+      expect(response.code).to eq(200)
+    end
+
+    it "returns JSON" do
+      expect(response.content_type).to eq("application/json")
+    end
+
+    it "returns the expected response report" do
+      expect(response.body).to eq(
+        {
+          checks: {
+            database: true,
+            redis: true,
+            sidekiq_processes: true,
+          },
+        }.to_json,
+      )
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/tcSBRSoL/711-m-healthcheck-smoke-test
https://trello.com/c/2EUGHq7k/713-m-courses-endpoint-smoke-tests

### Changes proposed in this pull request

- Smoke test to check V1 /healthcheck endpoint returns HTTP status of 200, json and expected shape
- Smoke test to check V1 /courses endpoint returns HTTP status of 200

### Guidance to review

As per the instructions in https://github.com/DFE-Digital/teacher-training-api/pull/1725

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally