### PR TITLE
[1579] Remove course subquery from CourseSearchService

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -150,10 +150,6 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_name_descending).order("name desc, course_code desc")
   end
 
-  scope :accredited_body_order, ->(provider_name) do
-    joins(:provider).merge(Provider.by_provider_name(provider_name))
-  end
-
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
       changed_at_since(timestamp)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -82,14 +82,6 @@ class Provider < ApplicationRecord
   scope :by_name_ascending, -> { order(provider_name: :asc) }
   scope :by_name_descending, -> { order(provider_name: :desc) }
 
-  scope :by_provider_name, ->(provider_name) do
-    order(
-      Arel.sql(
-        "CASE WHEN provider.provider_name = #{connection.quote(provider_name)} THEN '1' END",
-      ),
-    )
-  end
-
   scope :with_findable_courses, -> do
     where(id: Course.findable.select(:provider_id))
       .or(self.where(provider_code: Course.findable.select(:accredited_body_code)))

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -20,8 +20,6 @@ class CourseSearchService
     scope = scope.with_vacancies if has_vacancies?
     scope = scope.findable if findable?
     scope = scope.with_study_modes(study_types) if study_types.any?
-
-
     scope = scope.with_subjects(subject_codes) if subject_codes.any?
     scope = scope.with_provider_name(provider_name) if provider_name.present?
     scope = scope.with_send if send_courses_filter?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -212,23 +212,6 @@ describe Course, type: :model do
       end
     end
 
-    describe "accredited_body_order" do
-      let(:provider) { create(:provider) }
-      let(:delivered_course) { create(:course, provider: provider) }
-      let(:accredited_course) { create(:course, accrediting_provider: provider) }
-
-      before do
-        accredited_course
-        delivered_course
-      end
-
-      let(:subject) { described_class.accredited_body_order(provider.provider_name) }
-
-      it "returns courses accredited after courses delivered" do
-        expect(subject).to eq([delivered_course, accredited_course])
-      end
-    end
-
     context "by name" do
       let(:course_a) do
         create(:course, name: "Course A")

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -98,14 +98,6 @@ describe Provider, type: :model do
         expect(Provider.by_name_descending).to eq([provider_b, provider_a])
       end
     end
-
-    describe "#by_provider_name" do
-      it "orders the providers by name in descending order" do
-        provider_a
-        provider_b
-        expect(Provider.by_provider_name(provider_b.provider_name)).to eq([provider_b, provider_a])
-      end
-    end
   end
 
   describe "#changed_since" do

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -534,7 +534,7 @@ describe "GET v3/courses" do
         another_provider_course
       end
 
-      it "its courses are returned first" do
+      it "returns own courses first" do
         get request_path
 
         json_response = JSON.parse(response.body)

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -1,639 +1,183 @@
 require "rails_helper"
 
 RSpec.describe CourseSearchService do
-  describe ".call" do
-    let(:course_with_includes) { class_double(Course) }
-    let(:scope) { class_double(Course) }
-    let(:select_scope) { class_double(Course) }
-    let(:distinct_scope) { class_double(Course) }
-    let(:course_ids_scope) { class_double(Course) }
-    let(:order_scope) { class_double(Course) }
-    let(:joins_provider_scope) { class_double(Course) }
-    let(:filter) { nil }
-    let(:sort) { nil }
-    let(:expected_scope) { double }
+  subject { described_class.call(filter: filter, sort: sort) }
 
-    let(:includes_arguments) {
-      [:enrichments,
-       subjects: [:financial_incentive],
-       site_statuses: [:site],
-       provider: %i[recruitment_cycle ucas_preferences]]
-    }
+  let(:filter) { nil }
+  let(:sort) { nil }
+  let!(:generic_course) { create(:course, :non_salary_type_based) }
 
-    describe "when no scope is passed" do
-      subject { described_class.call(filter: filter) }
-      let(:filter) { {} }
+  it { is_expected.to eq([generic_course]) }
 
