### PR TITLE
[1242] - Add support providers view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
+!.keep
+*.DS_Store
+*.swo
+*.swp
+
 # Ignore all logfiles and tempfiles.
 /log/*
 /tmp/*

--- a/Gemfile
+++ b/Gemfile
@@ -202,6 +202,10 @@ group :test do
   gem "rspec_junit_formatter"
   gem "shoulda-matchers", "~> 4.5"
   gem "simplecov", "< 0.22", require: false
+
+  # Page objects
+  gem "site_prism", "~> 3.7"
+
   gem "webmock"
 
   # Adds support for Capybara system testing and selenium driver

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -478,6 +478,11 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
+    site_prism (3.7.1)
+      addressable (~> 2.5)
+      capybara (~> 3.8)
+      site_prism-all_there (>= 0.3.1, < 1.0)
+    site_prism-all_there (0.3.2)
     skylight (5.0.1)
       activesupport (>= 5.2.0)
     spring (2.1.1)
@@ -618,6 +623,7 @@ DEPENDENCIES
   sidekiq
   sidekiq-cron
   simplecov (< 0.22)
+  site_prism (~> 3.7)
   skylight
   spring
   spring-commands-rspec

--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -14,6 +14,10 @@
         <span class="govuk-header__product-name">
           <%= service_name %>
         </span>
+
+        <strong class="govuk-tag govuk-phase-banner__content__tag">
+          <%= Settings.environment.name.titlecase %>
+        </strong>
       <% end %>
     </div>
 

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -16,7 +16,8 @@ class NavigationBar::View < GovukComponent::Base
   end
 
   def user_signed_in?
-    @current_user.present?
+    # @current_user.present?
+    true
   end
 
 private

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -16,8 +16,7 @@ class NavigationBar::View < GovukComponent::Base
   end
 
   def user_signed_in?
-    # @current_user.present?
-    true
+    @current_user.present?
   end
 
 private

--- a/app/components/tab_navigation/script.js
+++ b/app/components/tab_navigation/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/tab_navigation/style.scss
+++ b/app/components/tab_navigation/style.scss
@@ -1,0 +1,113 @@
+@import "../base.scss";
+
+.app-tab-navigation {
+  margin-bottom: govuk-spacing(7);
+}
+
+.app-tab-navigation__list {
+  font-size: 0; // Removes white space when using inline-block on child element.
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  @include govuk-media-query($from: 375px) {
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    width: 100%;
+  }
+
+  // IE8 does not support box shadow, so use a standard border.
+  @include govuk-if-ie8 {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+
+}
+
+.app-tab-navigation__item {
+  @include govuk-font(19);
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  display: block;
+  margin-top: -1px;
+
+  &:last-child {
+    box-shadow: none;
+  }
+
+  @include govuk-media-query($from: 375px) {
+    box-shadow: none;
+    display: inline-block;
+    margin-right: govuk-spacing(4);
+    margin-top: 0;
+  }
+
+}
+
+.app-tab-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  display: block;
+  padding-top: 12px;
+  padding-bottom: 17px;
+  padding-left: govuk-spacing(3);
+  position: relative;
+  font-weight: bold;
+  text-decoration: none;
+
+  @include govuk-media-query($from: 375px) {
+    padding-left: 0;
+  }
+
+  &:link,
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover {
+    color: $govuk-link-hover-colour;
+  }
+
+  &:focus {
+    color: govuk-colour("black"); // Focus colour on yellow should really be black.
+    position: relative; // Ensure focus sits above everything else.
+    box-shadow: none;
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+    content: "";
+    display: block;
+    width: 100%;
+    position: absolute; bottom: 0; left: 0; right: 0;
+    height: 5px;
+  }
+
+}
+
+.app-tab-navigation__link[aria-current="page"] {
+  color: $govuk-link-active-colour;
+  position: relative;
+  text-decoration: none;
+
+  &:focus:before {
+    height: 7px; // Bar needs to change thickness so that we don’t rely on colour alone.
+  }
+
+  &:before {
+    background-color: $govuk-link-colour;
+    content: "";
+    display: block;
+    height: 100%;
+    position: absolute; bottom: 0; left: 0;
+    width: 5px;
+
+    @include govuk-media-query($from: 375px) {
+      height: 5px;
+      width: 100%;
+    }
+
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+  }
+
+}

--- a/app/components/tab_navigation/view.html.erb
+++ b/app/components/tab_navigation/view.html.erb
@@ -1,0 +1,13 @@
+<nav class="app-tab-navigation govuk-!-margin-bottom-4" aria-label="Sub navigation">
+  <ul class="app-tab-navigation__list">
+    <% items.each do |item| %>
+      <li class="app-tab-navigation__item">
+        <% if item.fetch(:current, false) || current_page?(item.fetch(:url)) %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link", aria: { current: "page" } %>
+        <% else %>
+          <%= govuk_link_to item[:name], item[:url], class: "app-tab-navigation__link" %>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</nav>

--- a/app/components/tab_navigation/view.rb
+++ b/app/components/tab_navigation/view.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module TabNavigation
+  class View < GovukComponent::Base
+    attr_reader :items
+
+    def initialize(items:)
+      @items = items
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate
+  # before_action :authenticate
 
   include Pundit
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,8 @@
 class ApplicationController < ActionController::Base
-  # before_action :authenticate
+  before_action :authenticate
 
   include Pundit
+  include Pagy::Backend
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
     if current_user
       UserSessions::Update.call(user: current_user, user_session: user_session)
 
-      redirect_to "/"
+      redirect_to "/support"
     else
       UserSession.end_session!(session)
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
     if current_user
       UserSessions::Update.call(user: current_user, user_session: user_session)
 
-      redirect_to "/support"
+      redirect_to support_path
     else
       UserSession.end_session!(session)
 
@@ -24,7 +24,7 @@ class SessionsController < ApplicationController
       UserSession.end_session!(session)
       redirect_to user_session.logout_url
     else
-      redirect_to "/"
+      redirect_to support_path
     end
   end
 end

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -1,7 +1,7 @@
 module Support
   class ProvidersController < ApplicationController
     def index
-      @providers = Provider.order(:provider_name).limit(30)
+      @pagy, @providers = pagy(Provider.order(:provider_name).includes(:courses, :users))
     end
 
     def show

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -1,0 +1,11 @@
+module Support
+  class ProvidersController < ApplicationController
+    def index
+      @providers = Provider.order(:provider_name).limit(30)
+    end
+
+    def show
+      @provider = Provider.find(params[:id])
+    end
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,6 @@
 module ApplicationHelper
+  include Pagy::Frontend
+
   def header_items(current_user)
     return unless current_user
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,30 +36,19 @@
 
     <%= render NavigationBar::View.new(
       items: [
+        { name: "Providers", url: support_providers_path, current: true },
       ],
       current_path: request.path,
       current_user: @current_user,
     ) %>
 
-    <div class="app-phase-banner app-phase-banner__env--<%= Settings.environment.name %>">
-      <div class="govuk-width-container">
-        <div class="govuk-phase-banner">
-          <p class="govuk-phase-banner__content">
-            <strong class="govuk-tag govuk-phase-banner__content__tag">
-              <%= Settings.environment.name.titlecase %>
-            </strong>
-          </p>
-        </div>
-      </div>
-    </div>
-
     <div class="govuk-width-container">
-
-    <main class="govuk-main-wrapper " id="main-content" role="main">
-      <div class="govuk-width-container">
-        <%= yield %>
-      </div>
-    </main>
+      <main class="govuk-main-wrapper " id="main-content" role="main">
+        <div class="govuk-width-container">
+          <%= yield %>
+        </div>
+      </main>
+    </div>
 
     <%= tag.footer(class: "govuk-footer", role: "contentinfo") do %>
       <div class="govuk-width-container">

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -7,7 +7,7 @@
 
     <p class="govuk-body-m"> Use DfE Sign-in to access your account. You need to be a registered administrator to login to these pages.</p>
 
-    <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe") %>
+    <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
 
     <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name") %>,   email <%= support_email %>.
     </p>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -9,6 +9,7 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
     </tr>
   </thead>
 
@@ -20,7 +21,15 @@
             <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
           </span>
         </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.provider_code %>
+          </span>
+        </td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<%= pagy_nav(@pagy).html_safe %>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -1,0 +1,26 @@
+
+<h1 class="govuk-heading-l">Providers</h1>
+
+<%= render TabNavigation::View.new(items: [
+  { name: "Providers", url: support_providers_path },
+]) %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @providers.each do |provider| %>
+      <tr class="govuk-table__row">
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+          </span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -1,3 +1,4 @@
+<%= render PageTitle::View.new(title: "support.providers.index") %>
 
 <h1 class="govuk-heading-l">Providers</h1>
 

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -15,7 +15,7 @@
 
   <tbody class="govuk-table__body">
     <% @providers.each do |provider| %>
-      <tr class="govuk-table__row">
+      <tr class="govuk-table__row qa-provider_row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,6 +8,9 @@ en:
       sign_in:
         index: Sign in
         new: User not found
+      support:
+        providers:
+          index: Providers
   course:
     update_email:
       name: "title"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,12 @@ Rails.application.routes.draw do
   get "/auth/dfe/callback", to: "sessions#callback"
   get "/auth/dfe/signout", to: "sessions#destroy"
 
+  namespace :support do
+    get "/" => redirect("/support/providers")
+
+    resources :providers, only: %i[index show]
+  end
+
   namespace :api do
     namespace :v1 do
       scope "/(:recruitment_year)", constraints: { recruitment_year: /2021|2022/ } do

--- a/spec/components/navigation_bar/view_preview.rb
+++ b/spec/components/navigation_bar/view_preview.rb
@@ -15,7 +15,7 @@ module NavigationBar
     def items
       [
         { name: "Home", url: "root_path" },
-        { name: "Trainee records", url: "trainees_path", current: false },
+        { name: "Providers", url: "#", current: false },
       ]
     end
 

--- a/spec/components/tab_navigation/view_preview.rb
+++ b/spec/components/tab_navigation/view_preview.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module TabNavigation
+  class ViewPreview < ViewComponent::Preview
+    def default
+      render(View.new(items: items))
+    end
+
+    def with_current_item_highlited
+      with_current = items.prepend(
+        { name: "Training details", url: mock_link, current: true },
+      )
+
+      render(View.new(items: with_current))
+    end
+
+  private
+
+    def items
+      [
+        { name: "Personal details", url: mock_link },
+        { name: "Timeline", url: mock_link },
+      ]
+    end
+
+    def mock_link
+      "https://www.gov.uk"
+    end
+  end
+end

--- a/spec/components/tab_navigation/view_spec.rb
+++ b/spec/components/tab_navigation/view_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module TabNavigation
+  describe View do
+    alias_method :component, :page
+
+    let(:mock_link) { "https://www.gov.uk" }
+
+    let(:items) do
+      [
+        { name: "Home", url: mock_link },
+        { name: "Providers", url: mock_link },
+      ]
+    end
+
+    context "default" do
+      before do
+        render_inline(described_class.new(items: items))
+      end
+
+      it "renders the provided links" do
+        rendered_items = component.find_all(".app-tab-navigation__link")
+
+        expect(rendered_items.size).to eq(2)
+      end
+    end
+
+    context "with current item" do
+      let(:active_item) { { name: "Training details", url: mock_link, current: true } }
+
+      before do
+        render_inline(described_class.new(items: items.prepend(active_item)))
+      end
+
+      it "renders the current item with the correct class" do
+        rendered_link = component.find(".app-tab-navigation__link", text: active_item[:name])
+        expect(rendered_link["aria-current"]).to eq("page")
+      end
+    end
+  end
+end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -29,7 +29,7 @@ describe SessionsController, type: :controller do
       let(:user) { build(:user) }
       it "redirects to the root page" do
         request_destroy
-        expect(response).to redirect_to("/")
+        expect(response).to redirect_to(support_path)
       end
     end
   end
@@ -62,7 +62,7 @@ describe SessionsController, type: :controller do
 
       it "redirects to the root page" do
         request_callback
-        expect(response).to redirect_to("/")
+        expect(response).to redirect_to(support_path)
       end
     end
 

--- a/spec/features/support/providers/providers_list_spec.rb
+++ b/spec/features/support/providers/providers_list_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View providers" do
+  let(:user) { create(:user, :admin) }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_there_are_providers
+    when_i_visit_the_provider_index_page
+  end
+
+  scenario "i can view the providers" do
+    then_i_see_the_providers
+  end
+
+  def and_there_are_providers
+    create_list(:provider, 2)
+  end
+
+  def when_i_visit_the_provider_index_page
+    provider_index_page.load
+  end
+
+  def then_i_see_the_providers
+    expect(provider_index_page.providers.size).to eq(2)
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -95,6 +95,10 @@ RSpec.configure do |config|
     config.after(:each)  { Bullet.end_request }
   end
 
+  config.before(:each, type: :system) do
+    driven_by(:rack_test)
+  end
+
   config.include ActiveJob::TestHelper, type: :request
 
   ActiveJob::Base.queue_adapter = :test

--- a/spec/support/feature_helpers/authentication.rb
+++ b/spec/support/feature_helpers/authentication.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  module Authentication
+    attr_reader :current_user
+
+    def given_i_am_authenticated(user: nil)
+      @current_user = user || create(:user)
+      user_exists_in_dfe_sign_in(user: @current_user)
+
+      visit_sign_in_page
+    end
+
+    def visit_sign_in_page
+      sign_in_page = PageObjects::SignIn.new
+      sign_in_page.load
+      sign_in_page.sign_in_button.click
+    end
+  end
+end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  module Pages
+    def provider_index_page
+      @provider_index_page ||= PageObjects::Support::ProviderIndex.new
+    end
+
+    def sign_in_page
+      @sign_in_page ||= PageObjects::SignIn.new
+    end
+  end
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "feature_helpers/authentication"
+require_relative "feature_helpers/pages"
+require_relative "dfe_sign_in_user_helper"
+
+RSpec.configure do |config|
+  config.include FeatureHelpers::Authentication, type: :feature
+  config.include FeatureHelpers::Pages, type: :feature
+  config.include DfESignInUserHelper, type: :feature
+end

--- a/spec/support/omniauth.rb
+++ b/spec/support/omniauth.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "omniauth"
+
+OmniAuth.config.test_mode = true

--- a/spec/support/page_objects/base.rb
+++ b/spec/support/page_objects/base.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require "site_prism"
+
+module PageObjects
+  class Base < SitePrism::Page; end
+end

--- a/spec/support/page_objects/sections/base.rb
+++ b/spec/support/page_objects/sections/base.rb
@@ -1,0 +1,6 @@
+module PageObjects
+  module Sections
+    class Base < SitePrism::Section
+    end
+  end
+end

--- a/spec/support/page_objects/sign_in.rb
+++ b/spec/support/page_objects/sign_in.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  class SignIn < PageObjects::Base
+    set_url "/sign-in"
+
+    element :page_heading, ".govuk-heading-l"
+
+    element :sign_in_button, ".qa-sign_in_button"
+  end
+end

--- a/spec/support/page_objects/support/provider_index.rb
+++ b/spec/support/page_objects/support/provider_index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class ProviderIndex < PageObjects::Base
+      set_url "providers"
+
+      def providers
+        page.find_all(".qa-provider_row")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider_index.rb
+++ b/spec/support/page_objects/support/provider_index.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderIndex < PageObjects::Base
-      set_url "providers"
+      set_url "/support/providers"
 
       def providers
         page.find_all(".qa-provider_row")


### PR DESCRIPTION
### Context

- https://trello.com/c/moAWvYfF/1242-m-add-provider-list-to-ttapi-ui

### Changes proposed in this pull request

<img width="1150" alt="Screenshot 2021-03-31 at 19 13 18" src="https://user-images.githubusercontent.com/616080/113191249-37255100-9255-11eb-84d5-76c779e0d587.png">

- Sets up layout and view for providers list
- Renders providers, temporarily paginated with a very minimal config and unstyled (handled in a different ticket)
- Add a component for the secondary navigation

### Guidance to review

- View in QA, and assert you're able to see the providers list.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
