### PR TITLE
Expose the structured degree fields on the V2 API

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -289,7 +289,11 @@ module API
                   :course_code,
                   :subjects_ids,
                   :subjects_types,
-                  :level)
+                  :level,
+                  :degree_grade,
+                  :additional_degree_subject_requirements,
+                  :degree_subject_requirements,
+                )
           .permit(
             :about_course,
             :course_length,

--- a/app/deserializers/api/v2/deserializable_course.rb
+++ b/app/deserializers/api/v2/deserializable_course.rb
@@ -30,6 +30,9 @@ module API
         accredited_body_code
         funding_type
         level
+        degree_grade
+        additional_degree_subject_requirements
+        degree_subject_requirements
       ].freeze
 
       attributes(*COURSE_ATTRIBUTES)

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -68,6 +68,9 @@ private
       accredited_body_code
       funding_type
       level
+      degree_grade
+      additional_degree_subject_requirements
+      degree_subject_requirements
     ]
   end
 

--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -18,7 +18,9 @@ module API
                  :content_status, :ucas_status, :funding_type,
                  :level, :is_send?, :english, :maths, :science, :gcse_subjects_required,
                  :age_range_in_years, :accrediting_provider,
-                 :accredited_body_code, :level
+                 :accredited_body_code, :level, :degree_grade,
+                 :additional_degree_subject_requirements,
+                 :degree_subject_requirements
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -22,6 +22,9 @@ FactoryBot.define do
         to: DateTime.new(provider.recruitment_cycle.year.to_i, 9, 29),
       )
     }
+    degree_grade { :two_one }
+    additional_degree_subject_requirements { true }
+    degree_subject_requirements { Faker::Lorem.sentence.to_s }
 
     trait :without_validation do
       to_create { |instance| instance.save(validate: false) }

--- a/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
@@ -26,28 +26,28 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   let(:payload)           { { email: user.email } }
   let(:credentials)       { encode_to_credentials(payload) }
 
-  let(:course)            {
+  let(:course)            do
     create :course,
            provider: provider,
            additional_degree_subject_requirements: true
-  }
+  end
   let(:permitted_params) do
     %i[additional_degree_subject_requirements]
   end
 
-  before do
-    perform_request(updated_additional_degree_subject_requirements)
-  end
-
   context "course has an updated_additional_degree_subject_requirements" do
-    let(:updated_additional_degree_subject_requirements) { { additional_degree_subject_requirements: false} }
+    let(:updated_additional_degree_subject_requirements) { { additional_degree_subject_requirements: false } }
 
     it "returns http success" do
+      perform_request(updated_additional_degree_subject_requirements)
       expect(response).to have_http_status(:success)
     end
 
     it "updates the updated_additional_degree_subject_requirements attribute to the correct value" do
-      expect(course.reload.additional_degree_subject_requirements).to eq(updated_additional_degree_subject_requirements[:additional_degree_subject_requirements])
+      expect {
+        perform_request(updated_additional_degree_subject_requirements)
+      }.to change { course.reload.additional_degree_subject_requirements }
+             .from(true).to(false)
     end
   end
 
@@ -56,11 +56,15 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       let(:updated_additional_degree_subject_requirements) { { additional_degree_subject_requirements: true } }
 
       it "returns http success" do
+        perform_request(updated_additional_degree_subject_requirements)
         expect(response).to have_http_status(:success)
       end
 
       it "does not change updated_additional_degree_subject_requirements attribute" do
-        expect(course.reload.additional_degree_subject_requirements).to eq(updated_additional_degree_subject_requirements[:additional_degree_subject_requirements])
+        expect {
+          perform_request(updated_additional_degree_subject_requirements)
+        }.to_not change { course.reload.additional_degree_subject_requirements }
+             .from(true)
       end
     end
   end
@@ -68,17 +72,16 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   context "with no values passed into the params" do
     let(:updated_additional_degree_subject_requirements) { {} }
 
-    before do
-      @additional_degree_subject_requirements = course.additional_degree_subject_requirements
-      perform_request(updated_additional_degree_subject_requirements)
-    end
-
     it "returns http success" do
