### PR TITLE
[SPIKE][1757] Add interrupt page acknowledgments model and API

### DIFF
--- a/app/controllers/api/v2/interrupt_page_acknowledgements_controller.rb
+++ b/app/controllers/api/v2/interrupt_page_acknowledgements_controller.rb
@@ -1,0 +1,45 @@
+module API
+  module V2
+    class InterruptPageAcknowledgementsController < API::V2::ApplicationController
+      before_action :build_user
+      deserializable_resource :interrupt_page_acknowledgement, only: :create
+
+      def index
+       authorize @user
+
+       # TODO: policy scope?
+       interrupt_acknowledgements = @user.interrupt_page_acknowledgements
+         .where(recruitment_cycle: recruitment_cycle)
+
+        render jsonapi: paginate(interrupt_acknowledgements, per_page: 10),
+          meta: { count: interrupt_acknowledgements.count },
+          fields: { interrupt_acknowledgements: %i[type] }
+      end
+
+      def create
+        authorize @user
+
+        acknowledgement = InterruptPageAcknowledgement.find_or_initialize_by(
+          user_id: params[:user_id],
+          recruitment_cycle: recruitment_cycle,
+          page: params.dig(:interrupt_page_acknowledgement, :page)
+        )
+        if acknowledgement.save
+          render jsonapi: acknowledgement
+        else
+          render jsonapi_errors: acknowledgement.errors, status: :unprocessable_entity
+        end
+      end
+
+    private
+
+      def build_user
+        @user = User.find(params[:user_id])
+      end
+
+      def recruitment_cycle
+        RecruitmentCycle.find_by_year(params[:recruitment_cycle_year])
+      end
+    end
+  end
+end

--- a/app/models/interrupt_page_acknowledgement.rb
+++ b/app/models/interrupt_page_acknowledgement.rb
@@ -1,0 +1,8 @@
+class InterruptPageAcknowledgement < ApplicationRecord
+  belongs_to :user
+  belongs_to :recruitment_cycle
+
+  ALL_PAGES = %w[rollover rollover_recruitment].freeze
+
+  enum page: ALL_PAGES.zip(ALL_PAGES).to_h
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
            primary_key: :id,
            inverse_of: "requester"
 
+  has_many :interrupt_page_acknowledgements
+
   scope :admins, -> { where(admin: true) }
   scope :non_admins, -> { where.not(admin: true) }
   scope :active, -> { where.not(accept_terms_date_utc: nil) }

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -18,4 +18,6 @@ class UserPolicy
   alias_method :accept_transition_screen?, :update?
   alias_method :accept_rollover_screen?, :update?
   alias_method :accept_terms?, :update?
+  alias_method :index?, :show?
+  alias_method :create?, :update?
 end

--- a/app/serializers/api/v2/serializable_interrupt_page_acknowledgement.rb
+++ b/app/serializers/api/v2/serializable_interrupt_page_acknowledgement.rb
@@ -1,0 +1,11 @@
+module API
+  module V2
+    class SerializableInterruptPageAcknowledgement < JSONAPI::Serializable::Resource
+      type "interrupt_page_acknowledgements"
+      has_one :user
+      has_one :recruitment_cycle
+
+      attributes :page, :created_at, :updated_at
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,9 @@ Rails.application.routes.draw do
         resources :providers
         patch :accept_terms, on: :member
         patch :generate_and_send_magic_link, on: :collection
+        scope "/recruitment_cycles/:recruitment_cycle_year" do
+          resources :interrupt_page_acknowledgements, only: %i[index create]
+        end
       end
 
       get "providers/suggest", to: "providers#suggest"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_20_134402) do
+ActiveRecord::Schema.define(version: 2021_05_25_152034) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
@@ -187,6 +187,17 @@ ActiveRecord::Schema.define(version: 2021_04_20_134402) do
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "subject_knowledge_enhancement_course_available", default: false, null: false
     t.index ["subject_id"], name: "index_financial_incentive_on_subject_id"
+  end
+
+  create_table "interrupt_page_acknowledgement", force: :cascade do |t|
+    t.string "page", null: false
+    t.bigint "recruitment_cycle_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["page", "recruitment_cycle_id", "user_id"], name: "interrupt_page_all_column_idx", unique: true
+    t.index ["recruitment_cycle_id"], name: "index_interrupt_page_acknowledgement_on_recruitment_cycle_id"
+    t.index ["user_id"], name: "index_interrupt_page_acknowledgement_on_user_id"
   end
 
   create_table "nctl_organisation", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This will be used for determining if a user has accepted on interrupt
page on publish for that recruitment cycle

### Context

corresponding publish PR with more info https://github.com/DFE-Digital/publish-teacher-training/pull/1679

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
