### PR TITLE
[2031] Add debug info to DuplicateUserError

### DIFF
--- a/app/services/authentication_service/duplicate_user_error.rb
+++ b/app/services/authentication_service/duplicate_user_error.rb
@@ -7,6 +7,13 @@ class AuthenticationService
       @existing_user_id              = existing_user_id
       @existing_user_sign_in_user_id = existing_user_sign_in_user_id
 
+      message += <<~DEBUG_INFO.insert(0, "\n")
+        user_id: #{@user_id},
+        user_sign_in_user_id: #{@user_sign_in_user_id},
+        existing_user_id: #{@existing_user_id},
+        existing_user_sign_in_user_id: #{@existing_user_sign_in_user_id}
+      DEBUG_INFO
+
       super(message)
     end
   end

--- a/spec/services/authentication_service/duplicate_user_error_spec.rb
+++ b/spec/services/authentication_service/duplicate_user_error_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe AuthenticationService::DuplicateUserError do
+  subject {
+    described_class.new(
+      "Disaster!",
+      user_id: 1,
+      user_sign_in_user_id: 2,
+      existing_user_id: 3,
+      existing_user_sign_in_user_id: 4,
+    )
+  }
+
+  it "includes debug info in the message" do
+    expect(subject.message).to eq <<~MESSAGE
+      Disaster!
+      user_id: 1,
+      user_sign_in_user_id: 2,
+      existing_user_id: 3,
+      existing_user_sign_in_user_id: 4
+    MESSAGE
+  end
+end


### PR DESCRIPTION

### Context
https://trello.com/c/KMR5Tpjc/2031-add-debug-info-to-error-message-for-error-duplicateusererror

It is impossible to debug this without more information.

Sentry just prints out the error message for the exception, (we could
also use something called raven_context to add some json to the 
exception, but that feature is undocumented so this feels safer). It
would be nice to have the email address as well, but this would be 
filtered out by our sentry config for PII reasons.

### Changes proposed in this pull request

Adds all the attributes on DuplicateUserError to the message

### Guidance to review

Not easy to test this with sentry as we disable it on the review apps. If you want to see the error message in action, just raise one manually in the console. Or if you really want to have a fun Friday afternoon, set up your own trial sentry account, set the dsn on your local app and manually send the exception using `Raven.capture_exception`

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
