### PR TITLE
require rails_helper in specs that are missing it

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -205,7 +205,7 @@ module API
         # This is because sites = [] is something that we can validate against,
         # but we can't actually revert easily from what I can tell because of the
         # remove_site! side effects that occur when it's called.
-        @course.errors[:sites] << "^You must choose at least one location" if site_ids.empty?
+        @course.errors.add(:sites, message: "^You must choose at least one location") if site_ids.empty?
         @updated_site_names = @course.sites.map(&:location_name) unless site_ids.empty?
       end
 

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -3,7 +3,7 @@ class EmailValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     if value.blank? || !value.match?(/@/)
-      record.errors[attribute] << EMAIL_VALIDATION_ERROR_MESSAGE
+      record.errors.add(attribute, message: EMAIL_VALIDATION_ERROR_MESSAGE)
     end
   end
 end

--- a/app/validators/phone_validator.rb
+++ b/app/validators/phone_validator.rb
@@ -3,7 +3,7 @@ class PhoneValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     if value.blank? || is_invalid_phone_number_format?(value)
-      record.errors[attribute] << PHONE_VALIDATION_ERROR_MESSAGE
+      record.errors.add(attribute, message: PHONE_VALIDATION_ERROR_MESSAGE)
     end
   end
 

--- a/app/validators/postcode_validator.rb
+++ b/app/validators/postcode_validator.rb
@@ -4,7 +4,7 @@ class PostcodeValidator < ActiveModel::EachValidator
 
     postcode = UKPostcode.parse(value)
     unless postcode.full_valid?
-      record.errors[attribute] << "is not valid (for example, BN1 1AA)"
+      record.errors.add(attribute, message: "is not valid (for example, BN1 1AA)")
     end
   end
 end

--- a/app/validators/words_count_validator.rb
+++ b/app/validators/words_count_validator.rb
@@ -3,7 +3,10 @@ class WordsCountValidator < ActiveModel::EachValidator
     return if string.blank?
 
     if word_count(string) > options[:maximum]
-      record.errors[attribute] << (options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}")
+      record.errors.add(
+        attribute,
+        message: options[:message] || "^Reduce the word count for #{attribute.to_s.humanize(capitalize: false)}",
+      )
     end
   end
 

--- a/spec/deserializers/api/v2/deserializable_course_spec.rb
+++ b/spec/deserializers/api/v2/deserializable_course_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe API::V2::DeserializableCourse do
   let(:course) { build(:course) }
   let(:course_jsonapi) do

--- a/spec/deserializers/api/v2/deserializable_provider_spec.rb
+++ b/spec/deserializers/api/v2/deserializable_provider_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe API::V2::DeserializableProvider do
   let(:provider) { build(:provider) }
   let(:provider_jsonapi) do

--- a/spec/deserializers/api/v2/deserializable_site_spec.rb
+++ b/spec/deserializers/api/v2/deserializable_site_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe API::V2::DeserializableSite do
   let(:site) { build(:site) }
   let(:site_jsonapi) do

--- a/spec/models/concerns/postcode_normalize_spec.rb
+++ b/spec/models/concerns/postcode_normalize_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe PostcodeNormalize do
   # TODO: Create a test object to use this on instead.
   let(:object) { Site.new }

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe "#funding_type=" do
     before do

--- a/spec/models/course/changed_at_since_spec.rb
+++ b/spec/models/course/changed_at_since_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe ".changed_at_since" do
     context "30 days ago" do

--- a/spec/models/course/created_at_since_spec.rb
+++ b/spec/models/course/created_at_since_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe ".created_at_since" do
     context "30 days ago" do

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe "#funding_type" do
     describe "self accredited salary" do

--- a/spec/models/course/is_fee_based_spec.rb
+++ b/spec/models/course/is_fee_based_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe "#is_fee_based?" do
     context "salary based course" do

--- a/spec/models/course/publish_sites_spec.rb
+++ b/spec/models/course/publish_sites_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 RSpec.describe Course, type: :model do
   describe "#publish_sites" do
     let(:published_new_site)            { create(:site_status, :published, :new) }

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Course, type: :model do
   describe "#publishable?" do
     let(:course) { create(:course) }

--- a/spec/models/course/update_valid_spec.rb
+++ b/spec/models/course/update_valid_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Course, type: :model do
   describe "#update_valid" do
     let(:current_cycle) { find_or_create :recruitment_cycle }

--- a/spec/models/nctl_organisation_spec.rb
+++ b/spec/models/nctl_organisation_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe NCTLOrganisation, type: :model do
   it { should belong_to(:organisation) }
 end

--- a/spec/models/organisation_user_spec.rb
+++ b/spec/models/organisation_user_spec.rb
@@ -1,4 +1,4 @@
-require "rspec"
+require "rails_helper"
 
 describe OrganisationUser, type: :model do
   subject { described_class.new }

--- a/spec/models/subject_area_spec.rb
+++ b/spec/models/subject_area_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe SubjectArea do
   it "excludes the discontinued subject area" do
     expect(described_class.active.find_by(typename: "DiscontinuedSubject")).to be_nil

--- a/spec/services/course_serializers_service_spec.rb
+++ b/spec/services/course_serializers_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe CourseSerializersService do
   let(:course_serializer_spy) { spy }
   let(:subject_serializer_spy) { spy }