-      it "defaults to Course" do
-        expect(Course).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-        expect(subject).to eq(distinct_scope)
+  context "with filter funding set to salary" do
+    let(:filter) { { funding: "salary" } }
+    let!(:salaried_course) { create(:course, :salary_type_based) }
+
+    it { is_expected.to eq([salaried_course]) }
+  end
+
+  context "with filter qualification" do
+    let(:filter) { { qualification: "qts" } }
+    let!(:qts_course) { create(:course, :resulting_in_qts) }
+    let!(:pgde_course) { create(:course, :resulting_in_pgde) }
+
+    it { is_expected.to eq([qts_course]) }
+
+    context "with multiple qualification" do
+      let(:filter) { { qualification: "qts,pgde" } }
+
+      it { is_expected.to eq([qts_course, pgde_course]) }
+    end
+  end
+
+  context "with filter vacancies" do
+    let(:filter) { { has_vacancies: "true" } }
+    let!(:course_with_vacancies) do
+      create(:course) do |course|
+        create(:site_status, :findable, :full_time_vacancies, course: course)
       end
     end
 
-    subject do
-      described_class.call(filter: filter, sort: sort, course_scope: scope)
+    it { is_expected.to eq([course_with_vacancies]) }
+  end
+
+
+  context "with filter study_type" do
+    let(:filter) { { study_type: "full_time" } }
+    let!(:full_time_course) { generic_course }
+    let!(:part_time_course) { create(:course, study_mode: :part_time) }
+
+    it { is_expected.to eq([full_time_course]) }
+
+    context "with multiple study_types" do
+      let(:filter) { { study_type: "part_time,full_time" } }
+
+      it { is_expected.to eq([full_time_course, part_time_course]) }
     end
+  end
 
-    describe "sort by" do
-      context "ascending provider name and course name" do
-        let(:sort) { "name,provider.provider_name" }
+  context "with filter subjects" do
+    let(:filter) { { subjects: "01" } }
+    let(:primary_with_mathematics) { create(:primary_subject, :primary_with_mathematics) }
+    let(:primary_with_english) { create(:primary_subject, :primary_with_english) }
+    let!(:english_course) { create(:course, subjects: [primary_with_english]) }
+    let!(:mathematics_course) { create(:course, subjects: [primary_with_mathematics]) }
 
-        it "orders in ascending order" do
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:ascending_canonical_order).and_return(select_scope)
-          expect(select_scope).to receive(:select).and_return(expected_scope)
-          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
+    it { is_expected.to eq([english_course]) }
 
-      context "descending provider name and course name" do
-        let(:sort) { "-provider.provider_name,-name" }
+    context "with multiple study_types" do
+      let(:filter) { { subjects: "01,03" } }
 
-        it "orders in descending order" do
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:descending_canonical_order).and_return(select_scope)
-          expect(select_scope).to receive(:select).and_return(expected_scope)
-          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
+      it { is_expected.to eq([english_course, mathematics_course]) }
+    end
+  end
 
-      context "by distance" do
-        let(:sort) { "distance" }
+  context "with filter provider_name" do
+    let(:filter) { { "provider.provider_name": "University of Cumbria" } }
+    let(:cumbria_provider) { create(:provider, provider_name: "University of Cumbria") }
+    let!(:cumbria_course) { create(:course, provider: cumbria_provider) }
 
-        describe "expand university" do
-          context "when false" do
-            let(:filter) do
-              { latitude: 54.9713392, longitude: -1.6112336, expand_university: "false" }
-            end
+    it { is_expected.to eq([cumbria_course]) }
 
-            it "orders in descending order by distance" do
-              expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-              expect(course_with_includes).to receive(:joins).and_return(joins_provider_scope)
-              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
-                (CASE
-                  WHEN provider.provider_type = 'O'
-                    THEN (distance - 10)
-                  ELSE distance
-                END) as boosted_distance
-              EOSQL
-              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
+    context "when provider name matches multiple results" do
+      let!(:accredited_course) { create(:course, accrediting_provider: cumbria_provider) }
 
