### PR TITLE
Pin docker image to alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.2-alpine AS middleman
+FROM ruby:2.7.2-alpine3.12 AS middleman
 
 RUN apk add --update --no-cache npm git build-base
 
@@ -15,7 +15,7 @@ RUN bundle exec middleman build --build-dir=../public
 
 ###
 
-FROM ruby:2.7.2-alpine
+FROM ruby:2.7.2-alpine3.12
 
 ARG COMMIT_SHA
 


### PR DESCRIPTION
### Context

alpine has released version 3.13 with
an updated version of node which might cause version conflicts.

### Changes proposed in this pull request
use `ruby:2.7.2-alpine3.12`


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
