### PR TITLE
Permit visa attributes in V2 provider updates

### DIFF
--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -134,7 +134,7 @@ module API
       end
 
       def update_provider
-        return unless provider_params.values.any?
+        return if provider_params.values.all?(&:nil?)
 
         @provider.assign_attributes(provider_params)
         @provider.save

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -187,6 +187,8 @@ module API
             :send_application_alerts,
             :ukprn,
             :urn,
+            :can_sponsor_skilled_worker_visa,
+            :can_sponsor_student_visa,
           )
           .permit(accredited_bodies: %i[provider_code provider_name description])
       end
@@ -231,6 +233,8 @@ module API
             :send_application_alerts,
             :ukprn,
             :urn,
+            :can_sponsor_skilled_worker_visa,
+            :can_sponsor_student_visa,
           )
           .permit(
             admin_contact: %w[name email telephone permission_given],
@@ -265,6 +269,8 @@ module API
             :region_code,
             :ukprn,
             :urn,
+            :can_sponsor_skilled_worker_visa,
+            :can_sponsor_student_visa,
           )
           .permit(
             :type_of_gt12,

--- a/app/deserializers/api/v2/deserializable_provider.rb
+++ b/app/deserializers/api/v2/deserializable_provider.rb
@@ -26,6 +26,8 @@ module API
         application_alert_contact
         ukprn
         urn
+        can_sponsor_skilled_worker_visa
+        can_sponsor_student_visa
       ].freeze
 
       attributes(*PROVIDER_ATTRIBUTES)

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -86,6 +86,8 @@ private
       postcode
       region_code
       ukprn
+      can_sponsor_skilled_worker_visa
+      can_sponsor_student_visa
     ]
     provider.lead_school? ? base_attributes << :urn : base_attributes
   end

--- a/spec/controllers/api/v2/providers_controller_spec.rb
+++ b/spec/controllers/api/v2/providers_controller_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe API::V2::ProvidersController do
   describe "#update" do
     context "when user is not an admin" do
       let(:user) { provider.users.first }
-      let(:provider) { course.provider }
-      let(:course) { create(:course) }
+      let(:provider) { create(:provider, can_sponsor_student_visa: true, can_sponsor_skilled_worker_visa: false) }
+      let(:course) { create(:course, provider: provider) }
 
       it "cannot update provider_name" do
         expect {
@@ -71,6 +71,20 @@ RSpec.describe API::V2::ProvidersController do
                 },
               }
         }.to raise_error(ActionController::UnpermittedParameters)
+      end
+
+      it "can update the visa sponsorship attributes" do
+        put :update,
+            params: {
+              code: provider.provider_code,
+              provider: {
+                can_sponsor_student_visa: false,
+                can_sponsor_skilled_worker_visa: true,
+              },
+            }
+
+        expect(provider.reload.can_sponsor_student_visa).to be(false)
+        expect(provider.reload.can_sponsor_skilled_worker_visa).to be(true)
       end
     end
 

--- a/spec/requests/api/v2/providers/update_spec.rb
+++ b/spec/requests/api/v2/providers/update_spec.rb
@@ -35,7 +35,9 @@ describe "PATCH /providers/:provider_code" do
     create :provider,
            organisations: [organisation],
            recruitment_cycle: recruitment_cycle,
-           courses: [course1]
+           courses: [course1],
+           can_sponsor_student_visa: false,
+           can_sponsor_skilled_worker_visa: false
   end
   let(:user)         { create :user, organisations: [organisation] }
   let(:payload)      { { email: user.email } }
@@ -59,6 +61,8 @@ describe "PATCH /providers/:provider_code" do
       train_with_disability: "train with disability",
       ukprn: "12345678",
       urn: "12345",
+      can_sponsor_student_visa: true,
+      can_sponsor_skilled_worker_visa: false,
     }
   end
   let(:permitted_params) do
@@ -76,6 +80,8 @@ describe "PATCH /providers/:provider_code" do
       train_with_disability
       ukprn
       urn
+      can_sponsor_student_visa
+      can_sponsor_skilled_worker_visa
     ]
   end
 
@@ -106,6 +112,8 @@ describe "PATCH /providers/:provider_code" do
       expect(json_response).to have_attribute(:train_with_disability).with_value("train with disability")
       expect(json_response).to have_attribute(:ukprn).with_value("12345678")
       expect(json_response).to have_attribute(:urn).with_value("12345")
+      expect(json_response).to have_attribute(:can_sponsor_student_visa).with_value(true)
+      expect(json_response).to have_attribute(:can_sponsor_skilled_worker_visa).with_value(false)
     end
   end
   describe "with unpermitted attributes on provider object" do


### PR DESCRIPTION

### Context

This is needed for Publish to be able to manage these new attributes. `Provider` attributes `can_sponsor_student_visa` and `can_sponsor_skilled_worker_visa` were added recently so that providers could declare information about the kind of visas they sponsor. This PR just attempts to make those attributes accessible via the `/api/v2/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code` endpoint.

https://trello.com/c/I2K4fchq/3441-add-visa-flow-to-publish

### Changes proposed in this pull request

- [x] Add `can_sponsor_student_visa` and `can_sponsor_skilled_worker_visa` to permitted params in `Api::V2::ProvidersController#update` (via `ProviderPolicy`)
- [x] Add `can_sponsor_student_visa` and `can_sponsor_skilled_worker_visa` to `DeserializableProvider` so that are received by the controller.

### Guidance to review

- I had to add the new attributes to the `except` lists for a few other `update_*` methods because they are all called from the same action and leaving as is causes an unsupported param exception.
- I couldn't see an obvious place to put a high-level spec that tests this particular feature other than `spec/features/api/v2/providers/update_spec.rb`. Have I missed something here?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