-              expect(select_scope).to receive(:select).with(select_criteria)
-                .and_return(order_scope)
-              expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
-              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-              expect(subject).to eq(distinct_scope)
-            end
-          end
+      it { is_expected.to eq([cumbria_course, accredited_course]) }
+    end
+  end
 
-          context "when absent" do
-            let(:filter) do
-              { latitude: 54.9713392, longitude: -1.6112336 }
-            end
+  context "with filter send_courses" do
+    let(:filter) { { send_courses: "true" } }
+    let!(:send_course) { create(:course, is_send: true) }
 
-            it "orders in descending order by distance" do
-              expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-              expect(course_with_includes).to receive(:joins).and_return(joins_provider_scope)
-              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
-                (CASE
-                  WHEN provider.provider_type = 'O'
-                    THEN (distance - 10)
-                  ELSE distance
-                END) as boosted_distance
-              EOSQL
-              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
+    it { is_expected.to eq([send_course]) }
+  end
 
-              expect(select_scope).to receive(:select).with(select_criteria)
-                .and_return(order_scope)
-              expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
-              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-              expect(subject).to eq(distinct_scope)
-            end
-          end
+  context "with location filter" do
+    let(:filter) { { latitude: 54.9713392, longitude: -1, radius: 30 } }
 
-          context "when true" do
-            let(:filter) do
-              { latitude: 54.9713392, longitude: -1.6112336, expand_university: "true" }
-            end
-
-            it "orders in descending order by boosted distance" do
-              expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-              expect(course_with_includes).to receive(:joins).and_return(joins_provider_scope)
-              expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(select_scope)
-              distance_with_university_area_adjustment = <<~EOSQL.gsub(/\s+/m, " ").strip
-                (CASE
-                  WHEN provider.provider_type = 'O'
-                    THEN (distance - 10)
-                  ELSE distance
-                END) as boosted_distance
-              EOSQL
-              select_criteria = "course.*, distance, #{distance_with_university_area_adjustment}"
-
-              expect(select_scope).to receive(:select).with(select_criteria)
-                .and_return(order_scope)
-              expect(order_scope).to receive(:order).with(:boosted_distance).and_return(expected_scope)
-              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-              expect(subject).to eq(distinct_scope)
-            end
-          end
-        end
-      end
-
-      context "unspecified" do
-        it "does not order" do
-          expect(scope).not_to receive(:order)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
+    let!(:nearby_course) do
+      create(:course) do |course|
+        course.site_statuses << build(:site_status, :findable, site: build(:site, latitude: 54.54, longitude: -1))
       end
     end
 
-    describe "filter is nil" do
-      let(:filter) { nil }
-
-      it "returns all" do
-        expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-        expect(subject).to eq(distinct_scope)
+    let!(:nearby_university_course) do
+      create(:course, provider: create(:provider, :university)) do |course|
+        course.site_statuses << build(:site_status, :findable, site: build(:site, latitude: 54.11, longitude: -1))
       end
     end
 
-    describe "range" do
-      context "when a range is specified" do
-        let(:longitude) { 0 }
-        let(:latitude) { 1 }
-        let(:radius) { 5 }
-        let(:filter) { { longitude: longitude, latitude: latitude, radius: radius } }
-
-        it "adds the within scope" do
-          expect(scope).to receive(:within).with(radius, origin: [latitude, longitude]).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when a range is not specified" do
-        let(:longitude) { 0 }
-        let(:latitude) { 1 }
-        let(:filter) { { longitude: longitude, latitude: latitude } }
-
-        it "does not add the within scope" do
-          expect(scope).not_to receive(:within)
-        end
+    let!(:far_away_course) do
+      create(:course) do |course|
+        course.site_statuses << build(:site_status, :findable, site: build(:site, latitude: 54.12, longitude: -1))
       end
     end
 
