### PR TITLE
Reduce events sent to Sentry.

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -11,5 +11,19 @@ Sentry.init do |config|
   config.release = ENV["COMMIT_SHA"]
 
   # https://docs.sentry.io/platforms/ruby/configuration/sampling/#configuring-the-transaction-sample-rate
-  config.traces_sample_rate = 0.5
+  config.traces_sampler = lambda do |sampling_context|
+    transaction = sampling_context[:transaction_context]
+
+    if transaction[:name].start_with? "/ping"
+      # Ping event isn't worth tracking.
+      false
+    elsif transaction[:name].match? %r{/api/public/v1/recruitment_cycles/\d+/providers/\w+/courses/\w+/locations}
+      # 85% of our traffic appears to be to the locations controller (about
+      # 30tpm!). Probably worth investigating in it's own right, but for now
+      # we need to throttle these down.
+      0.01
+    else
+      0.5
+    end
+  end
 end


### PR DESCRIPTION
- Set sampling rate for API V1 course locations endpoint to 0.01
- Don't send any /ping transactions
- Default sampling rate to 0.5

### Context

Performance tracking was recently switched to Sentry because the Skylight gem was causing errors and disk over-usage. However Sentry has transaction quotas that we're going to start bumping against.

### Changes proposed in this pull request

Send fewer course location lookup transactions to Sentry, they're taking up 85% of our quota. Also don't bother sending ping transactions.

### Guidance to review

Tested locally by setting the `SENTRY_DSN` env var and watching what shows up in Sentry.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
