### PR TITLE
Alert slack channel on deploy workflow failures

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -131,3 +131,15 @@ jobs:
           ref:    ${{ github.event.inputs.sha }}
           status: ${{ job.status }}
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Alert on Failure
+        if: ${{ failure() && github.ref == 'refs/heads/master' }}
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_bat_devops
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Teacher Training API
+          SLACK_TITLE: '<!channel> Deploy to ${{ matrix.environment }} Failed'
+          SLACK_MESSAGE: ':alert: Build failure on ${{ matrix.environment }} :sadparrot:'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ jobs:
       matrix: ${{ fromJson(needs.prepare-matrix.outputs.environments) }}
     steps:
       - name: Start ${{ matrix.environment }} Deployment
-        uses: bobheadxi/deployments@master
+        uses: bobheadxi/deployments@v0.4.3
         id: deployment
         with:
           step: start
@@ -123,7 +123,7 @@ jobs:
 
       - name: Update ${{ matrix.environment }} status
         if: ${{ always() }}
-        uses: bobheadxi/deployments@master
+        uses: bobheadxi/deployments@v0.4.3
         with:
           step:   finish
           token:  ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes proposed in this pull request
Pin update deployment status action to v0.4.3 as @5 (master) is erroring
Alert slack channel on deployment job failures.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
