### PR TITLE
[1324] Handle view component method deprecation warning

### DIFF
--- a/app/components/paginated_filter/view.rb
+++ b/app/components/paginated_filter/view.rb
@@ -4,7 +4,7 @@ module PaginatedFilter
   class View < ViewComponent::Base
     attr_reader :filters, :collection
 
-    with_content_areas :filter_actions
+    renders_one :filter_actions
 
     def initialize(filters:, collection:)
       @filters = filters


### PR DESCRIPTION
### Context

- https://trello.com/c/yF9UWNHC/1324-s-fix-deprecation-warnings-re-errors-in-rails-62

`ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2.`:

These warnings are caused by a method in the jsonapi-rails gem calling `.keys` on a given errors object:

https://github.com/jsonapi-rb/jsonapi-rails/blob/6d49925aedb08c34d9891916fd5936e6697ba9d6/lib/jsonapi/rails/serializable_active_model_errors.rb#L28

You can confirm this by opening that class up locally, adding a breakpoint before that line and triggering the method manually. You'll see the deprecation warning raised in your console.

The change for those deprecations needs to be made there. I was going to create a patch to the gem but it looks like a couple already exist:

https://github.com/jsonapi-rb/jsonapi-rails/pull/130
https://github.com/jsonapi-rb/jsonapi-rails/pull/126

### Changes proposed in this pull request

- `with_content_areas` will be deprecated. [Slots](https://viewcomponent.org/guide/slots.html) are recommended now

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
