### PR TITLE
[1725] Build rake task for rollover and RecruitmentCycle creation

### DIFF
--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -1,0 +1,15 @@
+class RecruitmentCycleCreationService
+  include ServicePattern
+
+  def initialize(year:, application_start_date:, application_end_date:)
+    @year = year
+    @application_start_date = application_start_date
+    @application_end_date = application_end_date
+  end
+
+  def call
+    RecruitmentCycle.create!(year: @year, application_start_date: @application_start_date, application_end_date: @application_end_date)
+
+    puts "The new RecruitmentCycle has been successfully created for:\n\nyear: '#{@year}'\napplication_start_date: '#{@application_start_date}'\napplication_end_date: '#{@application_end_date}'\n\n"
+  end
+end

--- a/app/services/rollover_service.rb
+++ b/app/services/rollover_service.rb
@@ -1,0 +1,56 @@
+class RolloverService
+  include ServicePattern
+
+  def initialize(provider_codes:)
+    @provider_codes = provider_codes
+  end
+
+  def call
+    providers = if @provider_codes.any?
+                  RecruitmentCycle.current_recruitment_cycle
+                                  .providers.where(provider_code: @provider_codes.to_a.map(&:upcase))
+                else
+                  RecruitmentCycle.current_recruitment_cycle.providers
+                end
+
+    new_recruitment_cycle = RecruitmentCycle.next_recruitment_cycle
+
+    total_counts = { providers: 0, sites: 0, courses: 0 }
+
+    total_bm = Benchmark.measure do
+      providers.each do |provider|
+        print "Copying provider #{provider.provider_code}: "
+        counts = nil
+        bm = Benchmark.measure do
+          Provider.connection.transaction do
+            copy_courses_to_provider_service = Courses::CopyToProviderService.new(
+              sites_copy_to_course: Sites::CopyToCourseService.new,
+              enrichments_copy_to_course: Enrichments::CopyToCourseService.new,
+              )
+
+            copy_provider_to_recruitment_cycle = Providers::CopyToRecruitmentCycleService.new(
+              copy_course_to_provider_service: copy_courses_to_provider_service,
+              copy_site_to_provider_service: Sites::CopyToProviderService.new,
+              logger: Logger.new(STDOUT),
+              )
+
+            counts = copy_provider_to_recruitment_cycle.execute(
+              provider: provider, new_recruitment_cycle: new_recruitment_cycle,
+              )
+          end
+        end
+        puts "provider #{counts[:providers].zero? ? 'skipped' : 'copied'}, " \
+               "#{counts[:sites]} sites copied, " \
+               "#{counts[:courses]} courses copied " \
+               "in %.3f seconds" % bm.real
+        total_counts.merge!(counts) { |_, total, count| total + count }
+      end
+    end
+
+    puts "Rollover done: " \
+           "#{total_counts[:providers]} providers, " \
+           "#{total_counts[:sites]} sites, " \
+           "#{total_counts[:courses]} courses " \
+           "in %.3f seconds" % total_bm.real
+  end
+end

--- a/app/services/rollover_service.rb
+++ b/app/services/rollover_service.rb
@@ -6,45 +6,10 @@ class RolloverService
   end
 
   def call
-    providers = if @provider_codes.any?
-                  RecruitmentCycle.current_recruitment_cycle
-                                  .providers.where(provider_code: @provider_codes.to_a.map(&:upcase))
-                else
-                  RecruitmentCycle.current_recruitment_cycle.providers
-                end
-
-    new_recruitment_cycle = RecruitmentCycle.next_recruitment_cycle
-
     total_counts = { providers: 0, sites: 0, courses: 0 }
 
     total_bm = Benchmark.measure do
-      providers.each do |provider|
-        print "Copying provider #{provider.provider_code}: "
-        counts = nil
-        bm = Benchmark.measure do
-          Provider.connection.transaction do
-            copy_courses_to_provider_service = Courses::CopyToProviderService.new(
-              sites_copy_to_course: Sites::CopyToCourseService.new,
-              enrichments_copy_to_course: Enrichments::CopyToCourseService.new,
-              )
-
-            copy_provider_to_recruitment_cycle = Providers::CopyToRecruitmentCycleService.new(
-              copy_course_to_provider_service: copy_courses_to_provider_service,
-              copy_site_to_provider_service: Sites::CopyToProviderService.new,
-              logger: Logger.new(STDOUT),
-              )
-
-            counts = copy_provider_to_recruitment_cycle.execute(
-              provider: provider, new_recruitment_cycle: new_recruitment_cycle,
-              )
-          end
-        end
-        puts "provider #{counts[:providers].zero? ? 'skipped' : 'copied'}, " \
-               "#{counts[:sites]} sites copied, " \
-               "#{counts[:courses]} courses copied " \
-               "in %.3f seconds" % bm.real
-        total_counts.merge!(counts) { |_, total, count| total + count }
-      end
+      providers.each { |provider| rollover(provider, total_counts) }
     end
 
     puts "Rollover done: " \
