### PR TITLE
Prevent rake task printing out puts statement during tests

### DIFF
--- a/app/services/recruitment_cycle_creation_service.rb
+++ b/app/services/recruitment_cycle_creation_service.rb
@@ -1,15 +1,18 @@
 class RecruitmentCycleCreationService
   include ServicePattern
 
-  def initialize(year:, application_start_date:, application_end_date:)
+  def initialize(year:, application_start_date:, application_end_date:, summary: false)
     @year = year
     @application_start_date = application_start_date
     @application_end_date = application_end_date
+    @summary = summary
   end
 
   def call
     RecruitmentCycle.create!(year: @year, application_start_date: @application_start_date, application_end_date: @application_end_date)
 
-    puts "The new RecruitmentCycle has been successfully created for:\n\nyear: '#{@year}'\napplication_start_date: '#{@application_start_date}'\napplication_end_date: '#{@application_end_date}'\n\n"
+    if @summary
+      puts "The new RecruitmentCycle has been successfully created for:\n\nyear: '#{@year}'\napplication_start_date: '#{@application_start_date}'\napplication_end_date: '#{@application_end_date}'\n\n"
+    end
   end
 end

--- a/lib/tasks/rollover.rake
+++ b/lib/tasks/rollover.rake
@@ -7,6 +7,6 @@ namespace :rollover do
 
   desc "Create a new recruitment cycle"
   task :create_recruitment_cycle, %i[year application_start_date application_end_date] => :environment do |_task, args|
-    RecruitmentCycleCreationService.call(year: args[:year], application_start_date: args[:application_start_date], application_end_date: args[:application_end_date])
+    RecruitmentCycleCreationService.call(year: args[:year], application_start_date: args[:application_start_date], application_end_date: args[:application_end_date], summary: true)
   end
 end


### PR DESCRIPTION
### Context

Prevent rake task printing out puts statement when running the specs.

### Guidance to review

- Run `recruitment_cycle_creation_service_spec.rb` and ensure the puts statement is not displayed
- Ensure the rake task still works as expected

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
