### PR TITLE
Expose provider_type Attribute on Provider Serializer v2

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -3,7 +3,7 @@ module API
     class SerializableProvider < JSONAPI::Serializable::Resource
       type "providers"
 
-      attributes :provider_code, :provider_name, :accredited_body?, :can_add_more_sites?,
+      attributes :provider_code, :provider_name, :provider_type, :accredited_body?, :can_add_more_sites?,
                  :accredited_bodies, :train_with_us, :train_with_disability,
                  :latitude, :longitude, :address1, :address2, :address3, :address4,
                  :postcode, :region_code, :telephone, :email, :website

--- a/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
+++ b/spec/requests/api/v2/providers/accredited_body_get_providers_spec.rb
@@ -20,6 +20,7 @@ describe "AccreditedBody API v2", type: :request do
     let(:accredited_provider) do
       create(:provider,
              provider_name: "a",
+             provider_type: "lead_school",
              organisations: [organisation],
              recruitment_cycle: recruitment_cycle)
     end
@@ -51,6 +52,7 @@ describe "AccreditedBody API v2", type: :request do
               "attributes" => {
                 "provider_code" => accredited_provider.provider_code,
                 "provider_name" => accredited_provider.provider_name,
+                "provider_type" => accredited_provider.provider_type,
                 "accredited_body?" => false,
                 "can_add_more_sites?" => true,
                 "accredited_bodies" => [],
@@ -102,6 +104,7 @@ describe "AccreditedBody API v2", type: :request do
               "attributes" => {
                 "provider_code" => delivering_provider1.provider_code,
                 "provider_name" => delivering_provider1.provider_name,
+                "provider_type" => accredited_provider.provider_type,
                 "accredited_body?" => delivering_provider1.accredited_body?,
                 "can_add_more_sites?" => delivering_provider1.can_add_more_sites?,
                 "accredited_bodies" => [
@@ -159,6 +162,7 @@ describe "AccreditedBody API v2", type: :request do
               "attributes" => {
                 "provider_code" => delivering_provider2.provider_code,
                 "provider_name" => delivering_provider2.provider_name,
+                "provider_type" => accredited_provider.provider_type,
                 "accredited_body?" => delivering_provider2.accredited_body?,
                 "can_add_more_sites?" => delivering_provider2.can_add_more_sites?,
                 "accredited_bodies" => [

--- a/spec/requests/api/v2/providers/providers_show_spec.rb
+++ b/spec/requests/api/v2/providers/providers_show_spec.rb
@@ -22,6 +22,7 @@ describe "Providers API v2", type: :request do
     let(:courses) { [course] }
     let!(:provider) do
       create(:provider,
+             :accredited_body,
              sites: [site],
              organisations: [organisation],
              accrediting_provider_enrichments: accrediting_provider_enrichments,
@@ -40,7 +41,8 @@ describe "Providers API v2", type: :request do
           "attributes" => {
             "provider_code" => provider.provider_code,
             "provider_name" => provider.provider_name,
-            "accredited_body?" => false,
+            "provider_type" => provider.provider_type,
+            "accredited_body?" => true,
             "can_add_more_sites?" => true,
             "train_with_us" => provider.train_with_us,
             "train_with_disability" => provider.train_with_disability,


### PR DESCRIPTION
### Context
https://trello.com/c/xNFb9yGQ/2989-course-guidance-to-providers-on-publish

### Changes proposed in this pull request
This PR exposes the value and tweaks the stubbed responses on the associated test files.

### Guidance to review
As part of a tweak to content on the publish-teacher-training app we need to expose this
attribute in order to show different content to university and SCITT/School Direct users.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
