### PR TITLE
Fix degree_subject_requirements bug

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -186,7 +186,7 @@ module API
       end
 
       def update_course
-        return unless course_params.values.any? || funding_type_params.present?
+        return unless course_params.values.any? || funding_type_params.present? || course_params.key?("degree_subject_requirements")
         return unless @course.course_params_assignable(course_params)
 
         @course.assign_attributes(course_params)

--- a/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
@@ -35,7 +35,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     %i[degree_subject_requirements]
   end
 
-  context "course has an updated_degree_subject_requirements" do
+  context "course has different degree_subject_requirements" do
     let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Physics A level." } }
 
     it "returns http success" do
@@ -43,7 +43,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(response).to have_http_status(:success)
     end
 
-    it "updates the updated_degree_subject_requirements attribute to the correct value" do
+    it "updates the degree_subject_requirements attribute to the correct value" do
       expect {
         perform_request(updated_degree_subject_requirements)
       }.to change { course.reload.degree_subject_requirements }
@@ -51,7 +51,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     end
   end
 
-  context "course has the same updated_degree_subject_requirements" do
+  context "course has the same degree_subject_requirements" do
     context "with values passed into the params" do
       let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Maths A level." } }
 
@@ -60,7 +60,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
         expect(response).to have_http_status(:success)
       end
 
-      it "does not change updated_degree_subject_requirements attribute" do
+      it "does not change degree_subject_requirements attribute" do
         expect {
           perform_request(updated_degree_subject_requirements)
         }.to_not change { course.reload.degree_subject_requirements }
@@ -77,11 +77,27 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(response).to have_http_status(:success)
     end
 
-    it "does not change updated_degree_subject_requirements attribute" do
+    it "does not change degree_subject_requirements attribute" do
       expect {
         perform_request(updated_degree_subject_requirements)
       }.to_not change { course.reload.degree_subject_requirements }
            .from("Must have a Maths A level.")
+    end
+  end
+
+  context "when nil is passed into the params" do
+    let(:updated_degree_subject_requirements) { { degree_subject_requirements: nil } }
+
+    it "returns http success" do
+      perform_request(updated_degree_subject_requirements)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the degree_subject_requirements attribute to nil" do
+      expect {
+        perform_request(updated_degree_subject_requirements)
+      }.to change { course.reload.degree_subject_requirements }
+            .from("Must have a Maths A level.").to(nil)
     end
   end
 end


### PR DESCRIPTION
### Context

At the moment, on Publish if you provide a value for the degree_subject_requirements and the go and edit your answer to there not being any additional subject requirements, your original response is not set to nil.

https://trello.com/c/KAPUFr0o/3494-add-structured-degree-requirements-fields-to-the-v2-ttapi

### Changes proposed in this pull request

- Allow the degree_subject_requirements field to be updated to nil

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
