### PR TITLE
[993] Add sandbox user rake task

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,4 +27,13 @@ Style/HashTransformValues:
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 
-
+Rails/UnknownEnv:
+  Environments:
+    - production
+    - development
+    - test
+    - pentest
+    - rollover
+    - sandbox
+    - qa_pass
+    - research

--- a/config/database.yml
+++ b/config/database.yml
@@ -39,3 +39,6 @@ rollover:
 
 production:
   <<: *default
+
+sandbox:
+  <<: *default

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -2,8 +2,3 @@ gcp_api_key: please_change_me
 publish_api_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
-bg_jobs:
-  save_statistic:
-    cron: "0 0 * * *" # daily at midnight
-    class: "SaveStatisticJob" 
-    queue: save_statistic

--- a/lib/tasks/sandbox.rake
+++ b/lib/tasks/sandbox.rake
@@ -1,0 +1,46 @@
+namespace :sandbox do
+  desc <<~DESC
+    Accepts a csv file path of users to be given access to the sandbox environment.
+    The file is expected to be in the following format:
+
+    name,email_address,provider
+    Dave Test,dave@example.com,Provider name SCITT
+
+    The name will be split first name, last name. Provider name must match exactly with the provider in the API.
+
+    Users will be created if they don't exist already.
+    They will then be added to the provider if they aren't associated already.
+    Providers are not created, if they don't exist the task will log this and skip the user.
+  DESC
+  task :import_users, [:csv_file_path] => [:environment] do |_task, args|
+    raise "Can only be run in sandbox or development" unless Rails.env.sandbox? || Rails.env.development?
+
+    current_recruitment_cycle = RecruitmentCycle.current
+
+    CSV.foreach(args[:csv_file_path], headers: :first_row, return_headers: false) do |row|
+      names = row[0].split(" ")
+      email = row[1]
+      provider_name = row[2]
+
+      first_name = names.shift
+      last_name = names.join(" ")
+
+      provider = current_recruitment_cycle.providers.find_by(provider_name: provider_name)
+      user = User
+        .create_with(first_name: first_name, last_name: last_name, accept_terms_date_utc: Time.now.utc)
+        .find_or_create_by(email: email)
+
+      if provider.blank?
+        puts "Provider: #{provider_name} not found. User: #{email} skipped"
+        next
+      end
+
+      if provider.organisation.users.include?(user)
+        puts "User #{email} already belongs to #{provider_name}"
+      else
+        puts "Adding #{email} to #{provider_name}"
+        provider.organisation.users << user
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

We now have Publish in the sandbox environment and need to grant users access in bulk to match the current Apply sandbox users.

### Changes proposed in this pull request

Add a rake task to allow the creation of users from a CSV in the sandbox environment. The csv can be piped into STDIN from a local machine and into this rake task on a running instance of the API in sandbox.

This task doesn't currently create providers as we need to have a think of the best way to handle the provider type etc and the implications of that for sandbox users. This will get us started with the publish sandbox for now.

### Guidance to review

This can be run locally on an anonymised DB dump with:

`rake sandbox:import_users\['./sandbox_users.csv'\]` (escaped [] needed for zsh)

Sandbox users needs to be in the format:

```
name, email,provider
Dave Test,dave@example.com,Provider name
Dave Testtwo,dave@example.com,Provider name one
Dave Testthree,dave@example.com,Provider name two
```

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
