### PR TITLE
[1497] Validations added to urn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,8 +41,8 @@ gem "jsonapi-rb"
 gem "jsonb_accessor"
 
 # Sending exceptions to sentry
-gem "sentry-ruby"
 gem "sentry-rails"
+gem "sentry-ruby"
 gem "sentry-sidekiq"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -108,7 +108,7 @@ class Provider < ApplicationRecord
 
   validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
 
-  validates :urn, length: { in: 5..6 }, if: -> { provider_type == "lead_school" }
+  validates :urn, length: { in: 5..6 }, if: :lead_school?, allow_nil: true
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -108,6 +108,9 @@ class Provider < ApplicationRecord
 
   validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
 
+  validates :urn, length: { in: 5..6 }, unless: -> { urn.blank? }
+  validates :urn, presence: true, if: -> { provider_type == "lead_school" }
+
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -108,8 +108,7 @@ class Provider < ApplicationRecord
 
   validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
 
-  validates :urn, length: { in: 5..6 }, unless: -> { urn.blank? }
-  validates :urn, presence: true, if: -> { provider_type == "lead_school" }
+  validates :urn, length: { in: 5..6 }, if: -> { provider_type == "lead_school" }
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -30,7 +30,7 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
-        urn: Faker::Number.number(digits: 5).to_s,
+        urn: Faker::Number.number(digits: 5),
         accrediting_provider: @is_accredited_body ? "accredited_body" : "not_an_accredited_body",
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -30,7 +30,6 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
-        urn: Faker::Number.number(digits: 5),
         accrediting_provider: @is_accredited_body ? "accredited_body" : "not_an_accredited_body",
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -30,6 +30,7 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
+        urn: "12345",
         accrediting_provider: @is_accredited_body ? "accredited_body" : "not_an_accredited_body",
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -30,7 +30,7 @@ module Providers
         provider_name: @provider_name,
         provider_code: @provider_code,
         provider_type: @provider_type,
-        urn: "12345",
+        urn: Faker::Number.number(digits: 5).to_s,
         accrediting_provider: @is_accredited_body ? "accredited_body" : "not_an_accredited_body",
       }.merge(DEFAULT_PROVIDER_ATTRIBUTES))
 

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -21,7 +21,6 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     accrediting_provider { "N" }
-    urn { Faker::Number.number(digits: 5).to_s }
     region_code { "london" }
     organisations { [create(:organisation, :with_user)] }
     association :recruitment_cycle, strategy: :find_or_create
@@ -33,6 +32,10 @@ FactoryBot.define do
     trait :university do
       provider_type { :university }
       accrediting_provider { "Y" }
+    end
+
+    trait :urn do
+      urn { Faker::Number.number(digits: [5, 6].sample) }
     end
 
     trait :scitt do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -20,6 +20,7 @@ FactoryBot.define do
     telephone { Faker::PhoneNumber.phone_number }
     website { Faker::Internet.url }
     provider_type { :lead_school }
+    urn { Faker::Number.number(digits: [5, 6].sample) }
     accrediting_provider { "N" }
     region_code { "london" }
     organisations { [create(:organisation, :with_user)] }
@@ -32,20 +33,19 @@ FactoryBot.define do
     trait :university do
       provider_type { :university }
       accrediting_provider { "Y" }
-    end
-
-    trait :urn do
-      urn { Faker::Number.number(digits: [5, 6].sample) }
+      urn { nil }
     end
 
     trait :scitt do
       provider_type { :scitt }
       accrediting_provider { "Y" }
+      urn { nil }
     end
 
     trait :accredited_body do
       provider_type { %i[university scitt].sample }
       accrediting_provider { "Y" }
+      urn { nil }
     end
 
     transient do

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -21,6 +21,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     accrediting_provider { "N" }
+    urn { "12345" }
     region_code { "london" }
     organisations { [create(:organisation, :with_user)] }
     association :recruitment_cycle, strategy: :find_or_create

--- a/spec/factories/providers.rb
+++ b/spec/factories/providers.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     website { Faker::Internet.url }
     provider_type { :lead_school }
     accrediting_provider { "N" }
-    urn { "12345" }
+    urn { Faker::Number.number(digits: 5).to_s }
     region_code { "london" }
     organisations { [create(:organisation, :with_user)] }
     association :recruitment_cycle, strategy: :find_or_create

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -30,8 +30,8 @@ describe Provider, type: :model do
 
   describe "urn validations" do
     context "when provider_type is lead_schools" do
-      let(:invalid_provider) { build(:provider, provider_type: "Y", urn: "1") }
-      let(:valid) { build(:provider, provider_type: "Y", urn: "12345") }
+      let(:invalid_provider) { build(:provider, urn: "1") }
+      let(:valid) { build(:provider, urn: "12345") }
 
       it "validates a urn of length 5 - 6" do
         expect(invalid_provider).to_not be_valid

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -28,6 +28,28 @@ describe Provider, type: :model do
     it { should have_many(:user_notifications) }
   end
 
+  describe "urn validations" do
+    context "when provider_type is not lead_school" do
+      let(:provider) { build(:provider, provider_type: "B") }
+      let(:provider_with_no_urn) { build(:provider, provider_type: "B", urn: nil) }
+
+      it "does not validate presence of urn" do
+        expect(provider_with_no_urn).to be_valid
+        expect(provider).to be_valid
+      end
+    end
+
+    context "when provider_type is lead_schools" do
+      let(:invalid_provider) { build(:provider, provider_type: "Y", urn: nil) }
+      let(:valid) { build(:provider, provider_type: "Y", urn: "12345") }
+
+      it "validates a urn of length 5 - 6" do
+        expect(invalid_provider).to_not be_valid
+        expect(provider).to be_valid
+      end
+    end
+  end
+
   describe "organisation" do
     it "returns the only organisation a provider has" do
       expect(subject.organisation).to eq subject.organisations.first

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -29,18 +29,8 @@ describe Provider, type: :model do
   end
 
   describe "urn validations" do
-    context "when provider_type is not lead_school" do
-      let(:provider) { build(:provider, provider_type: "B") }
-      let(:provider_with_no_urn) { build(:provider, provider_type: "B", urn: nil) }
-
-      it "does not validate presence of urn" do
-        expect(provider_with_no_urn).to be_valid
-        expect(provider).to be_valid
-      end
-    end
-
     context "when provider_type is lead_schools" do
-      let(:invalid_provider) { build(:provider, provider_type: "Y", urn: nil) }
+      let(:invalid_provider) { build(:provider, provider_type: "Y", urn: "1") }
       let(:valid) { build(:provider, provider_type: "Y", urn: "12345") }
 
       it "validates a urn of length 5 - 6" do


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/ymwbAv9m/1497-s-add-validation-to-urn-only-applicable-to-lead-school-providers)

### Changes proposed in this pull request

- Added validation for presence of urn in lead schools, and a length range of between 5 and 6 characters for the urn if it is present

### Guidance to review

- Open your rails console `rails c`
- Create an invalid provider like so (a lead school provider without a URN, that is) 
- `Provider.create!(provider_type: "Y", recruitment_cycle: RecruitmentCycle.first)`
- You should see an error
- You can validate it by adding a urn, which will need to be 5-6 characters long. 
- No URN needed if the provider_type is anything but lead school

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
