### PR TITLE
[1427] Show a list of the providers a user has access to

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -5,7 +5,17 @@ module Support
     end
 
     def show
-      @user = User.find(params[:id])
+      @providers = providers.order(:provider_name).page(params[:page] || 1)
+    end
+
+  private
+
+    def user
+      @user ||= User.find(params[:id])
+    end
+
+    def providers
+      RecruitmentCycle.current.providers.where(id: user.providers)
     end
   end
 end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module UserHelper
+  def full_name(user)
+    [user.first_name, user.last_name].join(" ")
+  end
+end

--- a/app/views/support/providers/_list.html.erb
+++ b/app/views/support/providers/_list.html.erb
@@ -1,0 +1,26 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @providers.each do |provider| %>
+      <tr class="govuk-table__row qa-provider_row">
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.provider_code %>
+          </span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -5,30 +5,5 @@
 <%= render "support/menu" %>
 
 <%= render PaginatedFilter::View.new(filters: @filters, collection: @providers) do %>
-  <table class="govuk-table">
-    <thead class="govuk-table__head">
-      <tr class="govuk-table__row">
-        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
-        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
-      </tr>
-    </thead>
-
-    <tbody class="govuk-table__body">
-      <% @providers.each do |provider| %>
-        <tr class="govuk-table__row qa-provider_row">
-          <td class="govuk-table__cell">
-            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
-            </span>
-          </td>
-
-          <td class="govuk-table__cell">
-            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-              <%= provider.provider_code %>
-            </span>
-          </td>
-        </tr>
-      <% end %>
-    </tbody>
-  </table>
+  <%= render "list", providers: @providers %>
 <% end %>

--- a/app/views/support/users/_users.html.erb
+++ b/app/views/support/users/_users.html.erb
@@ -17,7 +17,9 @@
           <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= user.last_name %></span>
         </td>
         <td class="govuk-table__cell">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= user.email %></span>
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= govuk_link_to user.email, support_user_path(user) %>
+          </span>
         </td>
       </tr>
     <% end %>

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -1,0 +1,9 @@
+<%= render PageTitle::View.new(title: "support.users.show") %>
+
+<h1 class="govuk-heading-l">
+  <%= full_name(@user) %>
+</h1>
+
+<%= render "support/providers/list", providers: @providers %>
+
+<%= render Paginator::View.new(scope: @providers) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,6 +17,7 @@ en:
             index: Courses
         users:
           index: Users
+          show: User overview
         data_exports:
           index: Data exports
     filter:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,7 +22,7 @@ Rails.application.routes.draw do
       get :users, on: :member
       resources :courses, only: %i[index]
     end
-    resources :users, only: %i[index]
+    resources :users, only: %i[index show]
 
     resources :data_exports, path: "data-exports", only: [:index] do
       member do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -29,7 +29,6 @@ FactoryBot.define do
     train_with_disability { Faker::Lorem.sentence.to_s }
     accrediting_provider_enrichments { nil }
 
-
     trait :university do
       provider_type { :university }
       accrediting_provider { "Y" }

--- a/spec/features/support/providers/viewing_a_user_spec.rb
+++ b/spec/features/support/providers/viewing_a_user_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing a user" do
+  let(:admin) { create(:user, :admin) }
+  let(:user) { create(:user, :with_provider) }
+
+  before do
+    given_i_am_authenticated(user: admin)
+    when_i_visit_the_provider_show_page
+    and_click_on_the_users_tab
+    and_i_click_on_the_user
+  end
+
+  scenario "i can view providers that belong to a user" do
+    then_i_should_see_a_table_of_providers
+  end
+
+  def when_i_visit_the_provider_show_page
+    provider_show_page.load(id: user.providers.first.id)
+  end
+
+  def and_click_on_the_users_tab
+    provider_show_page.users_tab.click
+  end
+
+  def and_i_click_on_the_user
+    provider_users_index_page.users.first.email.click
+  end
+
+  def then_i_should_see_a_table_of_providers
+    expect(users_show_page.provider_rows.size).to eq(1)
+  end
+end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -22,6 +22,10 @@ module FeatureHelpers
       @provider_courses_index_page ||= PageObjects::Support::ProviderCoursesIndex.new
     end
 
+    def users_show_page
+      @users_show_page ||= PageObjects::Support::UserShow.new
+    end
+
     def users_index_page
       @users_index_page ||= PageObjects::Support::UsersIndex.new
     end

--- a/spec/support/page_objects/sections/provider.rb
+++ b/spec/support/page_objects/sections/provider.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class Provider < PageObjects::Sections::Base; end
+  end
+end

--- a/spec/support/page_objects/sections/user.rb
+++ b/spec/support/page_objects/sections/user.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class User < PageObjects::Sections::Base
+      element :email, ".govuk-link"
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider_users_index_page.rb
+++ b/spec/support/page_objects/support/provider_users_index_page.rb
@@ -5,9 +5,7 @@ module PageObjects
     class ProviderUsersIndex < PageObjects::Base
       set_url "/support/providers/{provider_id}/users"
 
-      def users
-        page.find_all(".user-row")
-      end
+      sections :users, PageObjects::Sections::User, ".user-row"
     end
   end
 end

--- a/spec/support/page_objects/support/user_show_page.rb
+++ b/spec/support/page_objects/support/user_show_page.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class UserShow < PageObjects::Base
+      set_url "/support/users/{id}"
+
+      sections :provider_rows, PageObjects::Sections::Provider, ".qa-provider_row"
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/HtLxI0c5/1427-s-display-a-list-of-providers-that-a-user-has-access-to

### Changes proposed in this pull request

- Adds links to the users table on `support/providers/:id/users`, which redirect to:
- A new user show page on `support/users/:id`, which shows:
- A paginated list of the providers that user has access to in the current recruitment cycle, which looks something like:

<img width="1552" alt="Screenshot 2021-04-14 at 15 15 56" src="https://user-images.githubusercontent.com/18436946/114726389-44ead400-9d35-11eb-9c36-bf1ff9985573.png">

(page limit for pagination set artificially to four for the example screenshot, in reality it is 25 like elsewhere)

### Guidance to review

- Head to `support/providers/:id/users` for a provider
- Click on a user
- See that that user's providers are listed

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
