### PR TITLE
[1581] Remove error message and if conditional

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -106,7 +106,7 @@ class Provider < ApplicationRecord
 
   validates :email, email: true, if: :email_changed?
 
-  validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
+  validates :provider_name, length: { maximum: 100 }, on: :update
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -142,8 +142,7 @@ en:
               blank: "^Enter a course length"
         provider:
           attributes:
-            provider_name:
-              taken: "You must enter a unique provider name"
+            provider_name:     
               too_long: "Your provider name is too long, it must be fewer than 100 characters"
             email:
               blank: "^Enter email address"


### PR DESCRIPTION
### Context
https://trello.com/c/gT1UaJom/1581-remove-uniqueness-validation-error-message-and-conditional
Finishing production bug fix
### Changes proposed in this pull request
* Remove unique validation error message as no longer being used
* Remove if conditional as was always evaluating to true. As providers won't be editing their names from previous cycles then in practice it will always be the current recruitment cycle

### Guidance to review
Visit `/support/providers` and click on a provider
Edit provider name and verify max length validation and then edit name to see if it persists to database
### Checklist

- [X] Make sure all information from the Trello card is in here
- [X] Attach to Trello card
- [X] Rebased master
- [X] Cleaned commit history
- [X] Tested by running locally
