### PR TITLE
Increase webapp disk quota

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -5,6 +5,7 @@ resource cloudfoundry_app web_app {
   health_check_http_endpoint = "/ping"
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
+  disk_quota                 = 1500
   docker_image               = var.docker_image
   strategy                   = local.deployment_strategy
   timeout                    = 180


### PR DESCRIPTION
### Context
It's filling up in production

### Changes proposed in this pull request
Increase disk quota to 1.5GB
The root cause should be examined separately

### Guidance to review
Successfully deployed to QA: https://github.com/DFE-Digital/teacher-training-api/actions/runs/722017731

