### PR TITLE
[1314] Provider lookup supporting name or code

### DIFF
--- a/app/components/paginated_filter/view.html.erb
+++ b/app/components/paginated_filter/view.html.erb
@@ -1,0 +1,13 @@
+<div class='moj-filter-layout'>
+  <%= render Providers::Filters::View.new(filters: filters, filter_actions: filter_actions) %>
+
+  <div class='moj-filter-layout__content'>
+    <div class="moj-action-bar">
+      <div class="moj-action-bar__filter"></div>
+    </div>
+
+    <%= content %>
+
+    <%= render Paginator::View.new(scope: collection) %>
+  </div>
+</div>

--- a/app/components/paginated_filter/view.rb
+++ b/app/components/paginated_filter/view.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PaginatedFilter
+  class View < ViewComponent::Base
+    attr_reader :filters, :collection
+
+    with_content_areas :filter_actions
+
+    def initialize(filters:, collection:)
+      @filters = filters
+      @collection = collection
+    end
+  end
+end

--- a/app/components/providers/filters/script.js
+++ b/app/components/providers/filters/script.js
@@ -1,0 +1,30 @@
+import './style.scss'
+import $ from 'jquery'
+import { FilterToggleButton } from 'moj/all.js'
+
+const prepareFilterToggle = () => {
+  const filterContainer = $('.moj-filter-layout__filter')
+
+  if (filterContainer.length) {
+    /* eslint-disable no-new */
+    new FilterToggleButton({
+      bigModeMediaQuery: '(min-width: 48.063em)',
+      startHidden: false,
+      toggleButton: {
+        container: $('.moj-action-bar__filter'),
+        showText: 'Show filters',
+        hideText: 'Hide filters',
+        classes: 'govuk-button--secondary'
+      },
+      closeButton: {
+        container: $('.moj-filter__header-action'),
+        text: 'Close'
+      },
+      filter: {
+        container: filterContainer
+      }
+    })
+  }
+}
+
+prepareFilterToggle()

