### PR TITLE
Add degree requirements validation for publishing

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -55,6 +55,8 @@ class Course < ApplicationRecord
     not_set: nil,
   }.freeze
 
+  DEGREE_REQUIREMENTS_REQUIRED_FROM = 2022
+
   enum maths: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_maths
   enum english: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_english
   enum science: ENTRY_REQUIREMENT_OPTIONS, _suffix: :for_science
@@ -259,6 +261,7 @@ class Course < ApplicationRecord
   validate :validate_enrichment_publishable, on: :publish
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish
+  validate :validate_degree_requirements_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_qualification, on: %i[update new]
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
@@ -566,6 +569,13 @@ class Course < ApplicationRecord
     end
 
     requirements
+  end
+
+  def validate_degree_requirements_publishable
+    return true if recruitment_cycle.year.to_i < DEGREE_REQUIREMENTS_REQUIRED_FROM || degree_grade.present?
+
+    errors.add(:base, :degree_requirements_not_publishable)
+    false
   end
 
 private

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,6 +120,7 @@ en:
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "You must say whether you can sponsor visas"
+              degree_requirements_not_publishable: "Enter degree requirements"
         course_enrichment:
           attributes:
             salary_details:
@@ -143,7 +144,7 @@ en:
               blank: "^Enter a course length"
         provider:
           attributes:
-            provider_name:     
+            provider_name:
               too_long: "Your provider name is too long, it must be fewer than 100 characters"
             email:
               blank: "^Enter email address"


### PR DESCRIPTION
### Context

https://trello.com/c/waUHPqGC/3496-add-the-structured-degree-requirements-section-to-publish

This adds in a validation to ensure that degree grade is present for courses in the 2022 or later cycles.

### Changes proposed in this pull request

- Add an error message to the course if it's in the 2022 cycle and degree grade is not present 

### Guidance to review

Is the test coverage good enough?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
