### PR TITLE
[1317] Rollback of uniqueness of the provider name

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -106,7 +106,7 @@ class Provider < ApplicationRecord
 
   validates :email, email: true, if: :email_changed?
 
-  validates :provider_name, uniqueness: true, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
+  validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 


### PR DESCRIPTION
### Context

Hot fix to ensure that providers can make changes and a rollback from [this](https://trello.com/c/cwKSUfTf/1317-s-add-edit-provider-name-feature-to-providers-pages) ticket

### Changes proposed in this pull request

Removed the uniqueness validation for the Provider name

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
