### PR TITLE
Reduce sentry logging rate even moar.

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -21,9 +21,12 @@ Sentry.init do |config|
       # 85% of our traffic appears to be to the locations controller (about
       # 30tpm!). Probably worth investigating in it's own right, but for now
       # we need to throttle these down.
-      0.01
+      #
+      # At 85% of 400k/day this gives us ~340/day or ~20,000/month.
+      0.002
     else
-      0.5
+      # At 15% of 400k/day this gives us ~1200/day or ~36,000/month.
+      0.02
     end
   end
 end


### PR DESCRIPTION
Previous attempt would still put us way over our 100k/mo transaction
limit, now we have:

- API v1 course locations endpoints, which accounts for 85% of our ~400/day requests, gives us ~20k/month transactions.
- All other endpoints, which account for 15% of our ~400/day requests, gives us ~36k/month transactions

### Context

See #1868.

### Changes proposed in this pull request

Reduce logging rate even further, using actual m47h5!!! this time.

### Guidance to review

Probably just worth checking that the numbers actually make sense this time.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
