### PR TITLE
Update @channel alert in SLACK_MESSAGE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,6 @@ jobs:
         SLACK_COLOR: '#ef5343'
         SLACK_ICON_EMOJI: ':github-logo:'
         SLACK_USERNAME: Teacher Training API
-        SLACK_TITLE: '<!channel> Build failure'
-        SLACK_MESSAGE: ':alert: Teacher Training API Build failure :sadparrot:'
+        SLACK_TITLE: Build failure
+        SLACK_MESSAGE: ':alert: <!channel> Teacher Training API Build failure :sadparrot:'
         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,6 @@ jobs:
           SLACK_COLOR: '#ef5343'
           SLACK_ICON_EMOJI: ':github-logo:'
           SLACK_USERNAME: Teacher Training API
-          SLACK_TITLE: '<!channel> Deploy to ${{ matrix.environment }} Failed'
-          SLACK_MESSAGE: ':alert: Build failure on ${{ matrix.environment }} :sadparrot:'
+          SLACK_TITLE: Deploy to ${{ matrix.environment }} Failed
+          SLACK_MESSAGE: ':alert: <!channel> Build failure on ${{ matrix.environment }} :sadparrot:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -42,5 +42,5 @@ jobs:
           SLACK_ICON_EMOJI: ':github-logo:'
           SLACK_USERNAME: Teacher Training API
           SLACK_TITLE: Smoke tests failure
-          SLACK_MESSAGE: ':alert: Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
+          SLACK_MESSAGE: ':alert: <!channel> Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context

<!channel> is parsed as `@channel` only inside SLACK_MESSAGE

### Changes proposed in this pull request

move <!channel> inside SLACK_MESSAGE to notify the channel.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
