### PR TITLE
Use az cli to upload to Azure storage

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -96,6 +96,18 @@ jobs:
           path: backup_sanitised.sql
           retention-days: 7
 
+      - name: Notify slack channel on failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Teacher Training API
+          SLACK_TITLE: TTAPI database backup failed
+          SLACK_MESSAGE: ':alert: <!channel> TTAPI database backup failed'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
   restore:
    needs: [backup]
    runs-on: ubuntu-latest
@@ -121,3 +133,15 @@ jobs:
         run: cf conduit ${POSTGRES_SERVICE_INSTANCE} -- psql < backup_sanitised.sql
         env:
           POSTGRES_SERVICE_INSTANCE: teacher-training-api-postgres-${{ matrix.environment }}
+
+      - name: Notify slack channel on failure
+        if: failure()
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: twd_publish_register_tech
+          SLACK_COLOR: '#ef5343'
+          SLACK_ICON_EMOJI: ':github-logo:'
+          SLACK_USERNAME: Teacher Training API
+          SLACK_TITLE: TTAPI database restore failed
+          SLACK_MESSAGE: ':alert: <!channel> TTAPI database restore to ${{ matrix.environment }} failed'
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -41,27 +41,26 @@ jobs:
           cf conduit teacher-training-api-postgres-prod -- pg_dump --encoding utf8 --clean --no-owner --if-exists -f $PROD_BACKUP
           echo "PROD_BACKUP=$PROD_BACKUP" >> $GITHUB_ENV
 
-
       - name: Login to Azure
         uses: azure/login@v1
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS_PRODUCTION }}
 
-      - name: Get storageAccount connection string from keyvault
+      - name: Get storage account connection string from Key Vault
+        id: get_connection_string
         uses: Azure/get-keyvault-secrets@v1
         with:
           keyvault: s121p01-shared-kv-01
           secrets: TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION
-        id: GetSecretAction
 
-      - name: Upload sqldbdump to storageAccount
-        uses: bacongobbler/azure-blob-storage-upload@v1.2.0
-        with:
-          source_dir: ./
-          container_name: sqldbdump
-          connection_string: ${{ steps.GetSecretAction.outputs.TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION }}
-          extra_args: '--pattern *.sql'
-          sync: false
+      - name: Upload Backup to Azure Storage
+        run: |
+          tar -cvzf ${{ env.PROD_BACKUP }}.tar.gz ${{ env.PROD_BACKUP }}
+          az storage blob upload --container-name sqldbdump \
+          --file ${{ env.PROD_BACKUP }}.tar.gz --name ${{ env.PROD_BACKUP }}.tar.gz \
+          --connection-string ${AZURE_STORAGE_CONNECTION_STRING}
+        env:
+          AZURE_STORAGE_CONNECTION_STRING: ${{ steps.get_connection_string.outputs.TTAPI-STORAGE-ACCOUNT-CONNECTION-STRING-PRODUCTION }}
 
       - name: Sanitise the Database backup
         run: |


### PR DESCRIPTION
### Context

Database backup job has been failing for the last 10 days.

### Changes proposed in this pull request

Compress the backup file and use az cli to upload archive to Azure storage container.

Test run: https://github.com/DFE-Digital/teacher-training-api/runs/2943079250?check_suite_focus=true

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
