### PR TITLE
[1911] Reorder methods to ensure first name gets a chance to be update

### DIFF
--- a/spec/services/authentication_service_spec.rb
+++ b/spec/services/authentication_service_spec.rb
@@ -39,6 +39,7 @@ describe AuthenticationService do
 
       it "Safely logs that the user was found by sign_in_user_id" do
         subject
+
         expect(logger_spy).to have_received(:info) do |*_args, &block|
           message = block.call
           expect(message).to start_with("User found from sign_in_user_id in token")
@@ -58,13 +59,18 @@ describe AuthenticationService do
 
       it "Should log that the users email was updated" do
         subject
-        expect(logger_spy).to have_received(:debug).with(/Updating user email for/)
+
+        expect(logger_spy).to have_received(:debug) do |*_args, &block|
+          message = block.call
+          expect(message).to start_with("Updating user email for")
+        end
       end
 
       context "when the email is already in use" do
         let!(:existing_user) { create(:user, email: email) }
 
         it { should eq user }
+
         it "does not update the user's email" do
           expect { subject }.not_to(change { user.reload.email })
         end
@@ -138,7 +144,11 @@ describe AuthenticationService do
 
       it "Logs that there was no email in the token" do
         subject
-        expect(logger_spy).to have_received(:debug).with("No email in token")
+
+        expect(logger_spy).to have_received(:debug) do |*_args, &block|
+          message = block.call
+          expect(message).to start_with("No email in token")
+        end
       end
     end
 
@@ -153,7 +163,11 @@ describe AuthenticationService do
 
       it "Logs that there was no signin user id in the token" do
         subject
-        expect(logger_spy).to have_received(:debug).with("No sign_in_user_id in token")
+
+        expect(logger_spy).to have_received(:debug) do |*_args, &block|
+          message = block.call
+          expect(message).to start_with("No sign_in_user_id in token")
+        end
       end
     end
 


### PR DESCRIPTION
### Context
https://trello.com/c/6PXmSDyj/1911-bug-missing-personlisation-firstname

This is an attempt to fix a frequent Sentry exception caused by a welcome email job whereby the first name is missing which is required to personalise it.

### Changes proposed in this pull request
- Reorder the methods under `AuthenticationService#update_user_information` to ensure first name gets a chance to be updated. Up until now, if the update email method blows up because of `AuthenticationService::DuplicateUserError`, none of the other methods get executed which might be the reason we're getting `BadRequestError: Missing personalisation: first_name` within `WelcomeEmailMailer`. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