--- a/app/components/providers/filters/style.scss
+++ b/app/components/providers/filters/style.scss
@@ -1,0 +1,103 @@
+@import "../../base.scss";
+@import "~@ministryofjustice/frontend/moj/settings/assets";
+@import "~@ministryofjustice/frontend/moj/settings/measurements";
+@import "~@ministryofjustice/frontend/moj/helpers/all";
+@import "~@ministryofjustice/frontend/moj/objects/width-container";
+@import "~@ministryofjustice/frontend/moj/objects/filter-layout";
+@import "~@ministryofjustice/frontend/moj/objects/scrollable-pane";
+@import "~@ministryofjustice/frontend/moj/components/filter/filter";
+
+.app-filter {
+  box-shadow: none;
+
+  @include govuk-media-query($from: tablet) {
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
+// Apply GOV.UK focus styles - only needed with js.
+.js-enabled .app-filter:focus {
+  outline: $govuk-focus-width solid $govuk-focus-colour;
+}
+
+.moj-filter-layout__content {
+  overflow-x: hidden;
+}
+
+.moj-action-bar__filter {
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.filter-toggle-button {
+  float: right;
+  margin-bottom: govuk-spacing(1);
+  @include govuk-media-query($from: desktop) {
+    display: none;
+  }
+}
+
+.moj-action-bar__filter:after {
+  background: none;
+}
+
+@media (min-width: 48.0625em) {
+  .moj-filter-layout__filter {
+    max-width: 300px;
+    margin-bottom: 10px;
+  }
+}
+
+.js-enabled .moj-filter-layout__filter {
+  @include govuk-media-query($until: tablet) {
+    // only display a scrollbar if it there is overflow to scroll
+    overflow: auto;
+    // At this width the filter has `position: fixed`. We should set a max width that will safely include the filter and a scrollbar if present 
+    max-width: calc(100vw - calc(100vw - 100%));
+  }
+}
+
+.moj-filter__header {
+  background: govuk-colour("white");
+  box-shadow: none;
+  border: 1px solid $govuk-border-colour;
+  border-bottom: 0;
+  padding-top: govuk-spacing(3);
+  padding-bottom: govuk-spacing(3);
+}
+
+.moj-filter__selected {
+  box-shadow: none;
+  border: 1px solid $govuk-border-colour;
+  border-top: 0;
+  border-bottom: 0;
+  padding-top: govuk-spacing(5);
+  padding-bottom: govuk-spacing(5);
+}
+
+.moj-filter__options {
+  box-shadow: none;
+}
+
+.moj-filter__tag:focus, .moj-filterfe__tag:focus:hover {
+  outline: none;
+  box-shadow: 0 4px #0b0c0c;
+}
+
+// Fix for focus issue - see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640
+// We're catching the focus on a second element rather than having the filter component itself flash with focus when checkbox labels are clicked.
+.moj-filter__content:focus {
+  outline: none;
+}
+
+.moj-filter-layout__filter-wrapper {
+  max-width: 300px;
+  margin-right: 40px;
+  min-width: 260px;
+  width: 100%;
+  @include govuk-media-query($from: desktop) {
+    float: left;
+  }
+}
+

--- a/app/components/providers/filters/view.html.erb
+++ b/app/components/providers/filters/view.html.erb
@@ -1,0 +1,53 @@
+<div class="moj-filter-layout__filter-wrapper app-filter">
+  <div class="moj-filter-layout__filter">
+    <div class="moj-filter">
+      <div class="moj-filter__header">
+        <div class="moj-filter__header-title">
+          <h2 class="govuk-heading-m">Filters</h2>
+        </div>
+        <div class="moj-filter__header-action">
+        </div>
+      </div>
+
+      <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
+      <div class="moj-filter__content" tabindex="-1">
+        <% if filters %>
+          <div class="moj-filter__selected">
+            <div class="moj-filter__selected-heading">
+              <div class="moj-filter__heading-title">
+                <h2 class="govuk-heading-m">Selected filters</h2>
+              </div>
+              <div class="moj-filter__heading-action">
+                <p class="govuk-body">
+                <%= govuk_link_to 'Clear<span class="govuk-visually-hidden"> all filters</span>'.html_safe, support_providers_path, class: "govuk-link--no-visited-state" %>
+                </p>
+              </div>
+            </div>
+
+            <% filters.each do |filter, value| %>
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label_for(filter) %></h3>
+              <ul class="moj-filter-tags">
+                <% tags_for_filter(filter, value).each do |tag| %>
+                  <li>
+                    <%= govuk_link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
+                  </li>
+                <% end %>
+              </ul>
+            <% end %>
+          </div>
+        <% end %>
+
+        <div class="moj-filter__options">
+          <form method="get">
+            <%= submit_tag "Apply filters", class: "govuk-button" %>
+
+            <div class="govuk-form-group">
+              <%= label_tag "text_search", "Name or code", class: "govuk-label govuk-label--s" %>
+              <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/components/providers/filters/view.rb
+++ b/app/components/providers/filters/view.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Providers
+  module Filters
+    class View < GovukComponent::Base
+      attr_accessor :filters, :filter_actions
+
+      def initialize(filters:, filter_actions: nil)
+        @filters = filters
+        @filter_actions = filter_actions
+      end
+
+      def filter_label_for(filter)
+        I18n.t("components.filter.#{filter}")
+      end
+
+      def tags_for_filter(filter, value)
+        [{ title: title_html(filter, value), remove_link: remove_select_tag_link(filter) }]
+      end
+
+    private
+
+      def title_html(filter, value)
+        tag.span("Remove ", class: "govuk-visually-hidden") + value + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
+      end
+
+      def remove_select_tag_link(filter)
+        new_filters = filters.reject { |f| f == filter }
+        new_filters.to_query.blank? ? nil : "?" + new_filters.to_query
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::Base
   before_action :authenticate
 
   include Pundit
-  include Pagy::Backend
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -1,12 +1,30 @@
 module Support
   class ProvidersController < ApplicationController
     def index
-      @providers = RecruitmentCycle.current.providers.order(:provider_name).includes(:courses, :users).page(params[:page] || 1)
+      @providers = filtered_providers.page(params[:page] || 1)
     end
 
     def show
       @provider = Provider.find(params[:id])
       render layout: "provider_record"
+    end
+
+  private
+
+    def filtered_providers
+      Support::Providers::Filter.call(providers: find_providers, filters: filters)
+    end
+
+    def find_providers
+      RecruitmentCycle.current.providers.order(:provider_name).includes(:courses, :users)
+    end
+
+    def filters
+      @filters ||= ProviderFilter.new(params: filter_params).filters
+    end
+
+    def filter_params
+      params.permit(:text_search, :page, :commit)
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,4 @@
 module ApplicationHelper
-  include Pagy::Frontend
-
   def header_items(current_user)
     return unless current_user
 

--- a/app/models/provider_filter.rb
+++ b/app/models/provider_filter.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ProviderFilter
+  def initialize(params:)
+    @params = params
+  end
+
+  def filters
+    return if params.empty? && merged_filters.empty?
+
+    merged_filters
+  end
+
+private
+
+  attr_reader :params
+
+  def merged_filters
+    @merged_filters ||= text_search.with_indifferent_access
+  end
+
+  def text_search
+    return {} if params[:text_search].blank?
+
+    { "text_search" => params[:text_search] }
+  end
+end

--- a/app/services/support/providers/filter.rb
+++ b/app/services/support/providers/filter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Support
+  module Providers
+    class Filter
+      include ServicePattern
+
+      def initialize(providers:, filters:)
+        @providers = providers
+        @filters = filters
+      end
+
+      def call
+        return providers unless filters
+
+        filter_trainees
+      end
+
+    private
+
+      attr_reader :providers, :filters
+
+      def text_search(providers, text_search)
+        return providers if text_search.blank?
+
+        providers.search_by_code_or_name(text_search)
+      end
+
+      def filter_trainees
+        text_search(providers, filters[:text_search])
+      end
+    end
+  end
+end

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -6,31 +6,31 @@
   { name: "Providers", url: support_providers_path },
 ]) %>
 
-<table class="govuk-table">
-  <thead class="govuk-table__head">
-    <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
-    </tr>
-  </thead>
-
-  <tbody class="govuk-table__body">
-    <% @providers.each do |provider| %>
-      <tr class="govuk-table__row qa-provider_row">
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
-          </span>
-        </td>
-
-        <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= provider.provider_code %>
-          </span>
-        </td>
+<%= render PaginatedFilter::View.new(filters: @filters, collection: @providers) do %>
+  <table class="govuk-table">
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
 
-<%= render Paginator::View.new(scope: @providers) %>
+    <tbody class="govuk-table__body">
+      <% @providers.each do |provider| %>
+        <tr class="govuk-table__row qa-provider_row">
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+            </span>
+          </td>
+
+          <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= provider.provider_code %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
       support:
         providers:
           index: Providers
+    filter:
+      text_search: Name or code
   course:
     update_email:
       name: "title"

--- a/spec/models/provider_filter_spec.rb
+++ b/spec/models/provider_filter_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ProviderFilter do
+  let(:permitted_params) { ActionController::Parameters.new(params).permit(:text_search) }
+
+  subject { ProviderFilter.new(params: permitted_params) }
+
+  describe "#filters" do
+    context "with fully valid parameters" do
+      let(:params) do
+        {
+          text_search: "search terms",
+        }
+      end
+
+      it "returns the correct filter hash" do
+        expect(subject.filters).to eq(permitted_params.to_h)
+      end
+    end
+
+    context "with empty params" do
+      let(:params) { {} }
+
+      it "returns nil" do
+        expect(subject.filters).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
https://trello.com/c/8urvajGN/1314-m-provider-lookup

### Changes proposed in this pull request
- Add provider filter section allowing text search using name or code

### Guidance to review
- Visit `/support/providers`
- Input a name or code
- Results should match input

### Example
<img width="974" alt="Screenshot 2021-04-06 at 15 50 54" src="https://user-images.githubusercontent.com/28728/113730543-e481e400-96ef-11eb-8eb5-ddfc23b23094.png">

### Checklist
- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
