### PR TITLE
[1579] Log skylight to STDOUT

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,7 @@ module ManageCoursesBackend
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
-    config.skylight.logger = Logger.new(STDOUT)
+    config.skylight.logger = SemanticLogger['Skylight']
 
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,6 +51,7 @@ module ManageCoursesBackend
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
+    config.skylight.logger = Logger.new(STDOUT)
 
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"

--- a/config/application.rb
+++ b/config/application.rb
@@ -51,7 +51,9 @@ module ManageCoursesBackend
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
-    config.skylight.logger = SemanticLogger['Skylight']
+    config.skylight.logger = SemanticLogger[Skylight]
+    config.skylight.log_level = :fatal
+    config.skylight.native_log_level = :fatal
 
     config.view_component.preview_paths = [Rails.root.join("spec/components")]
     config.view_component.preview_route = "/view_components"


### PR DESCRIPTION
### Context
Skylight is writing the below in to a log file inside the app container with each request and this is increasing the disk utilisation and could lead to degraded performance if app isn't recycled in time before all disk space is usedup.

### Changes proposed in this pull request
[Log to SDTOUT](https://www.skylight.io/support/advanced-setup#logger)

### Guidance to review
The file should be not initialised/created in the app container since we are now writing to stdout.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running on qa
