### PR TITLE
[1949] Fix sentry reporting in controllers

### DIFF
--- a/app/controllers/concerns/error_handlers/base.rb
+++ b/app/controllers/concerns/error_handlers/base.rb
@@ -3,8 +3,10 @@ module ErrorHandlers
     extend ActiveSupport::Concern
 
     included do
-      if Rails.env.production?
-        rescue_from(StandardError) { render_json_error(status: 500) }
+      rescue_from(StandardError) do |e|
+        raise e unless Settings.render_json_errors
+        Sentry.capture_exception(e)
+        render_json_error(status: 500)
       end
 
       rescue_from(ActiveRecord::RecordNotFound) { render_json_error(status: 404) }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -55,3 +55,4 @@ skylight:
   authentication: please_change_me
 mapit_api_key: please_change_me
 mapit_url: https://mapit.mysociety.org
+render_json_errors: false

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -21,3 +21,4 @@ skylight:
   enable: true
 environment:
   name: "beta"
+render_json_errors: true

--- a/spec/controllers/concerns/error_handlers_base_spec.rb
+++ b/spec/controllers/concerns/error_handlers_base_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe ErrorHandlers::Base, type: :controller do
+  controller(ActionController::Base) do
+    include ErrorHandlers::Base
+
+    def error
+      raise hell
+    end
+  end
+
+
+  before do
+    allow(Settings).to receive(:render_json_errors).and_return(render_json_errors)
+
+    routes.draw {
+      get 'error' => 'anonymous#error'
+    }
+  end
+
+  context "when json error reporting is enabled" do
+    let(:render_json_errors) { true }
+
+    it "sends the error to sentry" do
+      expect(Sentry).to receive(:capture_exception).with(NameError)
+      get :error
+    end
+
+    it "renders some nice json" do
+      get :error
+      expect(response.content_type).to include "application/json"
+      expect(JSON.parse(response.body)).to match(
+        "errors" => [
+          "status" => 500,
+          "title" => a_string_including("ERROR"),
+          "detail" => a_string_including("gone wrong"),
+        ]
+      )
+    end
+  end
+
+  context "when json error reporting is disabled" do
+    let(:render_json_errors) { false }
+
+    # Sentry will capure and report this in middleware (which isn't included in controller tests)
+    it "doesn't swallow the error" do
+      expect { get :error }.to raise_error(NameError)
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/4cI5XPmN/1949-ttapi-is-not-reporting-errors-to-sentry-in-production

### Changes proposed in this pull request

Previously we were swallowing exceptions in production using
rescue_from and not capturing them in sentry. Make this configurable
and make sure that sentry is notified

### Guidance to review

If you don't believe this works, I can screen share with some prys stuck inside the sentry-ruby gem to show the behaviour before and after this PR

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
