### PR TITLE
Add missing queue to Sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,5 +2,6 @@
 :queues:
   - default
   - geocoding
+  - add_travel_to_work_area_and_london_borough
   - save_statistic
   - mailers


### PR DESCRIPTION
### Context
We recently added a new background job to backfill `travel_to_work` and `london_borough` info to Sites

https://github.com/DFE-Digital/teacher-training-api/blob/6cdd9757e849a02e98a3c2da15762b92091a5c2a/app/jobs/travel_to_work_area_and_london_borough_job.rb#L2

### Changes proposed in this pull request
- Add `add_travel_to_work_area_and_london_borough` queue to to `sidekiq.yml`

### Trello
https://trello.com/c/Q3Di0OfY/3076-failing-sidekiq-healthcheck

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
