### PR TITLE
Add qualification params to courses controller

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -186,7 +186,7 @@ module API
       end
 
       def update_course
-        return unless course_params.values.any? || funding_type_params.present? || course_params.key?("degree_subject_requirements")
+        return unless course_params.values.any? || funding_type_params.present? || qualification_params.present?
         return unless @course.course_params_assignable(course_params)
 
         @course.assign_attributes(course_params)
@@ -352,6 +352,16 @@ module API
 
       def funding_type_params
         params.fetch(:course, {})[:funding_type]
+      end
+
+      def qualification_params
+        course_params.keys & %w[
+          accept_english_gcse_equivalency
+          accept_maths_gcse_equivalency
+          accept_science_gcse_equivalency
+          degree_subject_requirements
+          additional_gcse_equivalencies
+        ]
       end
 
       def subject_ids

--- a/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
@@ -1,0 +1,103 @@
+require "rails_helper"
+
+describe "PATCH /providers/:provider_code/courses/:course_code" do
+  let(:jsonapi_renderer) { JSONAPI::Serializable::Renderer.new }
+
+  def perform_request(updated_additional_gcse_equivalencies)
+    jsonapi_data = jsonapi_renderer.render(
+      course,
+      class: {
+        Course: API::V2::SerializableCourse,
+      },
+    )
+
+    jsonapi_data[:data][:attributes] = updated_additional_gcse_equivalencies
+
+    patch "/api/v2/providers/#{course.provider.provider_code}" \
+            "/courses/#{course.course_code}",
+          headers: { "HTTP_AUTHORIZATION" => credentials },
+          params: {
+            _jsonapi: jsonapi_data,
+          }
+  end
+  let(:organisation)      { create :organisation }
+  let(:provider)          { create :provider, organisations: [organisation] }
+  let(:user)              { create :user, organisations: [organisation] }
+  let(:payload)           { { email: user.email } }
+  let(:credentials)       { encode_to_credentials(payload) }
+
+  let(:course)            {
+    create :course,
+           provider: provider,
+           additional_gcse_equivalencies: "Must have a cycling proficiency certificate."
+  }
+  let(:permitted_params) do
+    %i[additional_gcse_equivalencies]
+  end
+
+  context "course has different additional_gcse_equivalencies" do
+    let(:updated_additional_gcse_equivalencies) { { additional_gcse_equivalencies: "Must have a Physics A level." } }
+
+    it "returns http success" do
+      perform_request(updated_additional_gcse_equivalencies)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the additional_gcse_equivalencies attribute to the correct value" do
+      expect {
+        perform_request(updated_additional_gcse_equivalencies)
+      }.to change { course.reload.additional_gcse_equivalencies }
+            .from("Must have a cycling proficiency certificate.").to("Must have a Physics A level.")
+    end
+  end
+
+  context "course has the same additional_gcse_equivalencies" do
+    context "with values passed into the params" do
+      let(:updated_additional_gcse_equivalencies) { { additional_gcse_equivalencies: "Must have a cycling proficiency certificate." } }
+
+      it "returns http success" do
+        perform_request(updated_additional_gcse_equivalencies)
+        expect(response).to have_http_status(:success)
+      end
+
+      it "does not change additional_gcse_equivalencies attribute" do
+        expect {
+          perform_request(updated_additional_gcse_equivalencies)
+        }.to_not change { course.reload.additional_gcse_equivalencies }
+             .from("Must have a cycling proficiency certificate.")
+      end
+    end
+  end
+
+  context "with no values passed into the params" do
+    let(:updated_additional_gcse_equivalencies) { {} }
+
+    it "returns http success" do
+      perform_request(updated_additional_gcse_equivalencies)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "does not change additional_gcse_equivalencies attribute" do
+      expect {
+        perform_request(updated_additional_gcse_equivalencies)
+      }.to_not change { course.reload.additional_gcse_equivalencies }
+           .from("Must have a cycling proficiency certificate.")
+    end
+  end
+
+  context "when nil is passed into the params" do
+    let(:updated_additional_gcse_equivalencies) { { additional_gcse_equivalencies: nil } }
+
+    it "returns http success" do
+      perform_request(updated_additional_gcse_equivalencies)
+      expect(response).to have_http_status(:success)
+    end
+
+    it "updates the additional_gcse_equivalencies attribute to nil" do
+      expect {
+        perform_request(updated_additional_gcse_equivalencies)
+      }.to change { course.reload.additional_gcse_equivalencies }
+            .from("Must have a cycling proficiency certificate.").to(nil)
+    end
+  end
+end


### PR DESCRIPTION
### Context

As part of the work being carried out on the structured GCSE's on publish certain params
are not saving correctly to the database. On inspection this is due to the guard clause
on the update action of the controller. 

### Changes proposed in this pull request

This PR updates the method to include these params.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
