### PR TITLE
[851] Add `updated_since` filter option for /api/public/v1/courses

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -27,6 +27,7 @@ class CourseSearchService
     scope = scope.with_send if send_courses_filter?
     scope = scope.within(filter[:radius], origin: origin) if locations_filter?
     scope = scope.with_funding_types(funding_types) if funding_types.any?
+    scope = scope.changed_since(filter[:updated_since]) if updated_since_filter?
 
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
@@ -200,5 +201,9 @@ private
 
   def send_courses_filter?
     filter[:send_courses].to_s.downcase == "true"
+  end
+
+  def updated_since_filter?
+    filter[:updated_since].present?
   end
 end

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -20,7 +20,11 @@ describe "API" do
                 explode: true,
                 required: false,
                 description: "Refine courses to return.",
-                example: { has_vacancies: true, subjects: "00,01" }
+                example: {
+                  has_vacancies: true,
+                  subjects: "00,01",
+                  updated_since: "2020-11-13T11:21:55Z",
+                }
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -26,7 +26,11 @@ describe "API" do
                 explode: true,
                 required: false,
                 description: "Refine courses to return.",
-                example: { has_vacancies: true, subjects: "00,01" }
+                example: {
+                  has_vacancies: true,
+                  subjects: "00,01",
+                  updated_since: "2020-11-13T11:21:55Z",
+                }
       parameter name: :sort,
                 in: :query,
                 schema: { "$ref" => "#/components/schemas/Sort" },

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -215,6 +215,18 @@ RSpec.describe CourseSearchService do
       end
     end
 
+    describe "filter[updated_since]" do
+      let(:filter) { { updated_since: Time.zone.now.iso8601 } }
+      let(:expected_scope) { double }
+
+      it "adds the changed_since scope" do
+        expect(scope).to receive(:changed_since).and_return(course_ids_scope)
+        expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+        expect(course_with_includes).to receive(:where).and_return(expected_scope)
+        expect(subject).to eq(expected_scope)
+      end
+    end
+
     describe "filter[funding]" do
       context "when value is salary" do
         let(:filter) { { funding: "salary" } }

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -511,6 +511,11 @@
             "description": "Search radius in miles from given latitude and longitude.",
             "type": "number",
             "example": 20
+          },
+          "updated_since": {
+            "description": "Return courses have been updated since the date (ISO 8601 date format)",
+            "type": "string",
+            "example": "2020-11-13T11:21:55Z"
           }
         }
       },
@@ -1482,7 +1487,8 @@
             "description": "Refine courses to return.",
             "example": {
               "has_vacancies": true,
-              "subjects": "00,01"
+              "subjects": "00,01",
+              "updated_since": "2020-11-13T11:21:55Z"
             }
           },
           {
@@ -1718,7 +1724,8 @@
             "description": "Refine courses to return.",
             "example": {
               "has_vacancies": true,
-              "subjects": "00,01"
+              "subjects": "00,01",
+              "updated_since": "2020-11-13T11:21:55Z"
             }
           },
           {

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -99,3 +99,7 @@ properties:
     description: "Search radius in miles from given latitude and longitude."
     type: number
     example: 20
+  updated_since:
+    description: "Return courses have been updated since the date (ISO 8601 date format)"
+    type: string
+    example: "2020-11-13T11:21:55Z"


### PR DESCRIPTION
### Context
https://trello.com/c/eQnKyAgV/851-s-filter-by-updatedsince-on-api-public-v1-courses-endpoint-update-tech-notes-from-provider

### Changes proposed in this pull request
- Add `updated_since` filter scope to `CourseSearchService`
- Updated swagger doc spec

### Review
- http://localhost:3001/api/public/v1/recruitment_cycles/2021/courses?filter[updated_since]=2020-11-13T11:21:55Z

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
