### PR TITLE
Revert "Bump pagy from 3.13.0 to 4.8.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "active_model_serializers"
 gem "kaminari"
 
 # Pagination for API
-gem "pagy", "~> 4.8"
+gem "pagy", "~> 3.13"
 
 # JSON:API Ruby Client
 gem "jsonapi-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,7 +338,7 @@ GEM
       validate_url
       webfinger (>= 1.0.1)
     optimist (3.0.1)
-    pagy (4.8.0)
+    pagy (3.13.0)
     parallel (1.20.1)
     parallel_tests (3.7.0)
       parallel
@@ -632,7 +632,7 @@ DEPENDENCIES
   open_api-rswag-api
   open_api-rswag-specs
   open_api-rswag-ui
-  pagy (~> 4.8)
+  pagy (~> 3.13)
   parallel_tests
   pg
   pg_search


### PR DESCRIPTION
Reverts DFE-Digital/teacher-training-api#1966

Mystery as to why the CI passed on this PR, it broke when merged into master