### PR TITLE
[1315] Provider show page with users tab

### DIFF
--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -6,6 +6,7 @@ module Support
 
     def show
       @provider = Provider.find(params[:id])
+      render layout: "provider_record"
     end
   end
 end

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -1,0 +1,14 @@
+module Support
+  class UsersController < ApplicationController
+    def index
+      @users = provider.users.order(:last_name)
+      render layout: "provider_record"
+    end
+
+  private
+
+    def provider
+      @provider ||= Provider.find(params[:provider_id])
+    end
+  end
+end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module LayoutHelper
+  # Enables inheriting from and extending another layout.
+  # Adapted from the nestive gem: https://github.com/rwz/nestive/blob/master/lib/nestive/layout_helper.rb#L84
+  def extends_layout(layout, &block)
+    layout = layout.to_s
+    layout = "layouts/#{layout}" unless layout.include?("/")
+    view_flow.get(:layout).replace(capture(&block).to_s)
+
+    render(template: layout)
+  end
+end

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -1,0 +1,10 @@
+<%= extends_layout :application do %>
+  <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
+
+  <%= render TabNavigation::View.new(items: [
+    { name: "Details", url: support_provider_path(@provider) },
+    { name: "Users", url: support_provider_users_path(@provider) },
+  ]) %>
+
+  <%= yield %>
+<% end %>

--- a/app/views/support/providers/show.html.erb
+++ b/app/views/support/providers/show.html.erb
@@ -1,1 +1,0 @@
-<h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>

--- a/app/views/support/users/index.html.erb
+++ b/app/views/support/users/index.html.erb
@@ -1,0 +1,25 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">First name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Last name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-two-quarters">Email</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @users.each do |user| %>
+      <tr class="govuk-table__row user-row">
+        <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= user.first_name %></span>
+        </td>
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= user.last_name %></span>
+        </td>
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= user.email %></span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,9 @@ Rails.application.routes.draw do
   namespace :support do
     get "/" => redirect("/support/providers")
 
-    resources :providers, only: %i[index show]
+    resources :providers, only: %i[index show] do
+      resources :users, only: %i[index]
+    end
   end
 
   namespace :api do

--- a/spec/features/support/providers/provider_users_list_spec.rb
+++ b/spec/features/support/providers/provider_users_list_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View provider users" do
+  let(:user) { create(:user, :admin) }
+
+  scenario "i can view users belong to a provider" do
+    given_i_am_authenticated(user: user)
+    and_there_is_a_provider
+    when_i_visit_the_provider_show_page
+    and_click_on_the_users_tab
+    then_i_should_see_a_table_of_users
+  end
+
+  def and_there_is_a_provider
+    @provider = create(:provider)
+  end
+
+  def when_i_visit_the_provider_show_page
+    provider_show_page.load(id: @provider.id)
+  end
+
+  def and_click_on_the_users_tab
+    provider_show_page.users_tab.click
+  end
+
+  def then_i_should_see_a_table_of_users
+    expect(provider_users_index_page.users.size).to eq(1)
+  end
+end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -6,6 +6,14 @@ module FeatureHelpers
       @provider_index_page ||= PageObjects::Support::ProviderIndex.new
     end
 
+    def provider_show_page
+      @provider_show_page ||= PageObjects::Support::ProviderShow.new
+    end
+
+    def provider_users_index_page
+      @provider_users_index_page ||= PageObjects::Support::ProviderUsersIndex.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/page_objects/support/provider_show.rb
+++ b/spec/support/page_objects/support/provider_show.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class ProviderShow < PageObjects::Base
+      set_url "support/providers/{id}"
+
+      element :users_tab, ".app-tab-navigation__link", text: "Users"
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider_users_index_page.rb
+++ b/spec/support/page_objects/support/provider_users_index_page.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class ProviderUsersIndex < PageObjects::Base
+      set_url "support/providers/{provider_id}/users"
+
+      def users
+        page.find_all(".user-row")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/hpDqCfE2/1315-m-provider-show

### Changes proposed in this pull request
- Add tab navigation to provider show page
- Add users index resource

Taking inspiration from Apply, when the user clicks on a provider, the show page lands on the "Details" tab (to be filled in later).

### Guidance to review
- Visit `/support/providers`
- Click on a provider
- Click on the "Users" tab
- Confirm table of users is displayed

<img width="1093" alt="Screenshot 2021-04-01 at 14 05 34" src="https://user-images.githubusercontent.com/28728/113298100-5d013300-92f3-11eb-93d0-6a6403a7438f.png">


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
