### PR TITLE
[1908] Only rollover active courses and providers

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -275,6 +275,18 @@ class Course < ApplicationRecord
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
+  def rollable_published?
+    content_status == :published
+  end
+
+  def rollable_withdrawn?
+    content_status == :withdrawn
+  end
+
+  def rollable?
+    rollable_published? || rollable_withdrawn?
+  end
+
   def update_notification_attributes
     %w[name age_range_in_years qualification study_mode maths english science]
   end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -62,6 +62,18 @@ class Provider < ApplicationRecord
   # the accredited_providers that this provider is a training_provider for
   has_many :accrediting_providers, -> { distinct }, through: :courses
 
+  def rollable_courses?
+    courses.any?(&:rollable?)
+  end
+
+  def rollable_accredited_courses?
+    accredited_courses.any?(&:rollable?)
+  end
+
+  def rollable?
+    rollable_courses? || rollable_accredited_courses?
+  end
+
   # the providers that this provider is an accredited_provider for
   def training_providers
     Provider.where(id: current_accredited_courses.pluck(:provider_id))

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -6,6 +6,7 @@ module Courses
     end
 
     def execute(course:, new_provider:)
+      return nil unless course.rollable?
       return nil if course_code_already_exists_on_provider?(course: course, new_provider: new_provider)
 
       new_course = nil

--- a/spec/lib/mcb/editor/provider_editor_spec.rb
+++ b/spec/lib/mcb/editor/provider_editor_spec.rb
@@ -314,26 +314,6 @@ describe MCB::Editor::ProviderEditor, :needs_audit_user do
         end
       end
 
