### PR TITLE
Add SETTINGS__MAPIT_API_KEY variable for bg container

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -1056,6 +1056,10 @@
               {
                 "name": "SETTINGS__GOVUK_NOTIFY__API_KEY",
                 "value": "[parameters('govukNotifyApiKey')]"
+              },
+              {
+                "name": "SETTINGS__MAPIT_API_KEY",
+                "value": "[parameters('mapitApiKey')]"
               }
             ]
           },


### PR DESCRIPTION
### Context

`SETTINGS__MAPIT_API_KEY ` is missing from the bg container.

### Changes proposed in this pull request

Set `SETTINGS__MAPIT_API_KEY ` for the background container.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
