### PR TITLE
[1503] Add validations to URN and UKPRN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bin/fetch_config.rb
 
 # Ignore sanitised production data dump
 *.sql.gz
+*.sql
 
 # Exclude api doc application node modules
 docs/node_modules

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -108,11 +108,11 @@ class Provider < ApplicationRecord
 
   validates :provider_name, length: { maximum: 100 }, on: :update, if: RecruitmentCycle.current_recruitment_cycle
 
-  validates :urn, length: { in: 5..6 }, if: :lead_school?, allow_nil: true
-
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
-  validates :ukprn, length: { is: 8, wrong_length: "^UKPRN must be 8 characters" }, allow_blank: true
+  validates :ukprn, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }
+
+  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: :lead_school?
 
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?
   validates :train_with_disability, presence: true, on: :update, if: :train_with_disability_changed?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,6 +25,8 @@ class Site < ApplicationRecord
                    inclusion: { in: POSSIBLE_CODES, message: "must be A-Z, 0-9 or -" },
                    presence: true
 
+  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }
+
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil) }

--- a/app/validators/reference_number_format_validator.rb
+++ b/app/validators/reference_number_format_validator.rb
@@ -1,0 +1,9 @@
+class ReferenceNumberFormatValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return if options[:allow_blank] && value.blank?
+
+    if value.length > options[:maximum] || value.length < options[:minimum] || !value.match?(/\A-?\d+\Z/)
+      record.errors.add attribute, options[:message]
+    end
+  end
+end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     address4 { Faker::Address.state }
     postcode { Faker::Address.postcode }
     region_code { "london" }
-    urn { Faker::Number.number(digits: 6) }
+    urn { Faker::Number.number(digits: [5, 6].sample) }
 
     # When we retrieve a random code (as Site#pick_next_available_code does),
     # there is the possibility we'll end up with this code duplicated when

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -38,6 +38,14 @@ describe Provider, type: :model do
         expect(provider).to be_valid
       end
     end
+
+    context "when provider_type is lead_schools" do
+      let(:invalid_provider) { build(:provider, urn: "XXXXXX") }
+
+      it "validates that a urn contains digits only" do
+        expect(invalid_provider).to_not be_valid
+      end
+    end
   end
 
   describe "organisation" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -17,6 +17,24 @@ describe Site, type: :model do
   it { is_expected.to validate_presence_of(:code) }
   it { is_expected.to validate_inclusion_of(:code).in_array(Site::POSSIBLE_CODES).with_message("must be A-Z, 0-9 or -") }
 
+  it "validates that URN cannot be letters" do
+    subject.urn = "XXXXXX"
+    subject.valid?
+    expect(subject.errors[:urn]).to include("^URN must be 5 or 6 numbers")
+  end
+
+  it "validates URN minimum length" do
+    subject.urn = "1234"
+    subject.valid?
+    expect(subject.errors[:urn]).to include("^URN must be 5 or 6 numbers")
+  end
+
+  it "validates URN maximum length" do
+    subject.urn = "1234567"
+    subject.valid?
+    expect(subject.errors[:urn]).to include("^URN must be 5 or 6 numbers")
+  end
+
   describe "associations" do
     it { should belong_to(:provider) }
   end

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -133,6 +133,7 @@ describe "PATCH /providers/:provider_code" do
     include_examples "does not allow assignment", :accrediting_provider, :accredited_body
     include_examples "does not allow assignment", :changed_at,           Time.zone.now
     include_examples "does not allow assignment", :ukprn, "1234567"
+    include_examples "does not allow assignment", :ukprn, "XXXXXXXX"
     include_examples "does not allow assignment", :urn, "1234"
 
     let!(:next_cycle) { find_or_create(:recruitment_cycle, :next) }

--- a/spec/validators/reference_number_format_validator_spec.rb
+++ b/spec/validators/reference_number_format_validator_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe ReferenceNumberFormatValidator do
+  class ReferenceNumberFormatValidatorTest
+    include ActiveModel::Validations
+
+    attr_accessor :reference_number
+
+    validates :reference_number, reference_number_format: { allow_blank: true, maximum: 8, minimum: 8, message: "error" }
+  end
+
+  let(:reference_number) { "12345678" }
+
+  let(:model) do
+    model = ReferenceNumberFormatValidatorTest.new
+    model.reference_number = reference_number
+    model
+  end
+
+  describe "reference number validation" do
+    context "with a valid reference number" do
+      it "does not add an error" do
+        expect(model).to be_valid
+      end
+    end
+
+    context "without a reference number" do
+      let(:reference_number) { nil }
+
+      it "does not add an error" do
+        expect(model).to be_valid
+      end
+    end
+
+    context "with a short reference number" do
+      let(:reference_number) { "1234567" }
+
+      it "adds an error" do
+        expect(model).to be_invalid
+        expect(model.errors[:reference_number]).to contain_exactly("error")
+      end
+    end
+
+    context "with a long reference number" do
+      let(:reference_number) { "123456789" }
+
+      it "adds an error" do
+        expect(model).to be_invalid
+        expect(model.errors[:reference_number]).to contain_exactly("error")
+      end
+    end
+
+    context "with a reference number containing letters" do
+      let(:reference_number) { "SSSSSSSS" }
+
+      it "adds an error" do
+        expect(model).to be_invalid
+        expect(model.errors[:reference_number]).to contain_exactly("error")
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

This PR prevents users from entering a URN or UKPRN in an incorrect format.

### Changes proposed in this pull request

- Validate that the string is 5-6 numbers on URN (Site table)
- Validate that the string is 8 numbers on UKPRN (Provider table)
- Allow blank values
- Custom validators
- Add staging data dump file to .gitignore

### Guidance to review

- Pull down the code and ensure you have the latest migrations
- Boot up the rails console and navigate to a Site
- Ensure the URN will only be saved if it is nil, 5 or 6 numbers

- Repeat for UKPRN on the provider table. 
- Ensure the UKPRN will only be saved if it is nil, or 8 numbers

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
