### PR TITLE
Appease Rubocop so the builds stop failing

### DIFF
--- a/lib/rack/request_output.rb
+++ b/lib/rack/request_output.rb
@@ -5,7 +5,7 @@ module Rack
     end
 
     def call(env)
-      Rails.logger.debug("API HIT => #{env['rack.url_scheme']}://#{env['HTTP_HOST']}#{env['REQUEST_URI']}")
+      Rails.logger.debug { "API HIT => #{env['rack.url_scheme']}://#{env['HTTP_HOST']}#{env['REQUEST_URI']}" }
 
       @app.call(env)
     end


### PR DESCRIPTION
### Context

All the builds are failing due to the debug method not being passed a block 

### Changes proposed in this pull request

- pass a block into the debug method 