### PR TITLE
[1494] Add validation to UKPRN on provider table

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -110,6 +110,8 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
+  validates :ukprn, length: { is: 8, wrong_length: "^UKPRN must be 8 characters" }, allow_blank: true
+
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?
   validates :train_with_disability, presence: true, on: :update, if: :train_with_disability_changed?
 

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -129,6 +129,7 @@ describe "PATCH /providers/:provider_code" do
     include_examples "does not allow assignment", :updated_at,           Time.zone.now
     include_examples "does not allow assignment", :accrediting_provider, :accredited_body
     include_examples "does not allow assignment", :changed_at,           Time.zone.now
+    include_examples "does not allow assignment", :ukprn, "1234567"
 
     let!(:next_cycle) { find_or_create(:recruitment_cycle, :next) }
     include_examples "does not allow assignment", :recruitment_cycle_id


### PR DESCRIPTION
### Context

We are going to start collecting UKPRN numbers from providers. This PR sets out the validations. 

The front end work for this is in [this PR](https://github.com/DFE-Digital/publish-teacher-training/pull/1609).

### Changes proposed in this pull request

- Add validation to ensure the string is 8 characters
- Allow blank values
- Custom validation error message

### Guidance to review

- Pull down the code and ensure you have the latest migrations
- Boot up the rails console and navigate to a provider
- Ensure the UKPRN will only be saved if it is `nil` or `8 characters`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
