### PR TITLE
[1578] switch back to skylight

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -111,6 +111,9 @@ gem "open_api-rswag-ui"
 
 gem "pg_search"
 
+# End-user application performance monitoring
+gem "skylight"
+
 # govuk styling
 gem "govuk-components"
 gem "govuk_design_system_formbuilder"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,6 +508,8 @@ GEM
       capybara (~> 3.8)
       site_prism-all_there (>= 0.3.1, < 1.0)
     site_prism-all_there (0.3.2)
+    skylight (5.0.1)
+      activesupport (>= 5.2.0)
     spring (2.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -648,6 +650,7 @@ DEPENDENCIES
   sidekiq-cron
   simplecov (< 0.22)
   site_prism (~> 3.7)
+  skylight
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![Build](https://github.com/DFE-Digital/teacher-training-api/workflows/Build/badge.svg?branch=master&event=push)
 [![Maintainability](https://api.codeclimate.com/v1/badges/b97c086ada58c27c967c/maintainability)](https://codeclimate.com/github/DFE-Digital/teacher-training-api/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/b97c086ada58c27c967c/test_coverage)](https://codeclimate.com/github/DFE-Digital/teacher-training-api/test_coverage)
+[![View performance data on Skylight](https://badges.skylight.io/status/NXAwzyZjkp2m.svg?token=JaYZey50Y8gfC00RvzkcrDz5OP-SwiBSTtbhkMw1KIs)](https://www.skylight.io/app/applications/NXAwzyZjkp2m)
 
 # Teacher Training API
 
@@ -95,7 +96,7 @@ bundle exec guard --no-interactions
 
 GraphViz is required as a dependency of the [rails-erd](https://github.com/voormedia/rails-erd/) gem that is used to generate the entity relationship diagram during migrations.
 
-On OSX:
+On OSX: 
 
 ```bash
 brew install graphviz
@@ -249,7 +250,7 @@ can be useful for people who aren't as familiar with the app, or with certain
 complex operations that just aren't already packaged up in the app.
 
 In order to use the external environment functionality you must set the
-environments in ```config/azure_environments.yml ```like so:
+environments in ```config/azure_environments.yml ```like so:  
 ```
 qa:
   webapp: <webapp>

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,6 +50,8 @@ module ManageCoursesBackend
 
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
+    config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
+
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"
     config.view_component.show_previews = !Rails.env.production?

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -9,24 +9,4 @@ Sentry.init do |config|
   end
 
   config.release = ENV["COMMIT_SHA"]
-
-  # https://docs.sentry.io/platforms/ruby/configuration/sampling/#configuring-the-transaction-sample-rate
-  config.traces_sampler = lambda do |sampling_context|
-    transaction = sampling_context[:transaction_context]
-
-    if transaction[:name].start_with? "/ping"
-      # Ping event isn't worth tracking.
-      false
-    elsif transaction[:name].match? %r{/api/public/v1/recruitment_cycles/\d+/providers/\w+/courses/\w+/locations}
-      # 85% of our traffic appears to be to the locations controller (about
-      # 30tpm!). Probably worth investigating in it's own right, but for now
-      # we need to throttle these down.
-      #
-      # At 85% of 400k/day this gives us ~340/day or ~20,000/month.
-      0.002
-    else
-      # At 15% of 400k/day this gives us ~1200/day or ~36,000/month.
-      0.02
-    end
-  end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -50,5 +50,8 @@ application: teacher-training-api
 log_level: info
 magic_link:
   max_token_age: <%= 1.hour %>
+skylight:
+  enable: false
+  authentication: please_change_me
 mapit_api_key: please_change_me
 mapit_url: https://mapit.mysociety.org

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -17,5 +17,7 @@ bg_jobs:
     cron: "0 0 * * *" # daily at midnight
     class: "SaveStatisticJob"
     queue: save_statistic
+skylight:
+  enable: true
 environment:
   name: "beta"

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -11,5 +11,7 @@ bg_jobs:
     cron: "0 0 * * *" # daily at midnight
     class: "SaveStatisticJob"
     queue: save_statistic
+skylight:
+  enable: true
 environment:
   name: "qa"

--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,7 @@
+---
+# The authentication token for the application.
+authentication: <%= Settings.skylight.authentication %>
+ignored_endpoints:
+  - HeartbeatController#ping
+  - HeartbeatController#healthcheck
+  - HeartbeatController#sha

--- a/docs/alerting_and_monitoring.md
+++ b/docs/alerting_and_monitoring.md
@@ -2,19 +2,27 @@
 
 ## External Integrations
 
-### Sentry
+### Skylight
 
-[sentry.io](https://docs.sentry.io/platforms/ruby/) now includes performance monitoring tools, available
-on the apps [Performance tab](https://sentry.io/organizations/dfe-bat/performance/?project=1377944).
-Normally we enable performance monitoring only in production, by setting `traces_sample_rate` in the sentry initializer.
+skylight.io provides a rich set of performance monitoring tools, available form
+on the apps [dashboard page](https://www.skylight.io/app/applications/NXAwzyZjkp2m).
+Normally we enable skylight only in production.
 
 #### Configuring in deployed environments
 
 In a deployed environment, the environment variable
-`SENTRY_DSN` should be set to the value of the Sentry DSN, available under
-Settings -> Application Name -> Client Keys (DSN)
+`SETTINGS__SKYLIGHT__AUTHENTICATION` should be set to the auth token available
+from the application setting in skylight.io.
 
 #### Configuring for local development
 
 In local development, if you need to test performance monitoring you can enable
-Sentry by providing a `SENTRY_DSN` environment variable. In the Sentry dashboard, one can filter the performance metrics by environment (i.e: development).
+Skylight and set the auth token in a local settings file
+`config/settings.local.yml`, with the token itself availble on the
+[Skylight application setting page](https://www.skylight.io/app/settings/xRkb2HFQcwe7/app_settings)
+
+```yaml
+skylight:
+  authentication: "auth_token_goes_here"
+  enable: true
+```


### PR DESCRIPTION
### Context
Switch back to skylight monitoring, and turn off sentry monitoring

### Changes proposed in this pull request
- Add sentry back in.
- Turn off sentry performance monitoring

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
