### PR TITLE
Fix inconsistency between V3 courses search and show endpoints

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -6,7 +6,11 @@ module API
       before_action :build_courses
 
       def index
-        course_search = CourseSearchService.call(filter: params[:filter], sort: params[:sort], course_scope: @courses)
+        course_search = CourseSearchService.call(
+          filter: params[:filter],
+          sort: params[:sort],
+          course_scope: @courses.published,
+        )
 
         render jsonapi: paginate(course_search),
                fields: fields_param,

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -433,7 +433,7 @@ describe "GET v3/courses" do
       let(:request_path) { "/api/v3/courses?filter[subjects]=A1,B1" }
       let(:course_with_B1_subject) do
         create(:course,
-               enrichments: [published_enrichment],
+               enrichments: [build(:course_enrichment, :published)],
                site_statuses: [build(:site_status, :findable)],
                subjects: [create(:primary_subject, subject_code: "B1")])
       end
@@ -516,7 +516,7 @@ describe "GET v3/courses" do
                provider: provider_filtered_by,
                accrediting_provider: provider_filtered_by,
                site_statuses: [create(:site_status, :findable, site: site1)],
-               enrichments: [published_enrichment])
+               enrichments: [build(:course_enrichment, :published)])
       }
       let(:another_provider_course) {
         create(:course,
@@ -524,7 +524,7 @@ describe "GET v3/courses" do
                provider: another_training_provider,
                accrediting_provider: provider_filtered_by,
                site_statuses: [create(:site_status, :findable, site: site2)],
-               enrichments: [published_enrichment])
+               enrichments: [build(:course_enrichment, :published)])
       }
 
       before do

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -225,7 +225,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
           json_response = JSON.parse response.body
           expect(json_response["data"].count).to eq 1
           expect(json_response["data"].first)
-            .to have_attribute("name").with_value('Mathematics')
+            .to have_attribute("name").with_value("Mathematics")
         end
       end
 


### PR DESCRIPTION
### Context

This PR attempts to fix a bug in Find. https://trello.com/c/sU1EgzBi/3503-missing-course-on-find

Certain courses that are returned when searching trigger a 404 when the user drills down into them. e.g. Harrow Collegiate Teaching School Alliance has a course called Music (A431) in their search results https://www.find-postgraduate-teacher-training.service.gov.uk/results?l=3&page=2&query=Harrow+Collegiate+Teaching+School+Alliance that leads to a _Page not found_.

After checking the TTAPI database and queries used to implement the search and drill down it looks like this course code is returning a 404 from the TTAPI because its latest (and only) `CourseEnrichment` is in the `withdrawn` state. This triggers the check on this line:
https://github.com/DFE-Digital/teacher-training-api/blob/master/app/controllers/api/v3/courses_controller.rb#L21

### Changes proposed in this pull request

Add `published` scope to V3 courses `index` endpoint (`/api/v3/recruitment_cycles/:recruitment_cycle_year/providers/:provider_code/courses`). This makes it consistent with the show action in the same controller so that we don't get into a situation where a course is returned by the search API (index action) but then 404s for the show action.

### Guidance to review

- Does the change to the query make sense? Does it make the two actions consistent?
- Is there a better way to test this?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