-    describe "filter[provider.provider_name]" do
-      context "when provider name is present" do
-        let(:filter) { { "provider.provider_name": "University of Warwick" } }
-        let(:expected_scope) { double }
-        let(:provider_order_scope) { double }
+    it { is_expected.to eq([nearby_course]) }
 
-        it "adds some scope" do
-          expect(scope).to receive(:with_provider_name).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:select).and_return(joins_provider_scope)
-          expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(order_scope)
-          expect(order_scope).to receive(:order).and_return(provider_order_scope)
-          expect(provider_order_scope).to receive(:ascending_canonical_order).and_return(expected_scope)
-          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
+    context "when the radius is not specified" do
+      let(:filter) { { latitude: 54.9713392, longitude: -1 } }
+
+      it { is_expected.to match_array([generic_course, far_away_course, nearby_university_course, nearby_course]) }
     end
 
-    describe "filter[updated_since]" do
-      let(:filter) { { updated_since: Time.zone.now.iso8601 } }
+    context "when sorting by distance" do
+      let(:sort) { "distance" }
+      let(:filter) { { latitude: 54.9713392, longitude: -1 } }
 
-      it "adds the changed_since scope" do
-        expect(scope).to receive(:changed_since).and_return(course_ids_scope)
-        expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-        expect(subject).to eq(distinct_scope)
-      end
-    end
+      it { is_expected.to eq([nearby_course, far_away_course, nearby_university_course]) }
 
-    describe "filter[funding]" do
-      context "when value is salary" do
-        let(:filter) { { funding: "salary" } }
-
-        it "adds the with_salary scope" do
-          expect(scope).to receive(:with_salary).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
+      context "when expand_university is true" do
+        let(:filter) do
+          { latitude: 54.9713392, longitude: -1, expand_university: "true" }
         end
-      end
 
