### PR TITLE
[471] Update fee_domestic description in api docs

### DIFF
--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -213,7 +213,7 @@
           "fee_domestic": {
             "type": "integer",
             "nullable": true,
-            "description": "Fee in GBP for UK and EU students.",
+            "description": "Fee in GBP for UK students.",
             "example": 9200
           },
           "financial_support": {

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -99,7 +99,7 @@ properties:
   fee_domestic:
     type: integer
     nullable: true
-    description: "Fee in GBP for UK and EU students."
+    description: "Fee in GBP for UK students."
     example: 9200
   financial_support:
     type: string


### PR DESCRIPTION
### Context

https://trello.com/c/SHa65Stm/472-s-update-uk-eu-fees-info-in-api-documentation

### Changes proposed in this pull request

- Update description in api docs and api spec for `fee_domestic` from 'Fee in GBP for UK and EU students.' to' Fee in GBP for UK students.'

### Guidance to review

- Visit the docs at `/api-reference.html#schema-courseattributes` and check the description for `fee_domestic`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