@@ -52,5 +17,53 @@ class RolloverService
            "#{total_counts[:sites]} sites, " \
            "#{total_counts[:courses]} courses " \
            "in %.3f seconds" % total_bm.real
+  end
+
+private
+
+  attr_reader :provider_codes
+
+  def rollover(provider, total_counts)
+    print "Copying provider #{provider.provider_code}: "
+    counts = nil
+
+    bm = Benchmark.measure do
+      Provider.connection.transaction do
+        copy_courses_to_provider_service = Courses::CopyToProviderService.new(
+          sites_copy_to_course: Sites::CopyToCourseService.new,
+          enrichments_copy_to_course: Enrichments::CopyToCourseService.new,
+          )
+
+        copy_provider_to_recruitment_cycle = Providers::CopyToRecruitmentCycleService.new(
+          copy_course_to_provider_service: copy_courses_to_provider_service,
+          copy_site_to_provider_service: Sites::CopyToProviderService.new,
+          logger: Logger.new(STDOUT),
+          )
+
+        counts = copy_provider_to_recruitment_cycle.execute(
+          provider: provider, new_recruitment_cycle: new_recruitment_cycle,
+          )
+      end
+    end
+
+    puts "provider #{counts[:providers].zero? ? 'skipped' : 'copied'}, " \
+            "#{counts[:sites]} sites copied, " \
+            "#{counts[:courses]} courses copied " \
+            "in %.3f seconds" % bm.real
+
+    total_counts.merge!(counts) { |_, total, count| total + count }
+  end
+
+  def new_recruitment_cycle
+    @new_recruitment_cycle ||= RecruitmentCycle.next_recruitment_cycle
+  end
+
+  def providers
+    @providers ||= if provider_codes.any?
+                     RecruitmentCycle.current_recruitment_cycle
+                                     .providers.where(provider_code: provider_codes.to_a.map(&:upcase))
+                   else
+                     RecruitmentCycle.current_recruitment_cycle.providers
+                   end
   end
 end

--- a/lib/tasks/rollover.rake
+++ b/lib/tasks/rollover.rake
@@ -1,0 +1,12 @@
+namespace :rollover do
+  desc "Rollover providers, courses and locations to the next cycle"
+  task :providers, [:provider_codes] => :environment do |_task, args|
+    provider_codes = args[:provider_codes]
+    RolloverService.call(provider_codes: provider_codes&.split || [])
+  end
+
+  desc "Create a new recruitment cycle"
+  task :create_recruitment_cycle, %i[year application_start_date application_end_date] => :environment do |_task, args|
+    RecruitmentCycleCreationService.call(year: args[:year], application_start_date: args[:application_start_date], application_end_date: args[:application_end_date])
+  end
+end

