### PR TITLE
Stop Rails logging to file

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,6 +34,7 @@ Rails.application.configure do
   # Logging
   config.log_tags = [:request_id] # Prepend all log lines with the following tags.
   config.log_level = Settings.log_level
+  config.rails_semantic_logger.add_file_appender = false
 
   config.active_record.logger = nil # Don't log SQL in production
 


### PR DESCRIPTION
### Context

Rails is logging requests to /log/{env}.log
This is leading to an increased disk utilisation

### Changes proposed in this pull request

Remove logs from being written to disk.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
