### PR TITLE
[1544] Set relative url to system support

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < ApplicationController
     if current_user
       UserSessions::Update.call(user: current_user, user_session: user_session)
 
-      redirect_to support_path
+      redirect_to support_providers_path
     else
       UserSession.end_session!(session)
 
@@ -24,7 +24,7 @@ class SessionsController < ApplicationController
       UserSession.end_session!(session)
       redirect_to user_session.logout_url
     else
-      redirect_to support_path
+      redirect_to support_providers_path
     end
   end
 end

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -11,7 +11,7 @@ phase: Beta
 header_links:
   About: /
   Feedback: https://forms.gle/syqb5Fa9RSbo2WC1A
-  Support: /support.html
+  System Admin: /support/providers
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -4,7 +4,7 @@ host: api.publish-teacher-training-courses.service.gov.uk
 # Header-related options
 show_govuk_logo: true
 service_name: Teacher Training Courses
-service_link: https://www.find-postgraduate-teacher-training.service.gov.uk/
+service_link: https://api.publish-teacher-training-courses.service.gov.uk/
 phase: Beta
 
 # Links to show on right-hand-side of header

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -29,7 +29,7 @@ describe SessionsController, type: :controller do
       let(:user) { build(:user) }
       it "redirects to the root page" do
         request_destroy
-        expect(response).to redirect_to(support_path)
+        expect(response).to redirect_to(support_providers_path)
       end
     end
   end
@@ -62,7 +62,7 @@ describe SessionsController, type: :controller do
 
       it "redirects to the root page" do
         request_callback
-        expect(response).to redirect_to(support_path)
+        expect(response).to redirect_to(support_providers_path)
       end
     end
 


### PR DESCRIPTION
### Context

- https://trello.com/c/vfsBfD42/1544-m-logging-in-to-api-support

### Changes proposed in this pull request

Originally barked up the wrong tree around the thinking but this PR just sets a relative url to the support console. There's another ticket to handle returning to the correct url once you pass DFE sign in.

We have to explicitly set it to a route within `support` or else it will direct you to the `support.html` page in the docs

### Guidance to review

At this time of writing, this change is deployed to the qa branch for testing.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
