### PR TITLE
Manage secrets in KeyVault

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,10 +87,7 @@ jobs:
         env:
           ARM_ACCESS_KEY:             ${{ secrets[format('ARM_ACCESS_KEY_{0}', env.DEPLOY_ENV)] }}
           TF_VAR_paas_docker_image:   ${{ env.DOCKER_IMAGE }}
-          TF_VAR_cf_user:             ${{ secrets[format('CF_USERNAME_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_cf_user_password:    ${{ secrets[format('CF_PASSWORD_{0}', env.DEPLOY_ENV)] }}
-          TF_VAR_statuscake_username: ${{ secrets.STATUSCAKE_USERNAME }}
-          TF_VAR_statuscake_password: ${{ secrets.STATUSCAKE_API_KEY }}
+          TF_VAR_azure_credentials:   ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
 
       - name: Trigger ${{ env.DEPLOY_ENV }} Smoke Tests
         uses: benc-uk/workflow-dispatch@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,12 +72,6 @@ jobs:
           DOCKER_IMAGE: ${{ format('dfedigital/teacher-training-api:paas-{0}', github.event.inputs.sha) }}
           DEPLOY_ENV: ${{ matrix.environment }}
 
-      - name: Download app secrets file
-        working-directory: terraform/workspace_variables
-        run: echo $APP_SECRETS | base64 -d >> app_secrets.yml
-        env:
-          APP_SECRETS: ${{ secrets[format('APP_SECRETS_{0}', env.DEPLOY_ENV)] }}      
-
       - name: Terraform init, plan & apply
         working-directory: terraform
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,3 @@ terraform.tfstate.d/
 lock.json
 *secret*.tfvars
 .terraform/
-!terraform/workspace_variables/app_config.yml
-terraform/workspace_variables/*.yml
-terraform/workspace_variables/*.base64

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -3,6 +3,11 @@ data azurerm_key_vault key_vault {
   resource_group_name = var.key_vault_resource_group
 }
 
+data azurerm_key_vault_secret app_secrets {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = var.key_vault_app_secret_name
+}
+
 data azurerm_key_vault_secret infra_secrets {
   key_vault_id = data.azurerm_key_vault.key_vault.id
   name         = var.key_vault_infra_secret_name

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -1,0 +1,9 @@
+data azurerm_key_vault key_vault {
+  name                = var.key_vault_name
+  resource_group_name = var.key_vault_resource_group
+}
+
+data azurerm_key_vault_secret infra_secrets {
+  key_vault_id = data.azurerm_key_vault.key_vault.id
+  name         = var.key_vault_infra_secret_name
+}

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -9,6 +9,7 @@ resource cloudfoundry_app web_app {
   strategy                   = "blue-green-v2"
   timeout                    = 180
   environment                = var.app_environment_variables
+  docker_credentials         = var.docker_credentials
 
   service_binding {
     service_instance = cloudfoundry_service_instance.postgres.id
@@ -35,6 +36,7 @@ resource cloudfoundry_app worker_app {
   timeout              = 180
   health_check_timeout = 180
   environment          = var.app_environment_variables
+  docker_credentials   = var.docker_credentials
 
   service_binding {
     service_instance = cloudfoundry_service_instance.postgres.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -16,6 +16,8 @@ variable redis_service_plan {}
 
 variable docker_image {}
 
+variable docker_credentials {}
+
 variable app_environment {}
 
 variable app_environment_variables { type = map }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.29.0"
+      version = "2.45.1"
     }
     cloudfoundry = {
       source  = "cloudfoundry-community/cloudfoundry"
@@ -14,20 +14,30 @@ terraform {
       version = "1.0.0"
     }
   }
-  backend "azurerm" {
+  backend azurerm {
   }
+}
+
+provider azurerm {
+  features {}
+
+  skip_provider_registration = true
+  subscription_id            = local.azure_credentials.subscriptionId
+  client_id                  = local.azure_credentials.clientId
+  client_secret              = local.azure_credentials.clientSecret
+  tenant_id                  = local.azure_credentials.tenantId
 }
 
 provider cloudfoundry {
   api_url      = local.cf_api_url
-  user         = var.cf_user
-  password     = var.cf_user_password
+  user         = local.infra_secrets.CF_USER
+  password     = local.infra_secrets.CF_PASSWORD
   sso_passcode = var.cf_sso_passcode
 }
 
 provider statuscake {
-  username = var.statuscake_username
-  apikey   = var.statuscake_password
+  username = local.infra_secrets.STATUSCAKE_USERNAME
+  apikey   = local.infra_secrets.STATUSCAKE_PASSWORD
 }
 
 module paas {
@@ -36,6 +46,7 @@ module paas {
   cf_space                  = var.cf_space
   app_environment           = var.paas_app_environment
   docker_image              = var.paas_docker_image
+  docker_credentials        = local.docker_credentials
   web_app_host_name         = var.paas_web_app_host_name
   web_app_memory            = var.paas_web_app_memory
   web_app_instances         = var.paas_web_app_instances

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,3 @@
-variable cf_user { default = null }
-
-variable cf_user_password { default = null }
-
 variable cf_sso_passcode { default = null }
 
 variable cf_space {}
@@ -26,19 +22,26 @@ variable paas_web_app_host_name {}
 
 variable paas_app_config { type = map }
 
-variable paas_app_secrets_file { default = "workspace_variables/app_secrets.yml" }
+variable key_vault_name {}
+
+variable key_vault_resource_group {}
+
+variable key_vault_infra_secret_name {}
+
+variable azure_credentials {}
 
 variable statuscake_alerts {
   type    = map
   default = {}
 }
 
-variable statuscake_username { default = "not-empty" }
-
-variable statuscake_password { default = "not-empty" }
-
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
   paas_app_secrets               = yamldecode(file(var.paas_app_secrets_file))
   paas_app_environment_variables = merge(local.paas_app_secrets, var.paas_app_config)
+  docker_credentials = {
+    username = local.infra_secrets.DOCKERHUB_USERNAME
+    password = local.infra_secrets.DOCKERHUB_PASSWORD
+  }
+  azure_credentials = jsondecode(var.azure_credentials)
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -20,7 +20,7 @@ variable paas_app_environment {}
 
 variable paas_web_app_host_name {}
 
-variable paas_app_config { type = map }
+variable paas_app_config_file { default = "./workspace_variables/app_config.yml" }
 
 variable key_vault_name {}
 
@@ -39,9 +39,10 @@ variable statuscake_alerts {
 
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
-  paas_app_secrets               = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
+  app_config                     = yamldecode(file(var.paas_app_config_file))[var.paas_app_environment]
+  app_secrets                    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
   infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
-  paas_app_environment_variables = merge(local.paas_app_secrets, var.paas_app_config)
+  paas_app_environment_variables = merge(local.app_secrets, local.app_config)
   docker_credentials = {
     username = local.infra_secrets.DOCKERHUB_USERNAME
     password = local.infra_secrets.DOCKERHUB_PASSWORD

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,8 @@ variable key_vault_name {}
 
 variable key_vault_resource_group {}
 
+variable key_vault_app_secret_name {}
+
 variable key_vault_infra_secret_name {}
 
 variable azure_credentials {}
@@ -37,7 +39,8 @@ variable statuscake_alerts {
 
 locals {
   cf_api_url                     = "https://api.london.cloud.service.gov.uk"
-  paas_app_secrets               = yamldecode(file(var.paas_app_secrets_file))
+  paas_app_secrets               = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
+  infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.paas_app_secrets, var.paas_app_config)
   docker_credentials = {
     username = local.infra_secrets.DOCKERHUB_USERNAME

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -1,0 +1,23 @@
+default: &default
+  ASSETS_PRECOMPILE: true
+  RAILS_SERVE_STATIC_FILES: true
+
+qa:
+  <<: *default
+  RAILS_ENV: qa
+  RACK_ENV: qa
+
+staging:
+  <<: *default
+  RAILS_ENV: staging
+  RACK_ENV: staging
+
+prod:
+  <<: *default
+  RAILS_ENV: production
+  RACK_ENV: production
+
+sandbox:
+  <<: *default
+  RAILS_ENV: sandbox
+  RACK_ENV: sandbox

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -8,14 +8,10 @@ paas_worker_app_instances  = 2
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
-paas_app_config = {
-  RAILS_ENV                = "production"
-  RAILS_SERVE_STATIC_FILES = true
-}
 
 # KeyVault
-key_vault_name              = "s121d01-shared-kv-01"
-key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_name              = "s121p01-shared-kv-01"
+key_vault_resource_group    = "s121p01-shared-rg"
 key_vault_app_secret_name   = "TTAPI-APP-SECRETS-PRODUCTION"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -13,6 +13,12 @@ paas_app_config = {
   RAILS_SERVE_STATIC_FILES = true
 }
 
+# KeyVault
+key_vault_name              = "s121d01-shared-kv-01"
+key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_app_secret_name   = ""
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
+
 #StatusCake
 statuscake_alerts = {
   ttapi = {

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -16,7 +16,7 @@ paas_app_config = {
 # KeyVault
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = ""
+key_vault_app_secret_name   = "TTAPI-APP-SECRETS-PRODUCTION"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
 
 #StatusCake

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -17,7 +17,7 @@ paas_app_config = {
 # KeyVault
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = ""
+key_vault_app_secret_name   = "TTAPI-APP-SECRETS-QA"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
 
 # StatusCake

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -9,11 +9,6 @@ paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
 
-paas_app_config = {
-  RAILS_ENV                = "qa_paas"
-  RAILS_SERVE_STATIC_FILES = true
-}
-
 # KeyVault
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -14,6 +14,12 @@ paas_app_config = {
   RAILS_SERVE_STATIC_FILES = true
 }
 
+# KeyVault
+key_vault_name              = "s121d01-shared-kv-01"
+key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_app_secret_name   = ""
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
+
 # StatusCake
 statuscake_alerts = {
   ttapi = {

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -13,6 +13,12 @@ paas_app_config = {
   RAILS_SERVE_STATIC_FILES = true
 }
 
+# KeyVault
+key_vault_name              = "s121d01-shared-kv-01"
+key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_app_secret_name   = ""
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
+
 #StatusCake
 statuscake_alerts = {
   ttapi-sandbox = {

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -8,14 +8,10 @@ paas_worker_app_instances  = 2
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
-paas_app_config = {
-  RAILS_ENV                = "sandbox"
-  RAILS_SERVE_STATIC_FILES = true
-}
 
 # KeyVault
-key_vault_name              = "s121d01-shared-kv-01"
-key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_name              = "s121p01-shared-kv-01"
+key_vault_resource_group    = "s121p01-shared-rg"
 key_vault_app_secret_name   = "TTAPI-APP-SECRETS-SANDBOX"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
 

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -16,7 +16,7 @@ paas_app_config = {
 # KeyVault
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = ""
+key_vault_app_secret_name   = "TTAPI-APP-SECRETS-SANDBOX"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
 
 #StatusCake

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -16,7 +16,7 @@ paas_app_config = {
 # KeyVault
 key_vault_name              = "s121d01-shared-kv-01"
 key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = ""
+key_vault_app_secret_name   = "TTAPI-APP-SECRETS-STAGING"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
 
 #StatusCake

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -13,6 +13,12 @@ paas_app_config = {
   RAILS_SERVE_STATIC_FILES = true
 }
 
+# KeyVault
+key_vault_name              = "s121d01-shared-kv-01"
+key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_app_secret_name   = ""
+key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
+
 #StatusCake
 statuscake_alerts = {
   ttapi = {

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -8,14 +8,10 @@ paas_worker_app_instances  = 1
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
-paas_app_config = {
-  RAILS_ENV                = "staging"
-  RAILS_SERVE_STATIC_FILES = true
-}
 
 # KeyVault
-key_vault_name              = "s121d01-shared-kv-01"
-key_vault_resource_group    = "s121d01-shared-rg"
+key_vault_name              = "s121t01-shared-kv-01"
+key_vault_resource_group    = "s121t01-shared-rg"
 key_vault_app_secret_name   = "TTAPI-APP-SECRETS-STAGING"
 key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
 


### PR DESCRIPTION
Move secrets from GitHub to Azure KeyVault

BAT-INFRA-SECRETS-{ENV} & TTAPI-APP-SECRETS-{ENV}
stored in Azure KeyVault

Use `app_config.yml` for storing non-secret environment variables.

Context
Managing secrets in GitHub Secrets makes it difficult to view/edit secrets.
Storing Application Secrets and Infrastructure as separate yaml files in KeyVault
and accessing them directly using terraform during deployment.

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
