### PR TITLE
Configure logging as user provided service in PaaS

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -54,6 +54,6 @@ if Settings.logstash.host && Settings.logstash.port
 
   log_stash = LogStashLogger.new(Settings.logstash.to_h.merge(customize_event: fix_payload))
   SemanticLogger.add_appender(logger: log_stash, level: :info, formatter: LogStashFormatter.new)
-elsif Rails.env.production?
-  warn("logstash not configured, falling back to standard Rails logging")
+else
+  SemanticLogger.add_appender(io: STDOUT, level: :info, formatter: :json)
 end

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -17,6 +17,9 @@ resource cloudfoundry_app web_app {
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
   }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
+  }
   dynamic "routes" {
     for_each = local.web_app_routes
     content {
@@ -45,6 +48,9 @@ resource cloudfoundry_app worker_app {
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
   }
+  service_binding {
+    service_instance = cloudfoundry_user_provided_service.logging.id
+  }
 }
 
 resource cloudfoundry_route web_app_cloudapps_digital_route {
@@ -70,4 +76,10 @@ resource cloudfoundry_service_instance redis {
   name         = local.redis_service_name
   space        = data.cloudfoundry_space.space.id
   service_plan = data.cloudfoundry_service.redis.service_plans[var.redis_service_plan]
+}
+
+resource cloudfoundry_user_provided_service logging {
+  name             = local.logging_service_name
+  space            = data.cloudfoundry_space.space.id
+  syslog_drain_url = var.logstash_url
 }

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -18,6 +18,8 @@ variable docker_image {}
 
 variable docker_credentials {}
 
+variable logstash_url {}
+
 variable app_environment {}
 
 variable app_environment_variables { type = map }
@@ -27,6 +29,7 @@ locals {
   worker_app_name       = "teacher-training-api-worker-${var.app_environment}"
   postgres_service_name = "teacher-training-api-postgres-${var.app_environment}"
   redis_service_name    = "teacher-training-api-redis-${var.app_environment}"
+  logging_service_name  = "teacher-training-api-logit-${var.app_environment}"
   deployment_strategy   = "blue-green-v2"
 
   worker_app_start_command = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -47,6 +47,7 @@ module paas {
   app_environment           = var.paas_app_environment
   docker_image              = var.paas_docker_image
   docker_credentials        = local.docker_credentials
+  logstash_url              = local.infra_secrets.LOGSTASH_URL
   web_app_host_name         = var.paas_web_app_host_name
   web_app_memory            = var.paas_web_app_memory
   web_app_instances         = var.paas_web_app_instances


### PR DESCRIPTION
### Context

Send application logs to logit using user-provided-service instead of logstash gem.


### Changes proposed in this pull request

Add logging user_provided_service and bind to app.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
