### PR TITLE
[2086] Bump azure-blob-storage-upload

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -54,7 +54,7 @@ jobs:
         id: GetSecretAction
 
       - name: Upload sqldbdump to storageAccount
-        uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+        uses: bacongobbler/azure-blob-storage-upload@v1
         with:
           source_dir: ./
           container_name: sqldbdump


### PR DESCRIPTION
### Context
The job https://github.com/DFE-Digital/teacher-training-api/actions/workflows/database-restore.yml is failing

### Changes proposed in this pull request
Bump the dependency azure-blob-storage-upload as the build is failing

### Guidance to review
Run the job

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
