### PR TITLE
[99] Add provider creation task

### DIFF
--- a/app/services/csv_imports/fake_providers_import.rb
+++ b/app/services/csv_imports/fake_providers_import.rb
@@ -1,0 +1,35 @@
+require "csv"
+
+module CSVImports
+  class FakeProvidersImport
+    attr_reader :results
+
+    def initialize(path_to_csv)
+      @results = []
+      @path_to_csv = path_to_csv
+    end
+
+    def execute
+      CSV.foreach(@path_to_csv, headers: true) do |row|
+        provider_name = row["name"]
+        provider_code = row["code"]
+        provider_type = row["type"]
+        is_accredited_body = ActiveModel::Type::Boolean.new.cast(row["accredited_body"])
+
+        service = Providers::CreateFakeProviderService.new(
+          recruitment_cycle: RecruitmentCycle.current,
+          provider_name: provider_name,
+          provider_code: provider_code,
+          provider_type: provider_type,
+          is_accredited_body: is_accredited_body,
+        )
+
+        @results << if service.execute
+                      "Created provider #{provider_name}."
+                    else
+                      service.errors.join(" ")
+                    end
+      end
+    end
+  end
+end

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -47,11 +47,7 @@ module Providers
         region_code: provider.region_code,
       )
 
-      if provider.invalid?
-        errors << "Unable to create Provider #{provider_name}: #{provider.errors.to_sentence}."
-      end
-
-      errors.empty?
+      true
     end
 
   private

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -24,6 +24,7 @@ module Providers
 
     def execute
       return false if provider_already_exists?
