### PR TITLE
Don't access secrets for dependabot PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,12 +16,8 @@ jobs:
       DOCKER_IMAGE: dfedigital/teacher-training-api
 
     steps:
-    - uses: softprops/turnstyle@v1
-      name: Wait for other inprogress runs
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - uses: actions/checkout@v2
+    - name: Checkout
+      uses: actions/checkout@v2
 
     - name: Get values for current commit
       run: |
@@ -35,6 +31,7 @@ jobs:
         echo "BRANCH_TAG=paas-$GIT_BRANCH" >> $GITHUB_ENV
 
     - name: Login to DockerHub
+      if: github.actor != 'dependabot[bot]'
       uses: docker/login-action@v1
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -47,8 +44,8 @@ jobs:
       uses: docker/build-push-action@v2.1.0
       with:
         tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
-        pull: true
-        push: true
+        push: ${{ github.actor != 'dependabot[bot]' }}
+        load: ${{ github.actor == 'dependabot[bot]' }}
         target: middleman
         cache-from: |
           ${{ env.DOCKER_IMAGE}}-middleman:master
@@ -61,8 +58,8 @@ jobs:
         tags: |
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           ${{ env.DOCKER_IMAGE}}:${{ env.SHA_TAG }}
-        pull: true
-        push: true
+        push: ${{ github.actor != 'dependabot[bot]' }}
+        load: ${{ github.actor == 'dependabot[bot]' }}
         cache-from: |
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           ${{ env.DOCKER_IMAGE}}-middleman:master


### PR DESCRIPTION
### Context

Dependabot PRs can't access pipeline secrets

### Changes proposed in this pull request
Don't push images to DockerHub from dependabot PR build

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
