### PR TITLE
Add subject_codes to public/v1 API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -111,6 +111,10 @@ module API
           @object.description
         end
 
+        attribute :subject_codes do
+          @object.subjects.pluck(:subject_code).compact
+        end
+
         enrichment_attribute :about_course
         enrichment_attribute :course_length
         enrichment_attribute :fee_details

--- a/docs/source/release-notes.html.md.erb
+++ b/docs/source/release-notes.html.md.erb
@@ -5,6 +5,10 @@ weight: 2
 
 # Release Notes
 
+## 5 March 2021
+
+- Add `subject_codes` field to `CourseAttributes`. This is an array of two-digit subject codes as strings, corresponding to subjects available on the `/subjects` endpoint.
+
 ## v1.0 - 13 March 2020
 
 - Initial release of the API.

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -83,4 +83,5 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:state).with_value("published") }
   it { is_expected.to have_attribute(:study_mode).with_value("full_time") }
   it { is_expected.to have_attribute(:summary).with_value("PGCE with QTS full time teaching apprenticeship") }
+  it { is_expected.to have_attribute(:subject_codes).with_value(%w[00]) }
 end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -479,6 +479,14 @@
             "type": "string",
             "description": "Generated summary of the course.",
             "example": "PGCE with QTS full time"
+          },
+          "subject_codes": {
+            "type": "array",
+            "description": "The course’s subject codes, corresponding to subjects available on the `/subjects` endpoint",
+            "items": {
+              "type": "string",
+              "example": "00"
+            }
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -334,3 +334,9 @@ properties:
     type: string
     description: "Generated summary of the course."
     example: "PGCE with QTS full time"
+  subject_codes:
+    type: array
+    description: "The course’s subject codes, corresponding to subjects available on the `/subjects` endpoint"
+    items:
+      type: string
+      example: "00"


### PR DESCRIPTION
### Context

The Apply sync job still uses the V3 API to fetch subject codes. With these on the `public/v1` API we can turn off the v3 API altogether and start to benefit from features of the V1 API like the `updated_since` filter for courses.

### Changes proposed in this pull request

Add the field, a spec and documentation.

Introduce a pattern for release notes as discussed on Slack https://ukgovernmentdfe.slack.com/archives/CGVNJ2Q2F/p1614852108081800

### Guidance to review

Please be nice @defong 🙏 