--- a/spec/services/courses/assignable_subject_service_spec.rb
+++ b/spec/services/courses/assignable_subject_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Courses::AssignableSubjectService do
   let(:service) do
     described_class.new(

--- a/spec/services/geocoder_service_spec.rb
+++ b/spec/services/geocoder_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe GeocoderService do
   describe "#geocode" do
     let(:valid_site) {

--- a/spec/services/record_first_login_service_spec.rb
+++ b/spec/services/record_first_login_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe RecordFirstLoginService do
   let(:service) { described_class.new }
 

--- a/spec/services/send_welcome_email_service_spec.rb
+++ b/spec/services/send_welcome_email_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe SendWelcomeEmailService do
   before { Timecop.freeze }
   after { Timecop.return }

--- a/spec/services/serialize_course_service_spec.rb
+++ b/spec/services/serialize_course_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe SerializeCourseService do
   let(:serializers_stub) { { ClassToRender: double } }
   let(:serializers_service_spy) { spy(execute: serializers_stub) }

--- a/spec/services/service_container_spec.rb
+++ b/spec/services/service_container_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe ServiceContainer do
   it "Allows you to register services" do
     service_spy = spy

--- a/spec/services/subjects/creator_service_spec.rb
+++ b/spec/services/subjects/creator_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Subjects::CreatorService do
   let(:primary_model) { spy }
   let(:secondary_model) { spy }

--- a/spec/services/subjects/financial_incentive_creator_service_spec.rb
+++ b/spec/services/subjects/financial_incentive_creator_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Subjects::FinancialIncentiveCreatorService do
   let(:subject_spy) { spy }
   let(:financial_incentive_spy) { spy }

--- a/spec/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
+++ b/spec/services/subjects/financial_incentive_set_subject_knowledge_enhancement_course_available_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Subjects::FinancialIncentiveSetSubjectKnowledgeEnhancementCourseAvailableService do
   let(:financial_incentive_spy) { spy }
   let(:financial_incentives_records_spy) { spy }

--- a/spec/services/subjects/populate_subject_areas_service_spec.rb
+++ b/spec/services/subjects/populate_subject_areas_service_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe Subjects::SubjectAreaCreatorService do
   let(:subject_area_spy) { spy }
   let(:service) { described_class.new(subject_area: subject_area_spy) }

--- a/spec/test_setup_specs/test_data_cache_spec.rb
+++ b/spec/test_setup_specs/test_data_cache_spec.rb
@@ -1,4 +1,4 @@
-require "rspec"
+require "rails_helper"
 
 describe "TestDataCache" do
   context "cache pre-filled" do

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe EmailValidator do
   let(:model) do
     cls = Class.new do

--- a/spec/validators/email_validator_spec.rb
+++ b/spec/validators/email_validator_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 describe EmailValidator do
+  class EmailValidatorTest
+    include ActiveRecord::Validations
+
+    attr_accessor :email
+
+    validates :email, email: true
+  end
+
   let(:model) do
-    cls = Class.new do
-      include ActiveRecord::Validations
-
-      attr_accessor :email
-
-      validates :email, email: true
-    end
-
-    cls.new
+    EmailValidatorTest.new
   end
 
   describe "With nil email address" do
@@ -24,7 +24,7 @@ describe EmailValidator do
     end
 
     it "Returns the correct error message" do
-      expect(model.errors[:email]).to include("^Enter an email address in the correct format, like name@example.com")
+      expect(model.errors[:email]).to(include("^Enter an email address in the correct format, like name@example.com"))
     end
   end
 

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe PhoneValidator do
   let(:model) do
     cls = Class.new do

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -1,16 +1,16 @@
 require "rails_helper"
 
 describe PhoneValidator do
+  class PhoneValidatorTest
+    include ActiveRecord::Validations
+
+    attr_accessor :phone_number
+
+    validates :phone_number, phone: true
+  end
+
   let(:model) do
-    cls = Class.new do
-      include ActiveRecord::Validations
-
-      attr_accessor :phone_number
-
-      validates :phone_number, phone: true
-    end
-
-    cls.new
+    PhoneValidatorTest.new
   end
 
   describe "With nil phone number address" do

--- a/spec/validators/postcode_validator_spec.rb
+++ b/spec/validators/postcode_validator_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 describe PostcodeValidator do
   # TODO: Use a dummy model here, instead of site.
   let(:site) { build(:site) }

--- a/spec/validators/unique_course_validator_spec.rb
+++ b/spec/validators/unique_course_validator_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper.rb"
+
 describe UniqueCourseValidator do
   let(:service) { described_class.new }
   let(:provider) { create(:provider, sites: [site_one, site_two]) }

--- a/spec/validators/words_count_validator_spec.rb
+++ b/spec/validators/words_count_validator_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper.rb"
+
 describe WordsCountValidator do
   maximum = 10
 


### PR DESCRIPTION
### Context

Shoveling error messages directly into model errors is deprecated and is raising warnings left right and center.

### Changes proposed in this pull request

Adopt the suggested fix to use `.add` instead.

### Guidance to review

An example of the deprecation warning is:

```
DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead. (called from validate_each at /Users/misaka/Code/DfE/teacher-training-api/app/validators/email_validator.rb:6)
```

so this has been changed wherever needed. However in testing these fixes it was also noticed that a bunch of specs don't `require "rails_helper"` causing them to be untestable without running the whole suite. This was also fixed so that any spec that should require `rails_helper` does.

NB: there are some deprecation warnings still being emitted about `ActiveModel::Errors#keys` but this appears to be from inside of the jsonapi renderer we use as the source location is always a call to `render json_errors: ...`.