### PR TITLE
[1905] Allow requests for last year allocations on v2 API

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -49,7 +49,7 @@ module API
       end
 
       def destroy
-        authorize @allocation = current_recruitment_cycle.allocations.find(params[:id])
+        authorize @allocation = recruitment_cycle.allocations.find(params[:id])
 
         if @allocation.destroy
           head :ok
@@ -60,14 +60,16 @@ module API
 
     private
 
-      def current_recruitment_cycle
-        @current_recruitment_cycle ||= RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR)
+      def recruitment_cycle
+        @recruitment_cycle ||= RecruitmentCycle.find_by(
+          year: params[:recruitment_cycle_year],
+        ) || RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR)
       end
 
       def accredited_body
         @accredited_body ||= begin
                                accredited_body_code = params[:provider_code]
-                               current_recruitment_cycle.providers.find_by!(provider_code: accredited_body_code)
+                               recruitment_cycle.providers.find_by!(provider_code: accredited_body_code)
                              end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,6 +91,7 @@ Rails.application.routes.draw do
                   only: %i[index show update],
                   param: :code,
                   concerns: :provider_routes do
+          resources :allocations, only: %i[index]
           member do
             get :show_any
           end


### PR DESCRIPTION
### Context

https://trello.com/c/BQ6F49Q6/1905-providers-unable-to-confirm-last-years-allocations

To be deployed before: https://github.com/DFE-Digital/publish-teacher-training/pull/1711

### Changes proposed in this pull request

This PR allows publish to request allocations made by an accredited body in the previous recruitment cycle.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
