### PR TITLE
[1918] Fixed by allowing allocation to return current and previous allocation year

### DIFF
--- a/app/controllers/api/v2/allocations_controller.rb
+++ b/app/controllers/api/v2/allocations_controller.rb
@@ -7,7 +7,8 @@ module API
       def index
         authorize Allocation
 
-        scope = Allocation.where(accredited_body_id: accredited_body.id)
+        scope = Allocation.where(accredited_body_code: accredited_body.provider_code,
+                                 recruitment_cycle: [@recruitment_cycle.previous, @recruitment_cycle])
 
         if params[:filter] && params[:filter][:training_provider_code]
           scope = scope.where(provider_code: params[:filter][:training_provider_code])
@@ -61,9 +62,7 @@ module API
     private
 
       def recruitment_cycle
-        @recruitment_cycle ||= RecruitmentCycle.find_by(
-          year: params[:recruitment_cycle_year],
-        ) || RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR)
+        @recruitment_cycle ||= RecruitmentCycle.find_by(year: Allocation::ALLOCATION_CYCLE_YEAR)
       end
 
       def accredited_body
@@ -90,7 +89,7 @@ module API
           )
       end
 
-      # TODO remove when publish is doing the right thing
+      # TODO: remove when publish is doing the right thing
       def get_request_type(permitted_params)
         return permitted_params[:request_type] if permitted_params[:request_type].present?
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,7 +90,6 @@ Rails.application.routes.draw do
                   only: %i[index show update],
                   param: :code,
                   concerns: :provider_routes do
-          resources :allocations, only: %i[index]
           member do
             get :show_any
           end


### PR DESCRIPTION
### Context

Retrieval of allocations

### Changes proposed in this pull request
Allow the retrieval of allocations using recruitment year as a filter.
Removed previous attempt as it was erroneous assuming that there will be a provider for previous recruitment cycle (ie. new providers). 

### Guidance to review

Should have no impact going forward, as it defaults to current allocation year.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
