### PR TITLE
[1678] Touch provider when course is updated

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -2,6 +2,7 @@ class Course < ApplicationRecord
   include Discard::Model
   include WithQualifications
   include ChangedAt
+  include TouchProvider
   include Courses::EditOptions
   include StudyModeVacancyMapper
   include TimeFormat

--- a/spec/lib/mcb/commands/courses/touch_spec.rb
+++ b/spec/lib/mcb/commands/courses/touch_spec.rb
@@ -22,9 +22,12 @@ describe "mcb courses touch" do
   let(:rolled_over_course) { create(:course, provider: rolled_over_provider) }
 
   context "when the recruitment year is unspecified" do
-    it "updates the course updated_at for the current recruitment cycle" do
+    before do
       rolled_over_course
+      course
+    end
 
+    it "updates the course updated_at for the current recruitment cycle" do
       Timecop.freeze(Time.zone.today + 1) do
         execute_touch(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])
 
@@ -36,8 +39,6 @@ describe "mcb courses touch" do
     end
 
     it "updates the course changed_at" do
-      rolled_over_course
-
       Timecop.freeze(Time.zone.today + 1) do
         execute_touch(arguments: [rolled_over_provider.provider_code, rolled_over_course.course_code])
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -24,6 +24,24 @@ describe Course, type: :model do
     it { should have_associated_audits }
   end
 
+  describe "#touch_provider" do
+    let(:course) { create(:course) }
+
+    it "sets changed_at to the current time" do
+      Timecop.freeze do
+        course.touch
+        expect(course.provider.changed_at).to eq Time.now.utc
+      end
+    end
+
+    it "leaves updated_at unchanged" do
+      timestamp = 1.hour.ago
+      course.provider.update updated_at: timestamp
+      course.touch
+      expect(course.provider.updated_at).to eq timestamp
+    end
+  end
+
   describe "associations" do
     it { should belong_to(:provider) }
     it do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -30,7 +30,7 @@ describe Course, type: :model do
     it "sets changed_at to the current time" do
       Timecop.freeze do
         course.touch
-        expect(course.provider.changed_at).to eq Time.now.utc
+        expect(course.provider.changed_at).to be_within(1.second).of Time.now.utc
       end
     end
 

--- a/spec/requests/api/v1/course_spec.rb
+++ b/spec/requests/api/v1/course_spec.rb
@@ -128,22 +128,22 @@ describe "Courses API", type: :request do
 
       it "includes correct next link in response headers" do
         timestamp_of_first_course = 10.minutes.ago
-        Timecop.freeze(timestamp_of_first_course) do
-          first_course = create(:course,
-                                :infer_level,
-                                course_code: "LAST1",
-                                provider: provider)
+        first_course = create(:course,
+                              :infer_level,
+                              course_code: "LAST1",
+                              provider: provider)
 
+        Timecop.travel(timestamp_of_first_course) do
           create(:site_status, :published, course: first_course)
         end
 
         timestamp_of_last_course = 2.minutes.ago
 
+        last_course_in_results = create(:course,
+                                        :infer_level,
+                                        course_code: "LAST2",
+                                        provider: provider)
         Timecop.freeze(timestamp_of_last_course) do
-          last_course_in_results = create(:course,
-                                          :infer_level,
-                                          course_code: "LAST2",
-                                          provider: provider)
           create(:site_status, :published, course: last_course_in_results)
         end
 
@@ -243,11 +243,11 @@ describe "Courses API", type: :request do
             end
 
             timestamp_of_last_course = 2.minutes.ago
+            last_course_in_results = create(:course,
+                                            course_code: "LAST2",
+                                            age: timestamp_of_last_course,
+                                            provider: provider)
             Timecop.freeze(timestamp_of_last_course) do
-              last_course_in_results = create(:course,
-                                              course_code: "LAST2",
-                                              age: timestamp_of_last_course,
-                                              provider: provider)
               create(:site_status, :published, course: last_course_in_results)
             end
 
@@ -286,11 +286,11 @@ describe "Courses API", type: :request do
             end
 
             timestamp_of_last_course = 2.minutes.ago
+            last_course_in_results = create(:course,
+                                            course_code: "LAST2",
+                                            age: timestamp_of_last_course,
+                                            provider: provider)
             Timecop.freeze(timestamp_of_last_course) do
-              last_course_in_results = create(:course,
-                                              course_code: "LAST2",
-                                              age: timestamp_of_last_course,
-                                              provider: provider)
               create(:site_status, :published, course: last_course_in_results)
             end
             get "/api/v1/courses?recruitment_year=#{next_year}",


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/Dbm8Ct4t/1678-s-touch-provider-when-course-is-updated)

### Changes proposed in this pull request

- Added TouchProvider module to the course model to ensure that the provider model records updates to the course, through `changed_at`. 

### Guidance to review

- Open your rails console `$ rails c`
- `$ course = Course.all.sample`
- `$ course.changed_at` => outputs sometime in the past
- `$ course.provider.changed_at` => outputs sometime in the past
- `$ course.name = "A new name!"`
- `$ course.save`
- `$ course.changed_at` => outputs today's date
- `$ course.provider.changed_at` => outputs today's date # this is the important part
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
