### PR TITLE
Use separate publish_api_url setting

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,6 +1,7 @@
 gcp_api_key: please_change_me
+publish_api_url: https://www.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.find-postgraduate-teacher-training.service.gov.uk
+find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,6 +1,7 @@
 gcp_api_key: please_change_me
-publish_url: https://www.qa.publish-teacher-training-courses.service.gov.uk
-find_url: https://www.qa.find-postgraduate-teacher-training.service.gov.uk
+publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
+find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -1,4 +1,5 @@
 gcp_api_key: please_change_me
+publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 bg_jobs:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,6 +1,7 @@
 gcp_api_key: please_change_me
-publish_url: https://www.staging.publish-teacher-training-courses.service.gov.uk
-find_url: https://www2.staging.find-postgraduate-teacher-training.service.gov.uk
+publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
+find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 bg_jobs:
   save_statistic:
     cron: "0 0 * * *" # daily at midnight

--- a/spec/smoke/api/v1/courses_spec.rb
+++ b/spec/smoke/api/v1/courses_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper_smoke"
 
 describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
-  let(:base_url) { Settings.publish_url.sub("www", "api") }
+  let(:base_url) { Settings.publish_api_url }
 
   subject(:response) { HTTParty.get(url) }
 

--- a/spec/smoke/api/v1/healthcheck_spec.rb
+++ b/spec/smoke/api/v1/healthcheck_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper_smoke"
 
 describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
-  let(:base_url) { Settings.publish_url.sub("www", "api") }
+  let(:base_url) { Settings.publish_api_url }
 
   subject(:response) { HTTParty.get(url) }
 

--- a/spec/smoke/api/v1/providers_spec.rb
+++ b/spec/smoke/api/v1/providers_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper_smoke"
 
 describe "V1 Public API Smoke Tests", :aggregate_failures, smoke: true do
   let(:recruitment_year) { Settings.current_recruitment_cycle_year }
-  let(:base_url) { Settings.publish_url.sub("www", "api") }
+  let(:base_url) { Settings.publish_api_url }
 
   subject(:response) { HTTParty.get(url) }
 


### PR DESCRIPTION
### Context
Api URL is inferred by replacing `www.` with `api.` in `publish_url` setting.
This will not apply to all environments in PaaS as, qa,staging and sandbox don't have a `www` prefix in PaaS.
This is also causing smoke-tests to fail in sandbox env.

### Changes proposed in this pull request
Use a separate variable with correct value for `publish_api_url`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
