### PR TITLE
Add validation for visa sponsorship

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -258,6 +258,7 @@ class Course < ApplicationRecord
   validates :subjects, presence: true, on: :publish
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
+  validate :validate_provider_visa_sponsorship_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_qualification, on: %i[update new]
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
@@ -646,6 +647,12 @@ private
       unless site_status.valid?
         raise RuntimeError.new("Site status invalid on course #{provider.provider_code}/#{course_code}: #{site_status.errors.full_messages.first}")
       end
+    end
+  end
+
+  def validate_provider_visa_sponsorship_publishable
+    unless provider.visa_sponsorship_publishable?
+      errors.add(:provider, :visa_sponsorship_not_publishable)
     end
   end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -652,7 +652,7 @@ private
 
   def validate_provider_visa_sponsorship_publishable
     unless provider.visa_sponsorship_publishable?
-      errors.add(:provider, :visa_sponsorship_not_publishable)
+      errors.add(:base, :visa_sponsorship_not_publishable)
     end
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -268,7 +268,7 @@ class Provider < ApplicationRecord
   def visa_sponsorship_publishable?
     return true if recruitment_cycle.year.to_i < VISA_SPONSORSHIP_REQUIRED_FROM
 
-    %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa].none? { |attr| send(attr).nil? }
+    %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa].none? { |attr| public_send(attr).nil? }
   end
 
 private

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -264,6 +264,13 @@ class Provider < ApplicationRecord
     courses.each(&:discard)
   end
 
+  VISA_SPONSORSHIP_REQUIRED_FROM = 2022
+  def visa_sponsorship_publishable?
+    return true if recruitment_cycle.year.to_i < VISA_SPONSORSHIP_REQUIRED_FROM
+
+    %i[can_sponsor_student_visa can_sponsor_skilled_worker_visa].none? { |attr| send(attr).nil? }
+  end
+
 private
 
   def accrediting_provider_enrichment(provider_code)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,8 +119,7 @@ en:
               blank: "^You must say when applications open from"
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
-            provider:
-              visa_sponsorship_not_publishable: "You must say whether your provider can sponsor visas"
+              visa_sponsorship_not_publishable: "You must say whether you can sponsor visas"
         course_enrichment:
           attributes:
             salary_details:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,8 @@ en:
               blank: "^You must say when applications open from"
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
+            provider:
+              visa_sponsorship_not_publishable: "You must say whether your provider can sponsor visas"
         course_enrichment:
           attributes:
             salary_details:

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -35,6 +35,19 @@ describe API::V2::CoursesController, type: :controller do
         code: course.course_code,
       }
     end
+
+    it "returns a validation error when visa sponsorship information is unpublishable" do
+      course.provider.update(can_sponsor_student_visa: nil)
+      course.provider.recruitment_cycle.update(year: '2022')
+      expect(NotificationService::CoursePublished).not_to receive(:call).with(course: course)
+      post :publish, params: {
+        recruitment_cycle_year: Provider::VISA_SPONSORSHIP_REQUIRED_FROM,
+        provider_code: course.provider.provider_code,
+        code: course.course_code,
+      }
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to match(/Provider You must say whether your provider can sponsor visas/)
+    end
   end
 
   describe "#update_subjects" do

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -750,7 +750,7 @@ describe Provider, type: :model do
       end
     end
 
