### PR TITLE
Update setting to open allocations 2021

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,7 +29,7 @@ authentication:
   subject: "access"
 
 current_recruitment_cycle_year: 2021
-allocation_cycle_year: 2020
+allocation_cycle_year: 2021
 govuk_notify:
   api_key: please_change_me
   welcome_email_template_id: 42a9723d-b5a1-413a-89e6-bbdd073373ab

--- a/spec/config/settings_spec.rb
+++ b/spec/config/settings_spec.rb
@@ -9,6 +9,6 @@ describe Settings do
     its(%w[authentication algorithm]) { should eq "HS256" }
     its(%w[authentication secret]) { should eq "<%= SecureRandom.base64 %>" }
     its(%w[current_recruitment_cycle_year]) { should eq 2021 }
-    its(%w[allocation_cycle_year]) { should eq 2020 }
+    its(%w[allocation_cycle_year]) { should eq 2021 }
   end
 end


### PR DESCRIPTION
### Context

Allocations opened on 1 June 2021.

https://trello.com/c/yNzAoH7Q/1823-open-allocations-2021

### Changes proposed in this pull request

Update the setting to open the new allocations year.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