--- a/spec/services/recruitment_cycle_creation_service_spec.rb
+++ b/spec/services/recruitment_cycle_creation_service_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+describe RecruitmentCycleCreationService do
+  describe ".call" do
+    subject { described_class.call(year: 2030, application_start_date: "2031-09-01", application_end_date: "2032-09-01") }
+
+    it "calls the recruitment cycle creation service" do
+      expect(RecruitmentCycleCreationService).to receive(:call)
+      subject
+    end
+
+    it "returns nil" do
+      expect(subject).to be(nil)
+    end
+  end
+end

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+describe RolloverService do
+  let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
+  let(:email) { "user@education.gov.uk" }
+  let(:course)              { build :course, enrichments: [course_enrichment] }
+  let(:course_enrichment)   { build :course_enrichment, :published }
+  let(:site)                { build :site }
+
+  let!(:site_status) {
+    create :site_status,
+           :with_no_vacancies,
+           course: course,
+           site: site
+  }
+
+  let(:current_cycle_provider) {
+    create :provider,
+           courses: [course],
+           sites: [site]
+  }
+
+  before do
+    perform_rollover
+  end
+
+  subject(:next_cycle_provider) do
+    next_recruitment_cycle.providers.find_by(
+      provider_code: current_cycle_provider.provider_code,
+      )
+  end
+
+  let(:new_course) do
+    next_cycle_provider.courses.find_by(
+      course_code: course.course_code,
+      )
+  end
+
+  it "copies the provider" do
+    expect(next_cycle_provider).not_to be_nil
+    expect(next_cycle_provider).not_to eq current_cycle_provider
+  end
+
+  it "copies the provider's site" do
+    new_site = next_cycle_provider.sites.find_by(code: site.code)
+    expect(new_site).not_to be_nil
+    expect(new_site).not_to eq site
+  end
+
+  it "copies the course" do
+    expect(new_course).not_to be_nil
+    expect(new_course).not_to eq course
+  end
+
+  it "copies the course enrichments" do
+    expect(new_course.enrichments.count).to eq 1
+    expect(new_course.enrichments.first).to be_rolled_over
+  end
+
+  it "copies the course's site" do
+    new_site = next_cycle_provider.sites.find_by(code: site.code)
+    expect(new_course.sites).to eq [new_site]
+    expect(new_course.site_statuses.first).to be_full_time_vacancies
+    expect(new_course.site_statuses.first).to be_status_new_status
+  end
+
+  context "when provider already rolled over" do
+    it "copies a new course" do
+      course2 = create(:course, provider: current_cycle_provider)
+      current_cycle_provider.courses.reload
+
+      rollover_again
+
+      duplicated_course2 = next_cycle_provider.courses.find_by(course_code: course2.course_code)
+      expect(duplicated_course2).not_to be_nil
+      expect(duplicated_course2).not_to eq(course2)
+      expect(next_cycle_provider.courses.length).to eq(current_cycle_provider.courses.length)
+    end
+
+    it "copies a new site" do
+      site2 = create(:site, provider: current_cycle_provider)
+      current_cycle_provider.sites.reload
+
+      rollover_again
+
+      duplicated_site2 = next_cycle_provider.sites.find_by(code: site2.code)
+      expect(duplicated_site2).not_to be_nil
+      expect(duplicated_site2).not_to eq(site2)
+      expect(next_cycle_provider.sites.length).to eq(current_cycle_provider.sites.length)
+    end
+  end
+
+  def perform_rollover
+    stderr = nil
+    output = with_stubbed_stdout(stderr: stderr) do
+      RolloverService.call(provider_codes: [current_cycle_provider.provider_code])
+    end
+    [output, stderr]
+  end
+
+  def rollover_again
+    perform_rollover
+  end
+end


### PR DESCRIPTION
### Context

We are creating a service which encompasses the rollover code. It will be removed from MCB in a separate ticket. 

### Changes proposed in this pull request

- Add `RecruitmentCycleCreationService`, which takes the required fields as arguments. 
- Create `RolloverService` encompassing the logic previously in `rollover.rb`. You can rollover all providers or specific ones using a rake task.
- Refactor MCB rollover task, encapsulating logic in `RolloverService`
- Build rollover rake tasks

### Recruitment Cycle guidance to review

- Run ` bundle exec rake rollover:create_recruitment_cycle"[YYYY, "YYYY-MM-DD", "YYYY-MM-DD"]`. This is `year`, `application_start_date` and `application_end_date` respectively. 

- Open up the rails console and execute `RecruitmentCycle.find_by(year: YYYY)` to check the recruitment cycle has been successfully created. 

### Rollover guidance to review

- Ensure you have created a new `RecruitmentCycle`, as shown above because this is required.
- Ensure you have providers, locations and courses in your database.
- In Publish, change `can_edit_current_and_next_cycles` in `development.local.yml` to `true`
- Navigate to a provider `organisations/{provider_code}` check that you can click on `Current cycle` but not `Next cycle`
- Run `bundle exec rake rollover:providers"[{provider_code}]" `
- Go back to the publish UI and check that you can now access the next cycle. Check all sections have been correctly rolled over.
- You can rollover all providers, however there is currently an ongoing issue with email validation which will cause issues. See [this trello ticket](https://trello.com/c/dYKWlDZq/1416-fix-validation-on-provider-email).


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
