### PR TITLE
Validate secrets in deploy workflow before running terraform

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,9 +68,26 @@ jobs:
         run: |
           echo "DOCKER_IMAGE=$DOCKER_IMAGE" >> $GITHUB_ENV
           echo "DEPLOY_ENV=$DEPLOY_ENV" >> $GITHUB_ENV
+
+          . terraform/workspace_variables/$DEPLOY_ENV.sh
+          echo "TF_VAR_key_vault_name=$TF_VAR_key_vault_name" >> $GITHUB_ENV
+          echo "TF_VAR_key_vault_app_secret_name=$TF_VAR_key_vault_app_secret_name" >> $GITHUB_ENV
+          echo "TF_VAR_key_vault_infra_secret_name=$TF_VAR_key_vault_infra_secret_name" >> $GITHUB_ENV
         env:
           DOCKER_IMAGE: ${{ format('dfedigital/teacher-training-api:paas-{0}', github.event.inputs.sha) }}
           DEPLOY_ENV: ${{ matrix.environment }}
+
+      - uses: azure/login@v1
+        with:
+          creds: ${{ secrets[format('AZURE_CREDENTIALS_{0}', env.DEPLOY_ENV)] }}
+
+      - name: Validate Azure Key Vault secrets
+        uses: DFE-Digital/github-actions/validate-key-vault-secrets@master
+        with:
+          KEY_VAULT: ${{ env.TF_VAR_key_vault_name }}
+          SECRETS: |
+            ${{ env.TF_VAR_key_vault_app_secret_name }}
+            ${{ env.TF_VAR_key_vault_infra_secret_name }}
 
       - name: Terraform init, plan & apply
         working-directory: terraform

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ config/settings/*.local.yml
 config/environments/*.local.yml
 config/azure_environments.yml
 
+#ignore fetch_config.rb and use latest version from bat-platform-building-blocks
+bin/fetch_config.rb
+
 *.patch
 *.swp
 

--- a/Makefile
+++ b/Makefile
@@ -80,3 +80,17 @@ deploy: deploy-init
 
 destroy: deploy-init
 	terraform destroy -var-file=terraform/workspace_variables/$(DEPLOY_ENV).tfvars terraform
+
+install-fetch-config:
+	[ ! -f bin/fetch_config.rb ] \
+		&& curl -s https://raw.githubusercontent.com/DFE-Digital/bat-platform-building-blocks/master/scripts/fetch_config/fetch_config.rb -o bin/fetch_config.rb \
+		&& chmod +x bin/fetch_config.rb \
+		|| true
+
+edit-app-secrets: install-fetch-config
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh && bin/fetch_config.rb -s azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_app_secret_name} \
+		-e -d azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_app_secret_name} -f yaml
+
+print-app-secrets: install-fetch-config
+	. terraform/workspace_variables/$(DEPLOY_ENV).sh && bin/fetch_config.rb -s azure-key-vault-secret:$${TF_VAR_key_vault_name}/$${TF_VAR_key_vault_app_secret_name} \
+		-f yaml

--- a/terraform/workspace_variables/production.sh
+++ b/terraform/workspace_variables/production.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121p01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=TTAPI-APP-SECRETS-PRODUCTION
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-PRODUCTION

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -10,10 +10,7 @@ paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
 
 # KeyVault
-key_vault_name              = "s121p01-shared-kv-01"
-key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "TTAPI-APP-SECRETS-PRODUCTION"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-PRODUCTION"
+key_vault_resource_group = "s121p01-shared-rg"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/qa.sh
+++ b/terraform/workspace_variables/qa.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121d01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=TTAPI-APP-SECRETS-QA
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-QA

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -10,10 +10,7 @@ paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
 
 # KeyVault
-key_vault_name              = "s121d01-shared-kv-01"
-key_vault_resource_group    = "s121d01-shared-rg"
-key_vault_app_secret_name   = "TTAPI-APP-SECRETS-QA"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-QA"
+key_vault_resource_group = "s121d01-shared-rg"
 
 # StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/sandbox.sh
+++ b/terraform/workspace_variables/sandbox.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121p01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=TTAPI-APP-SECRETS-SANDBOX
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-SANDBOX

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -10,10 +10,7 @@ paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
 
 # KeyVault
-key_vault_name              = "s121p01-shared-kv-01"
-key_vault_resource_group    = "s121p01-shared-rg"
-key_vault_app_secret_name   = "TTAPI-APP-SECRETS-SANDBOX"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-SANDBOX"
+key_vault_resource_group = "s121p01-shared-rg"
 
 #StatusCake
 statuscake_alerts = {

--- a/terraform/workspace_variables/staging.sh
+++ b/terraform/workspace_variables/staging.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121t01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=TTAPI-APP-SECRETS-STAGING
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-STAGING

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -10,10 +10,7 @@ paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
 
 # KeyVault
-key_vault_name              = "s121t01-shared-kv-01"
-key_vault_resource_group    = "s121t01-shared-rg"
-key_vault_app_secret_name   = "TTAPI-APP-SECRETS-STAGING"
-key_vault_infra_secret_name = "BAT-INFRA-SECRETS-STAGING"
+key_vault_resource_group = "s121t01-shared-rg"
 
 #StatusCake
 statuscake_alerts = {


### PR DESCRIPTION
### Context

Secrets not in correct YAML format might lead to terraform erroring and outputting the values when running the deploy worklow.
To prevent such leaks we validate the secrets for correct YAML before running terraform.

### Changes proposed in this pull request

Run secrets validation step before running terraform.
Set key_vault variables as env variables to reuse in make commands.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
