### PR TITLE
[1785] Copy Allocations data into recruitment cycle 3

### DIFF
--- a/app/services/allocation_copy_data_service.rb
+++ b/app/services/allocation_copy_data_service.rb
@@ -1,0 +1,82 @@
+class AllocationCopyDataService
+  include ServicePattern
+
+  def initialize(allocation_cycle_year:, summary: false)
+    @allocation_cycle_year = allocation_cycle_year
+    @summary = summary
+  end
+
+  def call
+    copied = 0
+    skipped = 0
+
+    Allocation.where(recruitment_cycle_id: previous_allocation_cycle.id).find_each do |prev_alloc|
+      if prev_alloc.confirmed_number_of_places.to_i.zero? ||
+          allocation_exists?(prev_alloc)
+        skipped += 1
+      else
+        provider = find_provider(prev_alloc)
+        accredited_body = find_accredited_body(prev_alloc)
+        create_allocation(prev_alloc, provider, accredited_body)
+        copied += 1
+      end
+    end
+
+    if @summary
+      puts "###################################"
+      puts "## Allocation copying task complete"
+      puts "# copied: #{copied}"
+      puts "# skipped: #{skipped}"
+      puts "###################################"
+    end
+  end
+
+private
+
+  def create_allocation(prev_alloc, provider, accredited_body)
+    Allocation.create!(
+      provider_code: prev_alloc.provider_code,
+      accredited_body_code: prev_alloc.accredited_body_code,
+      recruitment_cycle_id: allocation_cycle.id,
+
+      provider_id: provider.id,
+      accredited_body_id: accredited_body.id,
+
+      number_of_places: prev_alloc.confirmed_number_of_places,
+      confirmed_number_of_places: nil,
+    )
+  end
+
+  def find_provider(prev_alloc)
+    # Fetch new provider with same code for current recruitment cycle
+    Provider.where(
+      provider_code: prev_alloc.provider_code,
+      recruitment_cycle_id: allocation_cycle.id,
+    ).first!
+  end
+
+  def find_accredited_body(prev_alloc)
+    # Fetch new accredited_body with same code for current recruitment cycle
+    Provider.where(
+      provider_code: prev_alloc.accredited_body_code,
+      recruitment_cycle_id: allocation_cycle.id,
+      accrediting_provider: :accredited_body,
+    ).first!
+  end
+
+  def allocation_exists?(prev_alloc)
+    Allocation.where(
+      provider_code: prev_alloc.provider_code,
+      accredited_body_code: prev_alloc.accredited_body_code,
+      recruitment_cycle_id: allocation_cycle.id,
+    ).exists?
+  end
+
+  def allocation_cycle
+    @allocation_cycle ||= RecruitmentCycle.where(year: @allocation_cycle_year).first!
+  end
+
+  def previous_allocation_cycle
+    allocation_cycle.previous
+  end
+end

--- a/lib/tasks/allocations.rake
+++ b/lib/tasks/allocations.rake
@@ -1,0 +1,7 @@
+namespace :allocations do
+  desc "Copy previous allocations data to allocation cycle year: rake allocations:copy_allocations_data_to_cycle_year"
+  task :copy_allocations_data_to_cycle_year, [:allocation_cycle_year] => :environment do |_task, args|
+    raise "Requires allocation cycle year" if args[:allocation_cycle_year].to_i.zero?
+    AllocationCopyDataService.call(allocation_cycle_year: args[:allocation_cycle_year], summary: true)
+  end
+end

--- a/lib/tasks/backfill_urns_and_ukprns.rake
+++ b/lib/tasks/backfill_urns_and_ukprns.rake
@@ -16,4 +16,3 @@ task backfill_provider_sites_with_urn: :environment do
     site.update(urn: row["establishment_urn"]) if site
   end
 end
-

--- a/spec/services/allocation_copy_data_service_spec.rb
+++ b/spec/services/allocation_copy_data_service_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+describe AllocationCopyDataService do
+  let!(:previous_cycle) { RecruitmentCycle.where(year: 2020).first || create(:recruitment_cycle, year: 2020) }
+  let!(:current_cycle) { RecruitmentCycle.where(year: 2021).first || create(:recruitment_cycle, year: 2021) }
+
+  let!(:provider1a) { create(:provider, :accredited_body, recruitment_cycle: previous_cycle) }
+  let!(:provider1b) { create(:provider, :accredited_body, recruitment_cycle: current_cycle, provider_code: provider1a.provider_code) }
+
+  let!(:provider2a) { create(:provider, recruitment_cycle: previous_cycle) }
+  let!(:provider2b) { create(:provider, recruitment_cycle: current_cycle, provider_code: provider2a.provider_code) }
+
+  let!(:allocation1) {
+    create(:allocation,
+           recruitment_cycle: previous_cycle, provider: provider1a, accredited_body: provider1a,
+             number_of_places: 5, confirmed_number_of_places: 5)
+  }
+  let!(:allocation2) {
+    create(:allocation,
+           recruitment_cycle: previous_cycle, provider: provider2a, accredited_body: provider1a,
+             number_of_places: 10, confirmed_number_of_places: 10)
+  }
+
+
+  it "copies over previous allocations to current allocation year" do
+    expect(Provider.count).to eql(4)
+    expect(Allocation.count).to eql(2)
+
+    a1 = Allocation.where(provider_code: provider1a.provider_code).first
+    expect(a1.provider.id).to eql(provider1a.id)
+    expect(a1.accredited_body.id).to eql(provider1a.id)
+    expect(a1.recruitment_cycle.id).to eql(previous_cycle.id)
+
+    a2 = Allocation.where(provider_code: provider2a.provider_code).first
+    expect(a2.provider.id).to eql(provider2a.id)
+    expect(a2.accredited_body.id).to eql(provider1a.id)
+    expect(a2.recruitment_cycle.id).to eql(previous_cycle.id)
+
+    current_cycle = RecruitmentCycle.where(year: 2021).first!
+    expect(current_cycle.previous.year).to eql("2020")
+
+    AllocationCopyDataService.call(allocation_cycle_year: current_cycle.year)
+    expect(Allocation.count).to eql(4)
+    expect(Allocation.where(recruitment_cycle_id: current_cycle.id).count).to eql(2)
+
+    b1 = Allocation.where(provider_code: provider1a.provider_code, recruitment_cycle_id: current_cycle.id).first
+    expect(b1.provider_id).to eql(provider1b.id)
+    expect(b1.accredited_body_id).to eql(provider1b.id)
+    expect(b1.provider_code).to eql(provider1a.provider_code)
+    expect(b1.accredited_body_code).to eql(provider1a.provider_code)
+    expect(b1.number_of_places).to eql(allocation1.confirmed_number_of_places)
+    expect(b1.confirmed_number_of_places).to be_nil
+
+    b2 = Allocation.where(provider_code: provider2a.provider_code, recruitment_cycle_id: current_cycle.id).first
+    expect(b2.provider_id).to eql(provider2b.id)
+    expect(b2.accredited_body_id).to eql(provider1b.id)
+    expect(b2.provider_code).to eql(provider2a.provider_code)
+    expect(b2.accredited_body_code).to eql(provider1a.provider_code)
+    expect(b2.number_of_places).to eql(allocation2.confirmed_number_of_places)
+    expect(b2.confirmed_number_of_places).to be_nil
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/sJvRcyC6/1785-copy-allocations-data-into-recruitment-cycle-3

### Changes proposed in this pull request

* Rake task `allocations:copy_allocations_data_to_cycle_year` to copy allocations from previous allocation year to current allocation year

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
