### PR TITLE
[452] add feature service

### DIFF
--- a/app/services/feature_service.rb
+++ b/app/services/feature_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module FeatureService
+  class << self
+    def require(feature_name)
+      unless enabled?(feature_name)
+        raise "Feature #{feature_name} is disabled"
+      end
+
+      true
+    end
+
+    def enabled?(feature_name)
+      return false if Settings.features.blank?
+
+      segments = feature_name.to_s.split(".")
+
+      segments.reduce(Settings.features) { |config, segment| config[segment] }
+    end
+  end
+end

--- a/spec/services/feature_service_spec.rb
+++ b/spec/services/feature_service_spec.rb
@@ -1,0 +1,126 @@
+require "rails_helper"
+
+describe FeatureService do
+  describe ".require" do
+    context "feature is enabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = true
+      end
+
+      it "returns true" do
+        response = FeatureService.require(:rspec_testing)
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "feature is disabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = false
+      end
+
+      it "raises an error" do
+        expect { FeatureService.require(:rspec_testing) }
+          .to raise_error(RuntimeError, "Feature rspec_testing is disabled")
+      end
+    end
+
+    context "nested feature is enabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = Config::Options.new nested: true
+      end
+
+      it "returns true" do
+        response = FeatureService.require("rspec_testing.nested")
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "nested feature is disabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = Config::Options.new nested: false
+      end
+
+      it "raises an error" do
+        expect { FeatureService.require("rspec_testing.nested") }
+          .to raise_error(RuntimeError, "Feature rspec_testing.nested is disabled")
+      end
+    end
+  end
+
+  describe ".enabled?" do
+    context "feature is enabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = true
+      end
+
+      it "returns true" do
+        response = FeatureService.enabled?(:rspec_testing)
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "feature is disabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = false
+      end
+
+      it "returns false" do
+        response = FeatureService.enabled?(:rspec_testing)
+
+        expect(response).to be_falsey
+      end
+    end
+
+    context "nested feature is enabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = Config::Options.new nested: true
+      end
+
+      it "looks up the feature using dot-separated segments" do
+        response = FeatureService.enabled?("rspec_testing.nested")
+
+        expect(response).to be_truthy
+      end
+    end
+
+    context "nested feature is disabled" do
+      before do
+        Settings.features ||= Config::Options.new
+        Settings.features.rspec_testing = Config::Options.new nested: false
+      end
+
+      it "looks up the feature using dot-separated segments" do
+        response = FeatureService.enabled?("rspec_testing.nested")
+
+        expect(response).to be_falsey
+      end
+    end
+
+    context "feature settings are empty" do
+      around(:each) do |example|
+        old_features = Settings.features
+        Settings.features = nil
+        example.run
+        # rspec takes care of ensuring that the following runs, even if an
+        # exception is raised in the spec.
+        Settings.features = old_features
+      end
+
+      it "returns false" do
+        response = FeatureService.enabled?(:rspec_testing)
+
+        expect(response).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add service to help use of features, patterns copied from Register and
Publish.

This has been pulled out of the other 452 PR as it's already a bit too large.

### Context

The change for the the GIAS spike needs to be put behind a feature flag, and in general we will likely want to support features in the API going forward.

### Changes proposed in this pull request

Add a `FeatureService` which reuses patterns from Publish and Register.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