-      context "when value is all" do
-        let(:filter) { { funding: "all" } }
-
-        it "doesn't add the with_salary scope" do
-          expect(scope).not_to receive(:with_salary)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[qualification]" do
-      context "when qualifications passed" do
-        let(:filter) { { qualification: "pgde,pgce_with_qts,pgde_with_qts,qts,pgce" } }
-
-        it "adds the with_qualifications scope" do
-          expect(scope)
-            .to receive(:with_qualifications)
-            .with(%w(pgde pgce_with_qts pgde_with_qts qts pgce))
-            .and_return(course_ids_scope)
-
-
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when no qualifications passed" do
-        let(:filter) { {} }
-
-        it "adds the with_qualifications scope" do
-          expect(scope).not_to receive(:with_qualifications)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[with_vacancies]" do
-      context "when true" do
-        let(:filter) { { has_vacancies: true } }
-
-        it "adds the with_vacancies scope" do
-          expect(scope).to receive(:with_vacancies).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when false" do
-        let(:filter) { { has_vacancies: false } }
-
-        it "doesn't add the with_vacancies scope" do
-          expect(scope).not_to receive(:with_vacancies)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the with_vacancies scope" do
-          expect(scope).not_to receive(:with_vacancies)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[findable]" do
-      context "when true" do
-        let(:filter) { { findable: true } }
-
-        it "adds the findable scope" do
-          expect(scope).to receive(:findable).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when false" do
-        let(:filter) { { findable: false } }
-
-        it "doesn't add the findable scope" do
-          expect(scope).not_to receive(:findable)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the findable scope" do
-          expect(scope).not_to receive(:findable)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[study_type]" do
-      context "when full_time" do
-        let(:filter) { { study_type: "full_time" } }
-
-        it "adds the with_study_modes scope" do
-          expect(scope).to receive(:with_study_modes).with(%w(full_time)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when part_time" do
-        let(:filter) { { study_type: "part_time" } }
-
-        it "adds the with_study_modes scope" do
-          expect(scope).to receive(:with_study_modes).with(%w(part_time)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when both" do
-        let(:filter) { { study_type: "part_time,full_time" } }
-
-        it "adds the with_study_modes scope with an array of both arguments" do
-          expect(scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the scope" do
-          expect(scope).not_to receive(:with_study_modes)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[funding_type]" do
-      context "when fee" do
-        let(:filter) { { funding_type: "fee" } }
-
-        it "adds the with_funding_types scope" do
-          expect(scope).to receive(:with_funding_types).with(%w(fee)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when salary" do
-        let(:filter) { { funding_type: "salary" } }
-
-        it "adds the with_funding_types scope" do
-          expect(scope).to receive(:with_funding_types).with(%w(salary)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when apprenticeship" do
-        let(:filter) { { funding_type: "apprenticeship" } }
-
-        it "adds the with_funding_types scope" do
-          expect(scope).to receive(:with_funding_types).with(%w(apprenticeship)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when all" do
-        let(:filter) { { funding_type: "fee,salary,apprenticeship" } }
-
-        it "adds the with_funding_types scope" do
-          expect(scope).to receive(:with_funding_types).with(%w(fee salary apprenticeship)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the scope" do
-          expect(scope).not_to receive(:with_funding_types)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[subjects]" do
-      context "a single subject code" do
-        let(:filter) { { subjects: "A1" } }
-
-        it "adds the subject scope" do
-          expect(scope).to receive(:with_subjects).with(%w(A1)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "multiple subject codes" do
-        let(:filter) { { subjects: "A1,B2" } }
-
-        it "adds the subject scope" do
-          expect(scope).to receive(:with_subjects).with(%w(A1 B2)).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the scope" do
-          expect(scope).not_to receive(:with_subjects)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "filter[send_courses]" do
-      context "when true" do
-        let(:filter) { { send_courses: true } }
-
-        it "adds the with_send scope" do
-          expect(scope).to receive(:with_send).and_return(course_ids_scope)
-          expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when false" do
-        let(:filter) { { send_courses: false } }
-
-        it "adds the with_send scope" do
-          expect(scope).not_to receive(:with_send)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) { {} }
-
-        it "doesn't add the with_send scope" do
-          expect(scope).not_to receive(:with_send)
-          expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-          expect(subject).to eq(distinct_scope)
-        end
-      end
-    end
-
-    describe "multiple filters" do
-      let(:filter) { { study_type: "part_time", funding: "salary" } }
-      let(:salary_scope) { double }
-
-      it "combines scopes" do
-        expect(scope).to receive(:with_salary).and_return(salary_scope)
-        expect(salary_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(course_ids_scope)
-        expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
-        expect(subject).to eq(distinct_scope)
+        it { is_expected.to eq([nearby_course, nearby_university_course, far_away_course]) }
       end
     end
   end
 
-  describe "expand_university" do
-    context "university course vs non university course" do
-      null_island = { latitude: 0, longitude: 0 }
+  context "with filter funding_type" do
+    let(:filter) { { funding_type: "salary" } }
+    let!(:salary_course) { create(:course, :with_salary) }
+    let!(:apprenticeship_course) { create(:course, :with_apprenticeship) }
 
-      over_5_miles_from_null_island = { latitude: 0.1, longitude: 0 }
+    it { is_expected.to eq([salary_course]) }
 
-      subject do
-        described_class.call(filter: filter,
-                             sort: "distance",
-                             course_scope: scope)
-      end
+    context "with multiple funding_type" do
+      let(:filter) { { funding_type: "salary,apprenticeship" } }
 
-      let(:university_course) do
-        create(:course, provider: university_provider,
-          site_statuses: [build(:site_status, :findable, site: site)],
-          enrichments: [build(:course_enrichment, :published)])
-      end
+      it { is_expected.to eq([salary_course, apprenticeship_course]) }
+    end
+  end
 
-      let(:non_university_course) do
-        create(:course, provider: non_university_provider,
-          site_statuses: [build(:site_status, :findable, site: site2)],
-          enrichments: [build(:course_enrichment, :published)])
-      end
+  context "with filter funding_type" do
+    let(:updated_at_time) { 1.day.ago }
+    let(:filter) { { updated_since: updated_at_time.iso8601 } }
+    let!(:recently_updated_course) { create(:course) }
 
-      let(:courses) do
-        [university_course, non_university_course]
-      end
+    before do
+      generic_course.update!(changed_at: 10.days.ago)
+    end
 
-      let(:site) do
-        build(:site, **over_5_miles_from_null_island)
-      end
+    it { is_expected.to eq([recently_updated_course]) }
+  end
 
-      let(:site2) do
-        build(:site, **null_island)
-      end
+  context "when sorting by course and provider name" do
+    let(:filter) { nil }
+    let(:warwick_provider) { create(:provider, provider_name: "University of Warwick") }
+    let(:plymouth_provider) { create(:provider, provider_name: "University of Plymouth") }
+    let!(:warwick_course) { create(:course, provider: warwick_provider) }
+    let!(:plymouth_course) { create(:course, provider: plymouth_provider) }
+    let(:sort) { "name,provider.provider_name" }
 
-      let(:university_provider) do
-        build(:provider, provider_type: :university, sites: [site])
-      end
+    it { is_expected.to eq([generic_course, plymouth_course, warwick_course]) }
 
-      let(:non_university_provider) do
-        build(:provider, provider_type: :scitt, sites: [site2])
-      end
+    context "descending provider name and course name" do
+      let(:sort) { "-provider.provider_name,-name" }
 
-      before do
-        courses
-      end
-
-      let(:scope) do
-        Course.all
-      end
-
-      context "when false" do
-        let(:filter) do
-          null_island.merge(expand_university: "false")
-        end
-
-        it "returns correctly" do
-          expect(subject.count(:id)).to eq(2)
-
-          expect(subject.first.boosted_distance).to eq(0)
-          expect(subject.first.distance).to eq(0)
-          expect(subject.first).to eq(non_university_course)
-
-          expect(subject.second.boosted_distance - subject.second.distance).to eq(-10)
-          expect(subject.second).to eq(university_course)
-        end
-      end
-
-      context "when absent" do
-        let(:filter) do
-          null_island
-        end
-
-        it "returns correctly" do
-          expect(subject.count(:id)).to eq(2)
-
-          expect(subject.first.boosted_distance).to eq(0)
-          expect(subject.first.distance).to eq(0)
-          expect(subject.first).to eq(non_university_course)
-
-          expect(subject.second.boosted_distance - subject.second.distance).to eq(-10)
-          expect(subject.second).to eq(university_course)
-        end
-      end
-
-      context "when true" do
-        describe "university course has less 10 miles" do
-          let(:filter) do
-            null_island.merge(expand_university: "true")
-          end
-
-          it "returns correctly" do
-            expect(subject.count(:id)).to eq(2)
-
-            expect(subject.first.boosted_distance - subject.first.distance).to eq(-10)
-            expect(subject.first).to eq(university_course)
-
-            expect(subject.second.boosted_distance).to eq(0)
-            expect(subject.second.distance).to eq(0)
-            expect(subject.second).to eq(non_university_course)
-          end
-        end
-      end
+      it { is_expected.to eq([warwick_course, plymouth_course, generic_course]) }
     end
   end
 end

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe CourseSearchService do
-
   describe ".call" do
     let(:course_with_includes) { class_double(Course) }
     let(:scope) { class_double(Course) }
@@ -16,10 +15,9 @@ RSpec.describe CourseSearchService do
 
     let(:includes_arguments) {
       [:enrichments,
-        subjects: [:financial_incentive],
-        site_statuses: [:site],
-        provider: %i[recruitment_cycle ucas_preferences],
-      ]
+       subjects: [:financial_incentive],
+       site_statuses: [:site],
+       provider: %i[recruitment_cycle ucas_preferences]]
     }
 
     describe "when no scope is passed" do
@@ -28,7 +26,8 @@ RSpec.describe CourseSearchService do
 
       it "defaults to Course" do
         expect(Course).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(subject).to eq(course_with_includes)
+        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+        expect(subject).to eq(distinct_scope)
       end
     end
 
@@ -44,7 +43,8 @@ RSpec.describe CourseSearchService do
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
           expect(course_with_includes).to receive(:ascending_canonical_order).and_return(select_scope)
           expect(select_scope).to receive(:select).and_return(expected_scope)
-          expect(subject).to eq(expected_scope)
+          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -55,7 +55,8 @@ RSpec.describe CourseSearchService do
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
           expect(course_with_includes).to receive(:descending_canonical_order).and_return(select_scope)
           expect(select_scope).to receive(:select).and_return(expected_scope)
-          expect(subject).to eq(expected_scope)
+          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -84,7 +85,8 @@ RSpec.describe CourseSearchService do
               expect(select_scope).to receive(:select).with(select_criteria)
                 .and_return(order_scope)
               expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
-              expect(subject).to eq(expected_scope)
+              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+              expect(subject).to eq(distinct_scope)
             end
           end
 
@@ -109,7 +111,8 @@ RSpec.describe CourseSearchService do
               expect(select_scope).to receive(:select).with(select_criteria)
                 .and_return(order_scope)
               expect(order_scope).to receive(:order).with(:distance).and_return(expected_scope)
-              expect(subject).to eq(expected_scope)
+              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+              expect(subject).to eq(distinct_scope)
             end
           end
 
@@ -134,7 +137,8 @@ RSpec.describe CourseSearchService do
               expect(select_scope).to receive(:select).with(select_criteria)
                 .and_return(order_scope)
               expect(order_scope).to receive(:order).with(:boosted_distance).and_return(expected_scope)
-              expect(subject).to eq(expected_scope)
+              expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+              expect(subject).to eq(distinct_scope)
             end
           end
         end
@@ -144,7 +148,8 @@ RSpec.describe CourseSearchService do
         it "does not order" do
           expect(scope).not_to receive(:order)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -154,7 +159,8 @@ RSpec.describe CourseSearchService do
 
       it "returns all" do
         expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(subject).to eq(course_with_includes)
+        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+        expect(subject).to eq(distinct_scope)
       end
     end
 
@@ -168,7 +174,8 @@ RSpec.describe CourseSearchService do
         it "adds the within scope" do
           expect(scope).to receive(:within).with(radius, origin: [latitude, longitude]).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -187,14 +194,17 @@ RSpec.describe CourseSearchService do
       context "when provider name is present" do
         let(:filter) { { "provider.provider_name": "University of Warwick" } }
         let(:expected_scope) { double }
-        let(:order_scope) { double }
+        let(:provider_order_scope) { double }
 
         it "adds some scope" do
           expect(scope).to receive(:with_provider_name).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(course_with_includes).to receive(:accredited_body_order).and_return(order_scope)
-          expect(order_scope).to receive(:ascending_canonical_order).and_return(expected_scope)
-          expect(subject).to eq(expected_scope)
+          expect(course_with_includes).to receive(:select).and_return(joins_provider_scope)
+          expect(joins_provider_scope).to receive(:joins).with(:provider).and_return(order_scope)
+          expect(order_scope).to receive(:order).and_return(provider_order_scope)
+          expect(provider_order_scope).to receive(:ascending_canonical_order).and_return(expected_scope)
+          expect(expected_scope).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -205,7 +215,8 @@ RSpec.describe CourseSearchService do
       it "adds the changed_since scope" do
         expect(scope).to receive(:changed_since).and_return(course_ids_scope)
         expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(subject).to eq(course_with_includes)
+        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+        expect(subject).to eq(distinct_scope)
       end
     end
 
@@ -216,7 +227,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_salary scope" do
           expect(scope).to receive(:with_salary).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -226,7 +238,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the with_salary scope" do
           expect(scope).not_to receive(:with_salary)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -243,7 +256,8 @@ RSpec.describe CourseSearchService do
 
 
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -253,7 +267,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_qualifications scope" do
           expect(scope).not_to receive(:with_qualifications)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -265,7 +280,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_vacancies scope" do
           expect(scope).to receive(:with_vacancies).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -275,7 +291,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the with_vacancies scope" do
           expect(scope).not_to receive(:with_vacancies)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -285,7 +302,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the with_vacancies scope" do
           expect(scope).not_to receive(:with_vacancies)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -297,7 +315,8 @@ RSpec.describe CourseSearchService do
         it "adds the findable scope" do
           expect(scope).to receive(:findable).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -307,7 +326,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the findable scope" do
           expect(scope).not_to receive(:findable)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -317,7 +337,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the findable scope" do
           expect(scope).not_to receive(:findable)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -329,7 +350,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_study_modes scope" do
           expect(scope).to receive(:with_study_modes).with(%w(full_time)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -339,7 +361,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_study_modes scope" do
           expect(scope).to receive(:with_study_modes).with(%w(part_time)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -349,7 +372,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_study_modes scope with an array of both arguments" do
           expect(scope).to receive(:with_study_modes).with(%w(part_time full_time)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -359,7 +383,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_study_modes)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -371,7 +396,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_funding_types scope" do
           expect(scope).to receive(:with_funding_types).with(%w(fee)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -381,7 +407,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_funding_types scope" do
           expect(scope).to receive(:with_funding_types).with(%w(salary)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -391,7 +418,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_funding_types scope" do
           expect(scope).to receive(:with_funding_types).with(%w(apprenticeship)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -401,7 +429,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_funding_types scope" do
           expect(scope).to receive(:with_funding_types).with(%w(fee salary apprenticeship)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -411,7 +440,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_funding_types)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -423,7 +453,8 @@ RSpec.describe CourseSearchService do
         it "adds the subject scope" do
           expect(scope).to receive(:with_subjects).with(%w(A1)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -433,7 +464,8 @@ RSpec.describe CourseSearchService do
         it "adds the subject scope" do
           expect(scope).to receive(:with_subjects).with(%w(A1 B2)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -443,7 +475,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the scope" do
           expect(scope).not_to receive(:with_subjects)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -455,7 +488,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_send scope" do
           expect(scope).to receive(:with_send).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -465,7 +499,8 @@ RSpec.describe CourseSearchService do
         it "adds the with_send scope" do
           expect(scope).not_to receive(:with_send)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
 
@@ -475,7 +510,8 @@ RSpec.describe CourseSearchService do
         it "doesn't add the with_send scope" do
           expect(scope).not_to receive(:with_send)
           expect(scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-          expect(subject).to eq(course_with_includes)
+          expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+          expect(subject).to eq(distinct_scope)
         end
       end
     end
@@ -488,7 +524,8 @@ RSpec.describe CourseSearchService do
         expect(scope).to receive(:with_salary).and_return(salary_scope)
         expect(salary_scope).to receive(:with_study_modes).with(%w(part_time)).and_return(course_ids_scope)
         expect(course_ids_scope).to receive(:includes).with(*includes_arguments).and_return(course_with_includes)
-        expect(subject).to eq(course_with_includes)
+        expect(course_with_includes).to receive(:distinct).and_return(distinct_scope)
+        expect(subject).to eq(distinct_scope)
       end
     end
   end


### PR DESCRIPTION
### Context

Previously, a 'where' scope was being added to clear out the duplicate
records. In its absence, the service call was failing with
a 'PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list'

While this works fine as is, the extra scope call can lead to some
awkward sql subqueries, which are generated by ActiveRecord, for
example, of the form
Select ... from (select id where course id in (...long list of possibly
all courses in the database)...., making it harder for our performance
monitoring tools (skylight) to parse the query

This change adds the order by expressions to the select, thus negating
the need for a subquery

### Changes proposed in this pull request

### Guidance to review

While the first two commits do the job just fine, the [third commit](https://github.com/DFE-Digital/teacher-training-api/blob/65d79fd504644466c503a217ceb97b5e36e20207/spec/services/course_search_service_spec.rb) is a rewrite of the `course_search_service_spec.rb` to use calls to the actual AR objects rather than stubbing

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