+      perform_request(updated_additional_degree_subject_requirements)
       expect(response).to have_http_status(:success)
     end
 
     it "does not change updated_additional_degree_subject_requirements attribute" do
-      expect(course.reload.additional_degree_subject_requirements).to eq(@additional_degree_subject_requirements)
+      expect {
+        perform_request(updated_additional_degree_subject_requirements)
+      }.to_not change { course.reload.additional_degree_subject_requirements }
+           .from(true)
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe "PATCH /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_additional_degree_subject_requirements)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+
+    jsonapi_data[:data][:attributes] = updated_additional_degree_subject_requirements
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { "HTTP_AUTHORIZATION" => credentials },
+          params: {
+            _jsonapi: jsonapi_data,
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:credentials)       { encode_to_credentials(payload) }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           additional_degree_subject_requirements: true
+  }
+  let(:permitted_params) do
+    %i[additional_degree_subject_requirements]
+  end
+
+  before do
+    perform_request(updated_additional_degree_subject_requirements)
+  end
+
+  context "course has an updated_additional_degree_subject_requirements" do
+    let(:updated_additional_degree_subject_requirements) { { additional_degree_subject_requirements: false} }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the updated_additional_degree_subject_requirements attribute to the correct value" do
+      expect(course.reload.additional_degree_subject_requirements).to eq(updated_additional_degree_subject_requirements[:additional_degree_subject_requirements])
+    end
+  end
+
+  context "course has the same updated_additional_degree_subject_requirements" do
+    context "with values passed into the params" do
+      let(:updated_additional_degree_subject_requirements) { { additional_degree_subject_requirements: true } }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change updated_additional_degree_subject_requirements attribute" do
+        expect(course.reload.additional_degree_subject_requirements).to eq(updated_additional_degree_subject_requirements[:additional_degree_subject_requirements])
+      end
+    end
+  end
+
+  context "with no values passed into the params" do
+    let(:updated_additional_degree_subject_requirements) { {} }
+
+    before do
+      @additional_degree_subject_requirements = course.additional_degree_subject_requirements
+      perform_request(updated_additional_degree_subject_requirements)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change updated_additional_degree_subject_requirements attribute" do
+      expect(course.reload.additional_degree_subject_requirements).to eq(@additional_degree_subject_requirements)
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/update_age_range_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_age_range_spec.rb
@@ -33,7 +33,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   }
   let(:age_range_in_years) { "3_to_7" }
   let(:permitted_params) do
-    %i[updated_age_range_in_years]
+    %i[age_range_in_years]
   end
 
   before do
@@ -41,7 +41,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   end
 
   context "course has an updated age range in years" do
-    let(:updated_age_range_in_years) { { age_range_in_years: "3_to_7" } }
+    let(:updated_age_range_in_years) { { age_range_in_years: "8_to_12" } }
 
     it "returns http success" do
       expect(response).to have_http_status(:success)

--- a/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe "PATCH /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_degree_grade)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+
+    jsonapi_data[:data][:attributes] = updated_degree_grade
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { "HTTP_AUTHORIZATION" => credentials },
+          params: {
+            _jsonapi: jsonapi_data,
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:credentials)       { encode_to_credentials(payload) }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           degree_grade: "two_one"
+  }
+  let(:permitted_params) do
+    %i[degree_grade]
+  end
+
+  before do
+    perform_request(updated_degree_grade)
+  end
+
+  context "course has an updated_degree_grade" do
+    let(:updated_degree_grade) { { degree_grade: "two_two" } }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the updated_degree_grade attribute to the correct value" do
+      expect(course.reload.degree_grade).to eq(updated_degree_grade[:degree_grade])
+    end
+  end
+
+  context "course has the same updated_degree_grade" do
+    context "with values passed into the params" do
+      let(:updated_degree_grade) { { degree_grade: "two_one" } }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change updated_degree_grade attribute" do
+        expect(course.reload.degree_grade).to eq(updated_degree_grade[:degree_grade])
+      end
+    end
+  end
+
+  context "with no values passed into the params" do
+    let(:updated_degree_grade) { {} }
+
+    before do
+      @degree_grade = course.degree_grade
+      perform_request(updated_degree_grade)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change updated_degree_grade attribute" do
+      expect(course.reload.degree_grade).to eq(@degree_grade)
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
@@ -35,19 +35,19 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     %i[degree_grade]
   end
 
