### PR TITLE
[2093] Added validation to the course model for site urn

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -266,6 +266,7 @@ class Course < ApplicationRecord
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle.after_2021? }
   validate :validate_provider_urn_ukprn_publishable, on: :publish, if: -> { recruitment_cycle.after_2021? }
+  validate :validate_all_sites_publishable, on: :publish, if: -> { recruitment_cycle.after_2021? }
   validate :validate_degree_requirements_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_qualification, on: %i[update new]
@@ -831,6 +832,12 @@ private
     end
     @services.register(:content_status) do
       Courses::ContentStatusService.new
+    end
+  end
+
+  def validate_all_sites_publishable
+    if sites.any? { |s| s.urn.blank? }
+      errors.add(:sites, :site_urn_not_publishable)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,6 +103,7 @@ en:
               blank: "^Complete your course information before publishing"
             sites:
               blank: "^You must pick at least one location for this course"
+              site_urn_not_publishable: "^You must provide a Unique Reference Number (URN) for all course locations"
             age_range_in_years:
               blank: "^You need to pick an age range"
             program_type:


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/WR5JVk06/2093-m-users-get-an-error-message-when-they-try-to-publish-a-course-if-there-are-sites-on-the-course-without-urn)

### Changes proposed in this pull request

- Added validation to the Course Model, that checks that all sites have URNs

### Guidance to review

- Create a new course in the 2022 cycle, and make sure that at least one connected site does not have a URN

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