-      context "when there are later recruitment cycles after the one that's been added to" do
-        let!(:next_recruitment_cycle) { create :recruitment_cycle, :next }
-        let!(:one_after_next_recruitment_cycle) { create :recruitment_cycle, year: next_recruitment_cycle.year.to_i + 1 }
-
-        it "clones the provider into all subsequent recruitment cycles" do
-          run_new_provider_wizard(
-            *valid_answers,
-            "y", # confirm creation
-            desired_attributes[:organisation_name],
-            "yes",
-          )
-
-          expect(next_recruitment_cycle.providers.count).to eq(1)
-          expect(next_recruitment_cycle.providers.first.attributes).to include(expected_provider_attributes)
-
-          expect(one_after_next_recruitment_cycle.providers.count).to eq(1)
-          expect(one_after_next_recruitment_cycle.providers.first.attributes).to include(expected_provider_attributes)
-        end
-      end
-
       it "does not create a Provider if creation isn't confirmed" do
         output = run_new_provider_wizard(
           *valid_answers,

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -3,9 +3,11 @@ require "rails_helper"
 RSpec.describe Courses::CopyToProviderService do
   let(:accrediting_provider) { create :provider, :accredited_body }
   let(:provider) { create :provider, courses: [course] }
+  let(:published_course_enrichment) { build :course_enrichment, :published }
   let(:maths) { create :secondary_subject, :mathematics }
   let(:course) {
     build :course,
+          enrichments: [published_course_enrichment],
           accrediting_provider: accrediting_provider,
           subjects: [maths],
           level: "secondary"
@@ -60,7 +62,9 @@ RSpec.describe Courses::CopyToProviderService do
   it "doesn't copy enrichments when they do not exist" do
     service.execute(course: course, new_provider: new_provider)
 
-    expect(mocked_enrichments_copy_to_course_service).to_not have_received(:execute)
+    expect(mocked_enrichments_copy_to_course_service).to_not have_received(:execute).with(
+      enrichment: nil,
+    )
   end
 
   it "saves without doing validations" do

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -2,8 +2,9 @@ require "rails_helper"
 
 describe Providers::CopyToRecruitmentCycleService do
   describe "#execute" do
-    let(:site)   { build :site }
-    let(:course) { create :course, provider: provider }
+    let(:site) { build :site }
+    let(:published_course_enrichment) { build :course_enrichment, :published }
+    let(:course) { create :course, enrichments: [published_course_enrichment], provider: provider }
     let(:ucas_preferences) { build(:ucas_preferences, type_of_gt12: :coming_or_not) }
     let(:contacts) {
       [

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -3,22 +3,31 @@ require "rails_helper"
 describe RolloverService do
   let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
   let(:email) { "user@education.gov.uk" }
-  let(:course)              { build :course, enrichments: [course_enrichment] }
-  let(:course_enrichment)   { build :course_enrichment, :published }
-  let(:site)                { build :site }
+  let(:published_course)              { build :course, enrichments: [published_course_enrichment] }
+  let(:published_course_enrichment)   { build :course_enrichment, :published }
+  let(:withdrawn_course)              { build :course, enrichments: [withdrawn_course_enrichment] }
+  let(:withdrawn_course_enrichment)   { build :course_enrichment, :withdrawn }
+  let(:rolled_over_course)                   { build :course, enrichments: [rolled_over_course_enrichment] }
+  let(:rolled_over_course_enrichment)        { build :course_enrichment, :rolled_over }
+  let(:initial_draft_course)                 { build :course, enrichments: [initial_draft_course_enrichment] }
+  let(:initial_draft_course_enrichment)      { build :course_enrichment, :initial_draft }
+  let(:subsequent_draft_course)              { build :course, enrichments: [subsequent_draft_course_enrichment] }
+  let(:subsequent_draft_course_enrichment)   { build :course_enrichment, :subsequent_draft }
+  let(:site) { build :site }
 
-  let!(:site_status) {
+  let!(:site_status) do
     create :site_status,
+           :published,
            :with_no_vacancies,
-           course: course,
+           course: published_course,
            site: site
-  }
+  end
 
-  let(:current_cycle_provider) {
+  let(:current_cycle_provider) do
     create :provider,
-           courses: [course],
+           courses: [published_course],
            sites: [site]
-  }
+  end
 
   before do
     perform_rollover
@@ -30,9 +39,9 @@ describe RolloverService do
     )
   end
 
-  let(:new_course) do
+  let(:new_published_course) do
     next_cycle_provider.courses.find_by(
-      course_code: course.course_code,
+      course_code: published_course.course_code,
     )
   end
 
@@ -47,30 +56,29 @@ describe RolloverService do
     expect(new_site).not_to eq site
   end
 
-  it "copies the course" do
-    expect(new_course).not_to be_nil
-    expect(new_course).not_to eq course
+  it "copies the published course" do
+    expect(new_published_course).not_to be_nil
+    expect(new_published_course).not_to eq published_course
   end
 
   it "copies the course enrichments" do
-    expect(new_course.enrichments.count).to eq 1
-    expect(new_course.enrichments.first).to be_rolled_over
+    expect(new_published_course.enrichments.count).to eq 1
+    expect(new_published_course.enrichments.first).to be_rolled_over
   end
 
   it "copies the course's site" do
     new_site = next_cycle_provider.sites.find_by(code: site.code)
-    expect(new_course.sites).to eq [new_site]
-    expect(new_course.site_statuses.first).to be_full_time_vacancies
-    expect(new_course.site_statuses.first).to be_status_new_status
+    expect(new_published_course.sites).to eq [new_site]
+    expect(new_published_course.site_statuses.first).to be_full_time_vacancies
+    expect(new_published_course.site_statuses.first).to be_status_new_status
   end
 
   context "when provider already rolled over" do
-    it "copies a new course" do
-      course2 = create(:course, provider: current_cycle_provider)
+    it "copies a new published course" do
+      course2 = create(:course, provider: current_cycle_provider, enrichments: [build(:course_enrichment, :published)])
       current_cycle_provider.courses.reload
 
       rollover_again
-
       duplicated_course2 = next_cycle_provider.courses.find_by(course_code: course2.course_code)
       expect(duplicated_course2).not_to be_nil
       expect(duplicated_course2).not_to eq(course2)
@@ -87,6 +95,93 @@ describe RolloverService do
       expect(duplicated_site2).not_to be_nil
       expect(duplicated_site2).not_to eq(site2)
       expect(next_cycle_provider.sites.length).to eq(current_cycle_provider.sites.length)
+    end
+  end
+
+  context "when provider has 1 published, 1 withdrawn and 1 rolled_over course" do
+    let(:current_cycle_provider) do
+      create :provider,
+             courses: [published_course, withdrawn_course, rolled_over_course],
+             sites: [site]
+    end
+
+    let(:new_withdrawn_course) do
+      next_cycle_provider.courses.find_by(
+        course_code: withdrawn_course.course_code,
+      )
+    end
+
+    let(:new_rolled_over_course) do
+      next_cycle_provider.courses.find_by(
+        course_code: rolled_over_course.course_code,
+      )
+    end
+
+    it "onlies rollover published and withdrawn courses" do
+      expect(current_cycle_provider.rollable?).to eq(true)
+      expect(next_cycle_provider.courses.count).to eq(2)
+      expect(new_withdrawn_course).not_to be_nil
+      expect(new_published_course).not_to be_nil
+      expect(new_withdrawn_course).not_to eq withdrawn_course
+      expect(new_published_course).not_to eq published_course
+      expect(new_rolled_over_course).to be_nil
+      expect(Course.all.count).to eq(5)
+      expect(next_cycle_provider.rollable?).to eq(false)
+      rollover_again
+      expect(Course.all.count).to eq(5)
+    end
+  end
+
+  context "provider with only non rollable courses" do
+    let(:current_cycle_provider) do
+      create :provider,
+             courses: [rolled_over_course, initial_draft_course, subsequent_draft_course],
+             sites: [site]
+    end
+
+    it "does not copy the provider" do
+      expect(current_cycle_provider.rollable?).to eq(false)
+      expect(next_cycle_provider).to be_nil
+    end
+  end
+
+  context "provider with no courses" do
+    let(:current_cycle_provider) do
+      create :provider
+    end
+
+    it "does not copy the provider" do
+      expect(current_cycle_provider.rollable?).to eq(false)
+      expect(next_cycle_provider).to be_nil
+    end
+  end
+
+  context "provider who accredits courses but has no courses of their own" do
+    let(:current_cycle_provider) do
+      create :provider,
+             :accredited_body,
+             accredited_courses: [published_course],
+             sites: [site]
+    end
+
+    it "copies the provider" do
+      expect(current_cycle_provider.rollable?).to eq(true)
+      expect(next_cycle_provider).to_not be_nil
+    end
+  end
+
+  context "accredited_body with 2 rollable courses" do
+    let(:current_cycle_provider) do
+      create :provider,
+             :accredited_body,
+             courses: [published_course, withdrawn_course, rolled_over_course],
+             accredited_courses: [published_course],
+             sites: [site]
+    end
+
+    it "copies the rollable courses" do
+      expect(current_cycle_provider.rollable?).to eq(true)
+      expect(next_cycle_provider.courses.count).to eq(2)
     end
   end
 


### PR DESCRIPTION
### Context

Changing the rollover script so that it no longer rolls over courses which weren't published last cycle. Only courses which have the status `withdrawn` or `published` will be rolled over. Accredited bodies, which accredit valid courses will always be rolled over even if they have no courses.

### Changes proposed in this pull request

- Add two `rollable?` methods, one on `Course` and one on `Provider` which encompass `content_status` logic.
- We don't rollover courses unless they are `rollable?`.
- We don't rollover providers unless they are `rollable?`.
- Remove failing MCB test as this is now redundant (all of MCB can now be removed).

### Guidance to review

- Run ` bundle exec rake rollover:create_recruitment_cycle"[YYYY, "YYYY-MM-DD", "YYYY-MM-DD"]`. This is `year`, `application_start_date` and `application_end_date` respectively. 
- Ensure you have providers, locations and courses in your database.
- In Publish, change `can_edit_current_and_next_cycles` in `development.local.yml` to `true`.
- Navigate to a provider `organisations/{provider_code}` check that you can click on `Current cycle` but not `Next cycle`.
- Look for a `rollable?` provider, e.g one with `published` or `withdrawn` courses.
- Run `bundle exec rake rollover:providers"[{provider_code}]" ` and check that the provider is successfully rolled over.
- Look for a non `rollable?` provider, e.g one that doesn't accredit courses, or have courses, or only has courses that are `draft` or `rolled_over`.
- Run `bundle exec rake rollover:providers"[{provider_code}]"` and check that the provider is not rolled over.

- You can rollover all providers, however there is currently an ongoing issue with email validation which will cause issues. See [this trello ticket](https://trello.com/c/dYKWlDZq/1416-fix-validation-on-provider-email). You can fix the emails manually (which are in the trello ticket) and run `bundle exec rake rollover:providers`. This will take around 20 minutes. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