-  before do
-    perform_request(updated_degree_grade)
-  end
-
   context "course has an updated_degree_grade" do
     let(:updated_degree_grade) { { degree_grade: "two_two" } }
 
     it "returns http success" do
+      perform_request(updated_degree_grade)
       expect(response).to have_http_status(:success)
     end
 
     it "updates the updated_degree_grade attribute to the correct value" do
-      expect(course.reload.degree_grade).to eq(updated_degree_grade[:degree_grade])
+      expect {
+        perform_request(updated_degree_grade)
+      }.to change { course.reload.degree_grade }
+             .from("two_one").to("two_two")
     end
   end
 
@@ -56,11 +56,15 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       let(:updated_degree_grade) { { degree_grade: "two_one" } }
 
       it "returns http success" do
+        perform_request(updated_degree_grade)
         expect(response).to have_http_status(:success)
       end
 
       it "does not change updated_degree_grade attribute" do
-        expect(course.reload.degree_grade).to eq(updated_degree_grade[:degree_grade])
+        expect {
+          perform_request(updated_degree_grade)
+        }.to_not change { course.reload.degree_grade }
+             .from("two_one")
       end
     end
   end
@@ -68,17 +72,16 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   context "with no values passed into the params" do
     let(:updated_degree_grade) { {} }
 
-    before do
-      @degree_grade = course.degree_grade
-      perform_request(updated_degree_grade)
-    end
-
     it "returns http success" do
+      perform_request(updated_degree_grade)
       expect(response).to have_http_status(:success)
     end
 
     it "does not change updated_degree_grade attribute" do
-      expect(course.reload.degree_grade).to eq(@degree_grade)
+      expect {
+        perform_request(updated_degree_grade)
+      }.to_not change { course.reload.degree_grade }
+           .from("two_one")
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe "PATCH /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_degree_subject_requirements)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+
+    jsonapi_data[:data][:attributes] = updated_degree_subject_requirements
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { "HTTP_AUTHORIZATION" => credentials },
+          params: {
+            _jsonapi: jsonapi_data,
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:credentials)       { encode_to_credentials(payload) }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           degree_subject_requirements: "Must have a Maths A level."
+  }
+  let(:permitted_params) do
+    %i[degree_subject_requirements]
+  end
+
+  before do
+    perform_request(updated_degree_subject_requirements)
+  end
+
+  context "course has an updated_degree_subject_requirements" do
+    let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Physics A level." } }
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the updated_degree_subject_requirements attribute to the correct value" do
+      expect(course.reload.degree_subject_requirements).to eq(updated_degree_subject_requirements[:degree_subject_requirements])
+    end
+  end
+
+  context "course has the same updated_degree_subject_requirements" do
+    context "with values passed into the params" do
+      let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Maths A level." } }
+
+      it "returns http success" do
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change updated_degree_subject_requirements attribute" do
+        expect(course.reload.degree_subject_requirements).to eq(updated_degree_subject_requirements[:degree_subject_requirements])
+      end
+    end
+  end
+
+  context "with no values passed into the params" do
+    let(:updated_degree_subject_requirements) { {} }
+
+    before do
+      @degree_subject_requirements = course.degree_subject_requirements
+      perform_request(updated_degree_subject_requirements)
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change updated_degree_subject_requirements attribute" do
+      expect(course.reload.degree_subject_requirements).to eq(@degree_subject_requirements)
+    end
+  end
+end

--- a/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
@@ -35,19 +35,19 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     %i[degree_subject_requirements]
   end
 
-  before do
-    perform_request(updated_degree_subject_requirements)
-  end
-
   context "course has an updated_degree_subject_requirements" do
     let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Physics A level." } }
 
     it "returns http success" do