-    context "when year is 2021 and provider as not declared sponsorship" do
+    context "when year is 2021 and provider has not declared sponsorship" do
       let(:provider) do
         build(
           :provider,

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -734,35 +734,50 @@ describe Provider, type: :model do
     end
   end
 
-  describe '#visa_sponsorship_publishable?' do
-    it "returns true when year is 2022 and provider has declared sponsorship" do
-      provider = build(
-        :provider,
-        can_sponsor_student_visa: true,
-        can_sponsor_skilled_worker_visa: false,
-        recruitment_cycle: build(:recruitment_cycle, year: 2022),
-      )
-      expect(provider.visa_sponsorship_publishable?).to be(true)
+  describe "#visa_sponsorship_publishable?" do
+    context "when year is 2022 and provider has declared sponsorship" do
+      let(:provider) do
+        build(
+          :provider,
+          can_sponsor_student_visa: true,
+          can_sponsor_skilled_worker_visa: false,
+          recruitment_cycle: build(:recruitment_cycle, year: 2022),
+        )
+      end
+
+      it "returns true" do
+        expect(subject.visa_sponsorship_publishable?).to be(true)
+      end
     end
 
-    it "returns true when year is 2021 and provider as not declared sponsorship" do
-      provider = build(
-        :provider,
-        can_sponsor_student_visa: nil,
-        can_sponsor_skilled_worker_visa: false,
-        recruitment_cycle: build(:recruitment_cycle, year: 2021),
-      )
-      expect(provider.visa_sponsorship_publishable?).to be(true)
+    context "when year is 2021 and provider as not declared sponsorship" do
+      let(:provider) do
+        build(
+          :provider,
+          can_sponsor_student_visa: nil,
+          can_sponsor_skilled_worker_visa: false,
+          recruitment_cycle: build(:recruitment_cycle, year: 2021),
+        )
+      end
+
+      it "returns true" do
+        expect(subject.visa_sponsorship_publishable?).to be(true)
+      end
     end
 
-    it "returns false when year is 2022 and provider as not declared sponsorship" do
-      provider = build(
-        :provider,
-        can_sponsor_student_visa: nil,
-        can_sponsor_skilled_worker_visa: false,
-        recruitment_cycle: build(:recruitment_cycle, year: 2022),
-      )
-      expect(provider.visa_sponsorship_publishable?).to be(false)
+    context "when year is 2022 and provider as not declared sponsorship" do
+      let(:provider) do
+        build(
+          :provider,
+          can_sponsor_student_visa: nil,
+          can_sponsor_skilled_worker_visa: false,
+          recruitment_cycle: build(:recruitment_cycle, year: 2022),
+        )
+      end
+
+      it "returns false" do
+        expect(provider.visa_sponsorship_publishable?).to be(false)
+      end
     end
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -765,7 +765,7 @@ describe Provider, type: :model do
       end
     end
 
-    context "when year is 2022 and provider as not declared sponsorship" do
+    context "when year is 2022 and provider has not declared sponsorship" do
       let(:provider) do
         build(
           :provider,

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -733,4 +733,36 @@ describe Provider, type: :model do
       it { is_expected.to contain_exactly(matching_provider) }
     end
   end
+
+  describe '#visa_sponsorship_publishable?' do
+    it "returns true when year is 2022 and provider has declared sponsorship" do
+      provider = build(
+        :provider,
+        can_sponsor_student_visa: true,
+        can_sponsor_skilled_worker_visa: false,
+        recruitment_cycle: build(:recruitment_cycle, year: 2022),
+      )
+      expect(provider.visa_sponsorship_publishable?).to be(true)
+    end
+
+    it "returns true when year is 2021 and provider as not declared sponsorship" do
+      provider = build(
+        :provider,
+        can_sponsor_student_visa: nil,
+        can_sponsor_skilled_worker_visa: false,
+        recruitment_cycle: build(:recruitment_cycle, year: 2021),
+      )
+      expect(provider.visa_sponsorship_publishable?).to be(true)
+    end
+
+    it "returns false when year is 2022 and provider as not declared sponsorship" do
+      provider = build(
+        :provider,
+        can_sponsor_student_visa: nil,
+        can_sponsor_skilled_worker_visa: false,
+        recruitment_cycle: build(:recruitment_cycle, year: 2022),
+      )
+      expect(provider.visa_sponsorship_publishable?).to be(false)
+    end
+  end
 end


### PR DESCRIPTION
### Context

Starting in the 2022 recruitment cycle we will require providers declare whether or not they can sponsor visas (student and skilled worker) before publishing any courses in that cycle. 

https://trello.com/c/I2K4fchq/3441-add-visa-flow-to-publish

### Changes proposed in this pull request

- [x] Add a new validation in the `Course` model to cover this requirement.
- [x] Add `Provider#visa_sponsorship_publishable?` as a helper method for the above validation.
- [x] Unit tests for `Provider#visa_sponsorship_publishable?` and controller spec to cover the API.

Validation as it appears in publish:
<img width="1020" alt="image" src="https://user-images.githubusercontent.com/450843/122546643-13d59b00-d027-11eb-82b0-ca70e458ad98.png">


### Guidance to review

- Is there a better way to implement the specs for this?
- Are there any potential knock-on effects that might cause issues in the 2022 cycle?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
