### PR TITLE
[1503] Add validation to URN on Site table

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,6 +25,8 @@ class Site < ApplicationRecord
                    inclusion: { in: POSSIBLE_CODES, message: "must be A-Z, 0-9 or -" },
                    presence: true
 
+  validates :urn, length: { in: 5..6, message: "^URN must be 5 or 6 characters" }, allow_blank: true
+
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil) }

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -10,6 +10,7 @@ describe Site, type: :model do
   end
 
   it { is_expected.to validate_presence_of(:location_name) }
+  it { is_expected.to validate_length_of(:urn).is_at_least(5).is_at_most(6).with_message("^URN must be 5 or 6 characters") }
   it { is_expected.to validate_presence_of(:address1) }
   it { is_expected.to validate_presence_of(:postcode) }
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }


### PR DESCRIPTION
### Context

We are starting to collect URN numbers from all sites. This PR sets out the validations.

The front end is a separate card.

### Changes proposed in this pull request

- Add validation to ensure the string is 5-6 characters
- Allow blank values
- Custom validation error message

### Guidance to review

- Pull down the code and ensure you have the latest migrations
- Boot up the rails console and navigate to a `Site`
- Ensure the URN will only be saved if it is nil, 5 or 6 characters

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