+      return false if attempting_to_make_lead_school_accredited_body?
 
       provider = @recruitment_cycle.providers.build({
         provider_name: @provider_name,
@@ -63,6 +64,12 @@ module Providers
         true
       else
         false
+      end
+    end
+
+    def attempting_to_make_lead_school_accredited_body?
+      if @provider_type == "lead_school" && @is_accredited_body
+        errors << "Provider #{@provider_name} (#{@provider_code}) cannot be both a lead school and an accredited body."
       end
     end
   end

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -3,6 +3,8 @@ module Providers
     attr_reader :errors
 
     def initialize(recruitment_cycle:, provider_name:, provider_code:, provider_type:, is_accredited_body:)
+      raise "Can only be run in sandbox or development" unless Rails.env.sandbox? || Rails.env.development? || Rails.env.test?
+
       @recruitment_cycle = recruitment_cycle
       @provider_name = provider_name
       @provider_code = provider_code

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -1,0 +1,68 @@
+module Providers
+  class CreateFakeProviderService
+    attr_reader :errors
+
+    def initialize(recruitment_cycle:, provider_name:, provider_code:, provider_type:, is_accredited_body:)
+      @recruitment_cycle = recruitment_cycle
+      @provider_name = provider_name
+      @provider_code = provider_code
+      @provider_type = provider_type
+      @is_accredited_body = is_accredited_body
+
+      @errors = []
+    end
+
+    def execute
+      if provider_already_exists?
+        errors << "Provider #{@provider_name} (#{@provider_code}) already exists."
+        return false
+      end
+
+      provider = @recruitment_cycle.providers.build(
+        provider_name: @provider_name,
+        provider_code: @provider_code,
+        provider_type: @provider_type,
+        accrediting_provider: @is_accredited_body ? "accredited_body" : "not_an_accredited_body",
+        address1: "1 Test Street",
+        address3: "Town",
+        address4: "County",
+        postcode: "M1 1JG",
+        region_code: "north_west",
+      )
+
+      organisation = Organisation.new(name: @provider_name)
+      organisation.providers << provider
+      if organisation.save
+        site_created = provider.sites.create(
+          location_name: "Site 1",
+          address1: provider.address1,
+          address2: provider.address2,
+          address3: provider.address3,
+          address4: provider.address4,
+          postcode: provider.postcode,
+          region_code: provider.region_code,
+        )
+        errors << "Unable to create Site for #{provider_name}." unless site_created
+      else
+        errors << "Unable to create Organisation for #{provider_name}: #{organisation.errors.to_sentence}."
+      end
+
+      if provider.invalid?
+        errors << "Unable to create Provider #{provider_name}: #{provider.errors.to_sentence}."
+      end
+
+      if errors.any?
+        false
+      else
+        true
+      end
+    end
+
+  private
+
+    def provider_already_exists?
+      @recruitment_cycle.providers.exists?(provider_name: @provider_name) || \
+        @recruitment_cycle.providers.exists?(provider_code: @provider_code)
+    end
+  end
+end

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -32,20 +32,17 @@ module Providers
 
       organisation = Organisation.new(name: @provider_name)
       organisation.providers << provider
-      if organisation.save
-        site_created = provider.sites.create(
-          location_name: "Site 1",
-          address1: provider.address1,
-          address2: provider.address2,
-          address3: provider.address3,
-          address4: provider.address4,
-          postcode: provider.postcode,
-          region_code: provider.region_code,
-        )
-        errors << "Unable to create Site for #{provider_name}." unless site_created
-      else
-        errors << "Unable to create Organisation for #{provider_name}: #{organisation.errors.to_sentence}."
-      end
+      organisation.save!
+
+      provider.sites.create!(
+        location_name: "Site 1",
+        address1: provider.address1,
+        address2: provider.address2,
+        address3: provider.address3,
+        address4: provider.address4,
+        postcode: provider.postcode,
+        region_code: provider.region_code,
+      )
 
       if provider.invalid?
         errors << "Unable to create Provider #{provider_name}: #{provider.errors.to_sentence}."

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -57,10 +57,8 @@ module Providers
   private
 
     def provider_already_exists?
-      if @recruitment_cycle.providers.exists?(provider_name: @provider_name) || \
-          @recruitment_cycle.providers.exists?(provider_code: @provider_code)
+      if @recruitment_cycle.providers.exists?(provider_code: @provider_code)
         errors << "Provider #{@provider_name} (#{@provider_code}) already exists."
-
         true
       else
         false

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -17,6 +17,7 @@
 
 ActiveSupport::Inflector.inflections do |inflect|
   inflect.acronym "API"
+  inflect.acronym "CSV"
   inflect.acronym "PGDE"
   inflect.acronym "UCAS"
   inflect.acronym "MFL" # Modern foreign languages

--- a/lib/tasks/sandbox.rake
+++ b/lib/tasks/sandbox.rake
@@ -56,7 +56,6 @@ namespace :sandbox do
 
     provider_type options -> "lead_school", "scitt", "unknown", "university"
     provider_code must be a unique string
-    provider_name must be a unique string
 
     Providers will be created if they don't exist, along with a single
     Organisation and Site per-provider.

--- a/spec/services/csv_imports/fake_providers_import_spec.rb
+++ b/spec/services/csv_imports/fake_providers_import_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe CSVImports::FakeProvidersImport do
 
   context "two providers to import" do
     let(:csv_content) do
-      "name,code,type,accredited_body\n\"Provider A\",ABC,scitt,false\n\"Provider B\",DEF,lead_school,true"
+      "name,code,type,accredited_body\n\"Provider A\",ABC,scitt,false\n\"Provider B\",DEF,lead_school,false"
     end
 
     it "creates two providers" do

--- a/spec/services/csv_imports/fake_providers_import_spec.rb
+++ b/spec/services/csv_imports/fake_providers_import_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe CSVImports::FakeProvidersImport do
+  let(:csv_content) { "" }
+  let(:csv_file)    { StringIO.new(csv_content) }
+
+  before do
+    allow(File).to receive(:open).with("csv_file.csv", anything, anything).and_return(csv_file)
+  end
+
+  context "one provider to import" do
+    let(:csv_content) do
+      "name,code,type,accredited_body\n\"Provider A\",ABC,scitt,false"
+    end
+
+    it "works" do
+      described_class.new("csv_file.csv").execute
+      created_provider = Provider.last
+
+      expect(created_provider.provider_name).to eq("Provider A")
+      expect(created_provider.provider_code).to eq("ABC")
+      expect(created_provider.provider_type).to eq("scitt")
+      expect(created_provider).not_to be_accredited_body
+    end
+
+    it "reports on the created provider" do
+      import = described_class.new("csv_file.csv")
+      import.execute
+
+      expect(import.results).to eq(["Created provider Provider A."])
+    end
+  end
+
+  context "two providers to import" do
+    let(:csv_content) do
+      "name,code,type,accredited_body\n\"Provider A\",ABC,scitt,false\n\"Provider B\",DEF,lead_school,true"
+    end
+
+    it "creates two providers" do
+      expect {
+        described_class.new("csv_file.csv").execute
+      }.to change { Provider.count }.by(2)
+    end
+
+    it "reports on both created providers" do
+      import = described_class.new("csv_file.csv")
+      import.execute
+
+      expect(import.results).to eq(["Created provider Provider A.", "Created provider Provider B."])
+    end
+  end
+
+  context "when the CSV contains duplicated data" do
+    let(:csv_content) do
+      "name,code,type,accredited_body\n\"Provider A\",ABC,scitt,false\n\"Provider A\",ABC,lead_school,true"
+    end
+
+    it "reports on the created provider and the error" do
+      import = described_class.new("csv_file.csv")
+      import.execute
+
+      expect(import.results).to eq(["Created provider Provider A.", "Provider Provider A (ABC) already exists."])
+    end
+  end
+end

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Providers::CreateFakeProviderService do
+  let(:provider_name) { "Fake Provider" }
+  let(:provider_code) { "ABC" }
+  let(:provider_type) { "scitt" }
+  let(:recruitment_cycle) { find_or_create :recruitment_cycle }
+  let(:is_accredited_body) { false }
+
+  let(:service) do
+    described_class.new(
+      provider_name: "Fake Provider",
+      provider_code: "123",
+      provider_type: "scitt",
+      recruitment_cycle: recruitment_cycle,
+      is_accredited_body: is_accredited_body,
+    )
+  end
+
+  it "creates providers" do
+    expect {
+      service.execute
+    }.to change { Provider.count }.by(1).and \
+      change { Organisation.count }.by(1).and \
+        change { Site.count }.by(1)
+  end
+
+  context "the provider code already exists" do
+    before do
+      create(:provider, provider_code: "123", recruitment_cycle: recruitment_cycle)
+    end
+
+    it "does not complete" do
+      expect(service.execute).not_to be(true)
+      expect(service.errors).to eq ["Provider Fake Provider (123) already exists."]
+    end
+  end
+
+  context "the provider name already exists" do
+    before do
+      create(:provider, provider_name: "Fake Provider", recruitment_cycle: recruitment_cycle)
+    end
+
+    it "does not complete" do
+      expect(service.execute).not_to be(true)
+      expect(service.errors).to eq ["Provider Fake Provider (123) already exists."]
+    end
+  end
+end

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Providers::CreateFakeProviderService do
-  let(:provider_name) { "Fake Provider" }
-  let(:provider_code) { "ABC" }
   let(:provider_type) { "scitt" }
   let(:recruitment_cycle) { find_or_create :recruitment_cycle }
   let(:is_accredited_body) { false }
@@ -11,7 +9,7 @@ RSpec.describe Providers::CreateFakeProviderService do
     described_class.new(
       provider_name: "Fake Provider",
       provider_code: "123",
-      provider_type: "scitt",
+      provider_type: provider_type,
       recruitment_cycle: recruitment_cycle,
       is_accredited_body: is_accredited_body,
     )
@@ -44,6 +42,16 @@ RSpec.describe Providers::CreateFakeProviderService do
     it "does not complete" do
       expect(service.execute).not_to be(true)
       expect(service.errors).to eq ["Provider Fake Provider (123) already exists."]
+    end
+  end
+
+  context "the requested provider is both a lead_school and an accredited_body" do
+    let(:provider_type) { "lead_school" }
+    let(:is_accredited_body) { true }
+
+    it "does not complete" do
+      expect(service.execute).not_to be(true)
+      expect(service.errors).to eq ["Provider Fake Provider (123) cannot be both a lead school and an accredited body."]
     end
   end
 

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -46,4 +46,24 @@ RSpec.describe Providers::CreateFakeProviderService do
       expect(service.errors).to eq ["Provider Fake Provider (123) already exists."]
     end
   end
+
+  context "is_accredited_body is true" do
+    let(:is_accredited_body) { true }
+
+    it "the created provider is an accredited_body" do
+      service.execute
+
+      expect(Provider.last.accredited_body?).to be(true)
+    end
+  end
+
+  context "is_accredited_body is false" do
+    let(:is_accredited_body) { false }
+
+    it "the created provider is an accredited_body" do
+      service.execute
+
+      expect(Provider.last.accredited_body?).to be(false)
+    end
+  end
 end

--- a/spec/services/providers/create_fake_provider_service_spec.rb
+++ b/spec/services/providers/create_fake_provider_service_spec.rb
@@ -23,20 +23,9 @@ RSpec.describe Providers::CreateFakeProviderService do
         change { Site.count }.by(1)
   end
 
-  context "the provider code already exists" do
+  context "a provider with that code already exists" do
     before do
       create(:provider, provider_code: "123", recruitment_cycle: recruitment_cycle)
-    end
-
-    it "does not complete" do
-      expect(service.execute).not_to be(true)
-      expect(service.errors).to eq ["Provider Fake Provider (123) already exists."]
-    end
-  end
-
-  context "the provider name already exists" do
-    before do
-      create(:provider, provider_name: "Fake Provider", recruitment_cycle: recruitment_cycle)
     end
 
     it "does not complete" do


### PR DESCRIPTION
### Context

We need to onboard users and providers to the Publish/TTAPI sandbox environment.

### Changes proposed in this pull request

Add task that:

* Accepts a CSV
* Creates an organisation
* Creates a provider
* Adds a location to the provider

This task is procedural stylee for now. We are currently discussing building some UI on the API for this sort of support work. This will serve as 'documentation' for creating a better structured service class in the future.

The data set on the provider and associated entities is minimal placeholder data. Sandbox users should probably be directed to update things like the address and location etc otherwise there will be a lot of courses at the same location in Find.

### Guidance to review

The tasks will run locally. Create appropriate CSV files as per the task description.

`bundle exec rake sandbox:create_providers\[./providers.csv\]`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
