### PR TITLE
don't spam-a-lot in test env

### DIFF
--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -54,6 +54,6 @@ if Settings.logstash.host && Settings.logstash.port
 
   log_stash = LogStashLogger.new(Settings.logstash.to_h.merge(customize_event: fix_payload))
   SemanticLogger.add_appender(logger: log_stash, level: :info, formatter: LogStashFormatter.new)
-else
+elsif !Rails.env.test?
   SemanticLogger.add_appender(io: STDOUT, level: :info, formatter: :json)
 end


### PR DESCRIPTION
### Context

Running specs was spamming the console with a line or two of JSON output
for every single test. Way way too much.

### Changes proposed in this pull request

Don't add SemanticLogger when in `test` env.

### Guidance to review

Before:

```
% be rspec spec/controllers/api/v2/courses_controller_spec.rb
Run options:
  include {:focus=>true}
  exclude {:smoke=>true}

All examples were filtered out; ignoring {:focus=>true}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:57.678556Z","level":"warn","level_index":3,"pid":73616,"thread":"10680","name":"CourseEnrichment","message":"Creating scope :draft. Overwriting existing method CourseEnrichment.draft."}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:57.859813Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 06884fd0-aed0-4429-8469-a7d13ac65414) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"06884fd0-aed0-4429-8469-a7d13ac65414","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  1\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:57.968036Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 4726cdf9-d4d7-4f94-9b08-97cc3281daf4) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"4726cdf9-d4d7-4f94-9b08-97cc3281daf4","provider_job_id":null,"arguments":"[\n  \"Site\",\n  1\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:57.968385Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 3ac20b74-8ffe-494e-a174-fa20395ccf48) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"3ac20b74-8ffe-494e-a174-fa20395ccf48","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  2\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.028283Z","level":"warn","level_index":3,"pid":73616,"thread":"10680","name":"Rails","message":"Unable to deserialize course because no JSON API payload was found. (courses#publish)"}
.{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.363124Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: de56199c-0b98-4cec-b35c-b8c5c8f48520) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"de56199c-0b98-4cec-b35c-b8c5c8f48520","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  3\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.441424Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 6731234e-bad6-4a4e-a170-3a4942207a83) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"6731234e-bad6-4a4e-a170-3a4942207a83","provider_job_id":null,"arguments":"[\n  \"Site\",\n  2\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.441726Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 85a71e99-505a-4007-a351-635745bff512) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"85a71e99-505a-4007-a351-635745bff512","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  4\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.456137Z","level":"warn","level_index":3,"pid":73616,"thread":"10680","name":"Rails","message":"Unable to deserialize course because no JSON API payload was found. (courses#update)"}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.677391Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Completed JSON API rendering (139.58ms)"}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.677858Z","level":"info","level_index":2,"pid":73616,"thread":"10680","duration_ms":227.56700008176267,"duration":"227.6ms","name":"API::V2::CoursesController","message":"Completed #update","payload":{"controller":"API::V2::CoursesController","action":"update","params":{"course":{"subjects_ids":["47"]},"recruitment_cycle_year":"2021","provider_code":"A08","code":"C675"},"format":"HTML","method":"POST","path":"/api/v2/recruitment_cycles/2021/providers/A08/courses/C675","status":200,"view_runtime":117.59,"sk_rendered_format":"jsonapi","sk_variant":[],"db_runtime":48.3,"user":{"id":6,"sign_in_id":"manage_courses_api"},"request_id":null,"allocations":80923,"status_message":"OK"}}
.{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.856184Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 51617e7e-feab-4d17-838e-09d43548f946) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"51617e7e-feab-4d17-838e-09d43548f946","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  5\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.918974Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 0a1c9bd4-fa91-4cd0-853d-17700aa8ec0d) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"0a1c9bd4-fa91-4cd0-853d-17700aa8ec0d","provider_job_id":null,"arguments":"[\n  \"Site\",\n  3\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.919204Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 69450500-ce4c-4c0d-a2b0-f144353a8a5a) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"69450500-ce4c-4c0d-a2b0-f144353a8a5a","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  6\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:58.957631Z","level":"info","level_index":2,"pid":73616,"thread":"10680","duration_ms":33.002999844029546,"duration":"33.0ms","name":"API::V2::CoursesController","message":"Completed #withdraw","payload":{"controller":"API::V2::CoursesController","action":"withdraw","params":{"recruitment_cycle_year":"2021","provider_code":"A12","code":"C961"},"format":"HTML","method":"POST","path":"/api/v2/recruitment_cycles/2021/providers/A12/courses/C961/withdraw","status":204,"view_runtime":0.0,"sk_rendered_format":null,"sk_variant":[],"db_runtime":10.62,"user":{"id":11,"sign_in_id":"manage_courses_api"},"request_id":null,"allocations":10933,"status_message":"No Content"}}
.{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.152611Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: f93ff5f8-11d0-4e56-be5e-30b7223b2fbf) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"f93ff5f8-11d0-4e56-be5e-30b7223b2fbf","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  7\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.206825Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 47dfb128-6ec1-4d46-b81d-8530e5068578) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"47dfb128-6ec1-4d46-b81d-8530e5068578","provider_job_id":null,"arguments":"[\n  \"Site\",\n  4\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.207025Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 1c129b1e-d631-4bac-a96d-61fa263f058a) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"1c129b1e-d631-4bac-a96d-61fa263f058a","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  8\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.219528Z","level":"info","level_index":2,"pid":73616,"thread":"10680","duration_ms":7.641000207513571,"duration":"7.641ms","name":"API::V2::CoursesController","message":"Completed #send_vacancies_updated_notification","payload":{"controller":"API::V2::CoursesController","action":"send_vacancies_updated_notification","params":{"_jsonapi":{"vacancy_statuses":[{"id":"123456","status":"no_vacancies"}]},"recruitment_cycle_year":"2021","provider_code":"A16","code":"C1284"},"format":"HTML","method":"POST","path":"/api/v2/recruitment_cycles/2021/providers/A16/courses/C1284/send_vacancies_updated_notification","status":204,"view_runtime":0.0,"sk_rendered_format":null,"sk_variant":[],"db_runtime":3.15,"user":{"id":16,"sign_in_id":"manage_courses_api"},"request_id":null,"allocations":2403,"status_message":"No Content"}}
.{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.393144Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: ce73e1e8-4e23-456c-b39a-9ba859617083) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"ce73e1e8-4e23-456c-b39a-9ba859617083","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  9\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.452056Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: ee8a6c79-ed06-4b02-82bc-c1aa091d4838) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"ee8a6c79-ed06-4b02-82bc-c1aa091d4838","provider_job_id":null,"arguments":"[\n  \"Site\",\n  5\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.452399Z","level":"info","level_index":2,"pid":73616,"thread":"10680","name":"Rails","message":"Enqueued GeocodeJob (Job ID: 3955495f-76d8-4e75-b213-b9283e8080a1) to Test(geocoding)","payload":{"event_name":"enqueue.active_job","adapter":"Test","queue":"geocoding","job_class":"GeocodeJob","job_id":"3955495f-76d8-4e75-b213-b9283e8080a1","provider_job_id":null,"arguments":"[\n  \"Provider\",\n  10\n]"}}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.484606Z","level":"warn","level_index":3,"pid":73616,"thread":"10680","name":"Rails","message":"Unable to deserialize course because no JSON API payload was found. (courses#update)"}
{"host":"stutter.local","application":"Semantic Logger","environment":"test","timestamp":"2021-02-24T14:09:59.485388Z","level":"info","level_index":2,"pid":73616,"thread":"10680","duration_ms":21.5490001719445,"duration":"21.5ms","name":"API::V2::CoursesController","message":"Completed #update","payload":{"controller":"API::V2::CoursesController","action":"update","params":{"course":{"name":"new course name"},"recruitment_cycle_year":"2021","provider_code":"A20","code":"C1594"},"format":"HTML","method":"PUT","path":"/api/v2/recruitment_cycles/2021/providers/A20/courses/C1594","view_runtime":0.0,"sk_rendered_format":null,"sk_variant":[],"db_runtime":5.58,"user":{"id":24,"sign_in_id":"0457457e-5373-4c9e-9519-ba03312bdb4f"},"request_id":null,"exception_object":"found unpermitted parameter: :name","status":500,"allocations":5942,"status_message":"Internal Server Error"}}
```

🙀 🙀 🙀 

After:

```
% be rspec spec/controllers/api/v2/courses_controller_spec.rb
Run options:
  include {:focus=>true}
  exclude {:smoke=>true}

All examples were filtered out; ignoring {:focus=>true}
.......

Finished in 3.6 seconds (files took 3.96 seconds to load)
7 examples, 0 failures
```

😹 😹 😹 