+      perform_request(updated_degree_subject_requirements)
       expect(response).to have_http_status(:success)
     end
 
     it "updates the updated_degree_subject_requirements attribute to the correct value" do
-      expect(course.reload.degree_subject_requirements).to eq(updated_degree_subject_requirements[:degree_subject_requirements])
+      expect {
+        perform_request(updated_degree_subject_requirements)
+      }.to change { course.reload.degree_subject_requirements }
+            .from("Must have a Maths A level.").to("Must have a Physics A level.")
     end
   end
 
@@ -56,11 +56,15 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Maths A level." } }
 
       it "returns http success" do
+        perform_request(updated_degree_subject_requirements)
         expect(response).to have_http_status(:success)
       end
 
       it "does not change updated_degree_subject_requirements attribute" do
-        expect(course.reload.degree_subject_requirements).to eq(updated_degree_subject_requirements[:degree_subject_requirements])
+        expect {
+          perform_request(updated_degree_subject_requirements)
+        }.to_not change { course.reload.degree_subject_requirements }
+             .from("Must have a Maths A level.")
       end
     end
   end
@@ -68,17 +72,16 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   context "with no values passed into the params" do
     let(:updated_degree_subject_requirements) { {} }
 
-    before do
-      @degree_subject_requirements = course.degree_subject_requirements
-      perform_request(updated_degree_subject_requirements)
-    end
-
     it "returns http success" do
+      perform_request(updated_degree_subject_requirements)
       expect(response).to have_http_status(:success)
     end
 
     it "does not change updated_degree_subject_requirements attribute" do
-      expect(course.reload.degree_subject_requirements).to eq(@degree_subject_requirements)
+      expect {
+        perform_request(updated_degree_subject_requirements)
+      }.to_not change { course.reload.degree_subject_requirements }
+           .from("Must have a Maths A level.")
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -145,6 +145,9 @@ describe "Courses API v2", type: :request do
                 "age_range_in_years" => provider.courses[0].age_range_in_years,
                 "accrediting_provider" => nil,
                 "accredited_body_code" => nil,
+                "degree_grade" =>  provider.courses[0].degree_grade,
+                "additional_degree_subject_requirements" => provider.courses[0].additional_degree_subject_requirements,
+                "degree_subject_requirements" => provider.courses[0].degree_subject_requirements,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },
@@ -718,6 +721,9 @@ describe "Courses API v2", type: :request do
               "age_range_in_years" => provider.courses[0].age_range_in_years,
               "accrediting_provider" => nil,
               "accredited_body_code" => nil,
+              "degree_grade" =>  provider.courses[0].degree_grade,
+              "additional_degree_subject_requirements" => provider.courses[0].additional_degree_subject_requirements,
+              "degree_subject_requirements" => provider.courses[0].degree_subject_requirements,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -33,6 +33,10 @@ describe API::V2::SerializableCourse do
   it { should have_attribute :provider_code }
   it { should have_attribute :age_range_in_years }
   it { should have_attribute(:recruitment_cycle_year).with_value(course.recruitment_cycle.year) }
+  it { should have_attribute(:degree_grade).with_value(course.degree_grade) }
+  it { should have_attribute(:additional_degree_subject_requirements).with_value(course.additional_degree_subject_requirements) }
+  it { should have_attribute(:degree_subject_requirements).with_value(course.degree_subject_requirements) }
+
 
   context "with a provider" do
     let(:provider) { course.provider }


### PR DESCRIPTION
### Context

This PR follows on from #1967 which adds the `degree_grade` and `subject_requirements`  columns to the course table.

It does the work to expose the new attrs on the V2 API via the CourseSerailiser

### Changes proposed in this pull request

This PR does the following:

1. Adds the new fields to the course factory
2. Updates the serialiser to expose them
3. Adds them to the deserialiser
4. Updates the controllers course_params and enrichment_params methods
5. Updates the course policy
6. Updates the course show request spec

### Guidance to review

https://trello.com/c/KAPUFr0o/3494-add-structured-degree-requirements-fields-to-the-v2-ttapi

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
