### PR TITLE
[1320] Add courses view to providers sub menu

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -1,0 +1,14 @@
+module Support
+  class CoursesController < ApplicationController
+    def index
+      @courses = provider.courses.order(:name).page(params[:page] || 1)
+      render layout: "provider_record"
+    end
+
+  private
+
+    def provider
+      @provider ||= RecruitmentCycle.current.providers.find(params[:provider_id])
+    end
+  end
+end

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -4,6 +4,7 @@
   <%= render TabNavigation::View.new(items: [
     { name: "Details", url: support_provider_path(@provider) },
     { name: "Users", url: support_provider_users_path(@provider) },
+    { name: "Courses", url: support_provider_courses_path(@provider) },
   ]) %>
 
   <%= yield %>

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -1,0 +1,25 @@
+<%= render PageTitle::View.new(title: "support.providers.courses.index") %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course code</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @courses.each do |course| %>
+      <tr class="govuk-table__row course-row">
+        <td class="govuk-table__cell">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %></span>
+        </td>
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.course_code %></span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render Paginator::View.new(scope: @courses) %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   end
 
   config.active_job.queue_adapter = :test
-  
+
   # Logging
   config.log_level = :error
 end

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,4 @@
 Rails.application.config.semantic_logger.application = Settings.application_name
 Rails.application.config.rails_semantic_logger.format = :json
 SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
-Rails.application.config.logger.info('Application logging to STDOUT')
+Rails.application.config.logger.info("Application logging to STDOUT")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,8 @@ en:
       support:
         providers:
           index: Providers
+          courses:
+            index: Courses
     filter:
       text_search: Name or code
   course:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
 
     resources :providers, only: %i[index show] do
       resources :users, only: %i[index]
+      resources :courses, only: %i[index]
     end
   end
 

--- a/spec/features/support/providers/provider_courses_list_spec.rb
+++ b/spec/features/support/providers/provider_courses_list_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View provider courses" do
+  let(:user) { create(:user, :admin) }
+
+  scenario "i can view courses belonging to a provider" do
+    given_i_am_authenticated(user: user)
+    and_there_is_a_provider_with_courses
+    when_i_visit_the_provider_show_page
+    and_click_on_the_courses_tab
+    then_i_should_see_a_table_of_courses
+  end
+
+  def and_there_is_a_provider_with_courses
+    @provider = create(:provider)
+    @provider.courses << create(:course)
+  end
+
+  def when_i_visit_the_provider_show_page
+    provider_show_page.load(id: @provider.id)
+  end
+
+  def and_click_on_the_courses_tab
+    provider_show_page.courses_tab.click
+  end
+
+  def then_i_should_see_a_table_of_courses
+    expect(provider_courses_index_page.courses.size).to eq(1)
+  end
+end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -14,6 +14,10 @@ module FeatureHelpers
       @provider_users_index_page ||= PageObjects::Support::ProviderUsersIndex.new
     end
 
+    def provider_courses_index_page
+      @provider_courses_index_page ||= PageObjects::Support::ProviderCoursesIndex.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/page_objects/support/provider_courses_index_page.rb
+++ b/spec/support/page_objects/support/provider_courses_index_page.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class ProviderCoursesIndex < PageObjects::Base
+      set_url "/support/providers/{provider_id}/courses"
+
+      def courses
+        page.find_all(".course-row")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider_show.rb
+++ b/spec/support/page_objects/support/provider_show.rb
@@ -6,6 +6,7 @@ module PageObjects
       set_url "/support/providers/{id}"
 
       element :users_tab, ".app-tab-navigation__link", text: "Users"
+      element :courses_tab, ".app-tab-navigation__link", text: "Courses"
     end
   end
 end

--- a/spec/support/page_objects/support/provider_users_index_page.rb
+++ b/spec/support/page_objects/support/provider_users_index_page.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class ProviderUsersIndex < PageObjects::Base
-      set_url "support/providers/{provider_id}/users"
+      set_url "/support/providers/{provider_id}/users"
 
       def users
         page.find_all(".user-row")


### PR DESCRIPTION
### Context

- https://trello.com/c/0Yz9ZE0n/1320-s-add-course-list-to-provider-pages-on-api-ui

### Changes proposed in this pull request

- Add the provider's courses under a courses view

<img width="1163" alt="Screenshot 2021-04-07 at 16 21 59" src="https://user-images.githubusercontent.com/616080/113892026-8a4f5480-97bd-11eb-92d2-408d6ec079bb.png">

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
