### PR TITLE
[1916] Added backlink to the provider show page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,6 +43,9 @@
     ) %>
 
     <div class="govuk-width-container">
+      <div class="govuk-width-container">
+        <%= yield :breadcrumbs %>
+      </div>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-width-container">
 

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -1,6 +1,13 @@
 <%= extends_layout :application do %>
-  <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
+  <%= content_for(:breadcrumbs) do %>
+    <%= render GovukComponent::BackLink.new(
+      text: 'All provider records',
+      href: support_providers_path,
+    ) %>
+  <% end %>
   
+  <h1 class="govuk-heading-l"><%= @provider.provider_name %></h1>
+
   <%= render TabNavigation::View.new(items: [
     { name: "Details", url: support_provider_path(@provider) },
     { name: "Users", url: users_support_provider_path(@provider) },


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/0vlooAj5/1916-s-back-link-on-provider-show)

### Changes proposed in this pull request

- Added a backlink to take users back to the provider list page

### Guidance to review

- Start up rails server `SETTINGS__USE_SSL=1 rails s`
- Direct yourself to support console `https://localhost:3001/support/providers`
- Click on any provider
- At the top of the page above the provider name you should be able to see a backlink

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
