### PR TITLE
[2091] Publish locations allow providers to create more than 37 locations

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -234,7 +234,7 @@ class Provider < ApplicationRecord
   end
 
   def can_add_more_sites?
-    sites.size < Site::POSSIBLE_CODES.size
+    true
   end
 
   # This reflects the fact that organisations should actually be a has_one.

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -229,10 +229,6 @@ class Provider < ApplicationRecord
     update_columns changed_at: timestamp
   end
 
-  def unassigned_site_codes
-    Site::POSSIBLE_CODES - sites.pluck(:code)
-  end
-
   def can_add_more_sites?
     true
   end

--- a/app/serializers/course_provider_serializer.rb
+++ b/app/serializers/course_provider_serializer.rb
@@ -1,5 +1,7 @@
 class CourseProviderSerializer < ActiveModel::Serializer
-  has_many :sites, key: :campuses
+  has_many :sites, key: :campuses do
+    object.sites.where(code: Site::POSSIBLE_CODES)
+  end
 
   attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
              :scheme_member

--- a/app/serializers/provider_serializer.rb
+++ b/app/serializers/provider_serializer.rb
@@ -1,5 +1,7 @@
 class ProviderSerializer < ActiveModel::Serializer
-  has_many :sites, key: :campuses
+  has_many :sites, key: :campuses do
+    object.sites.where(code: Site::POSSIBLE_CODES)
+  end
 
   attributes :institution_code, :institution_name, :institution_type, :accrediting_provider,
              :address1, :address2, :address3, :address4, :postcode, :region_code, :scheme_member,

--- a/app/services/sites/code_generator.rb
+++ b/app/services/sites/code_generator.rb
@@ -1,0 +1,44 @@
+module Sites
+  class CodeGenerator
+    include ServicePattern
+
+    def initialize(provider:)
+      @provider = provider
+    end
+
+    def call
+      ucas_style_code.presence || highest_site_code.next
+    end
+
+  private
+
+    attr_reader :provider
+
+    def highest_site_code
+      return "Z" if existing_sequential_codes.blank?
+
+      existing_sequential_codes.max
+    end
+
+    def existing_sequential_codes
+      existing_site_codes - Site::POSSIBLE_CODES
+    end
+
+    def existing_site_codes
+      @existing_site_codes ||= provider.sites.pluck(:code)
+    end
+
+    def unassigned_ucas_style_site_codes
+      Site::POSSIBLE_CODES - existing_site_codes
+    end
+
+    def ucas_style_code
+      @ucas_style_code ||= begin
+        available_desirable_codes = unassigned_ucas_style_site_codes & Site::DESIRABLE_CODES
+        available_undesirable_codes = unassigned_ucas_style_site_codes & Site::EASILY_CONFUSED_CODES
+
+        available_desirable_codes.sample || available_undesirable_codes.sample
+      end
+    end
+  end
+end

--- a/spec/factories/sites.rb
+++ b/spec/factories/sites.rb
@@ -9,17 +9,7 @@ FactoryBot.define do
     region_code { "london" }
     urn { Faker::Number.number(digits: [5, 6].sample) }
 
-    # When we retrieve a random code (as Site#pick_next_available_code does),
-    # there is the possibility we'll end up with this code duplicated when
-    # creating Sites that aren't persisted (e.g. running build(:site) twice).
-    # Using a sequence significantly reduces the chances of this happening in
-    # the tests, and starting at a random number ensures we don't start to test
-    # site codes in a deterministic way by accident (they should only be
-    # deterministic when set explicitly by the test).
-    sequence(:code, Random.rand(1000)) do |n|
-      max_codes = Site::POSSIBLE_CODES.count
-      Site::POSSIBLE_CODES[n % max_codes]
-    end
+    sequence(:code) { |n| "A#{n}" }
 
     provider
 

--- a/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
+++ b/spec/lib/mcb/commands/apiv1/providers/find_spec.rb
@@ -1,8 +1,8 @@
 require "mcb_helper"
 
 describe '"mcb apiv1 providers find"' do
-  let(:site1)     { build(:site) }
-  let(:site2)     { build(:site) }
+  let(:site1)     { build(:site, code: "A") }
+  let(:site2)     { build(:site, code: "Z") }
   let(:contact1)  { build(:contact, :utt_type) }
   let(:contact2)  { build(:contact, :admin_type) }
   let(:provider1) { create(:provider, sites: [site1], contacts: [contact1]) }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -208,35 +208,10 @@ describe Provider, type: :model do
 
   its(:recruitment_cycle) { is_expected.to eq find(:recruitment_cycle) }
 
-  describe "#unassigned_site_codes" do
+  describe "#can_add_more_sites?" do
     subject { create(:provider) }
 
-    before do
-      %w[A B C D 1 2 3 -].each { |code| subject.sites << build(:site, code: code) }
-    end
-
-    let(:expected_unassigned_codes) { ("E".."Z").to_a + %w[0] + ("4".."9").to_a }
-
-    its(:unassigned_site_codes) { is_expected.to eq(expected_unassigned_codes) }
-  end
-
-  describe "#can_add_more_sites?" do
-    context "when provider has less sites than max allowed" do
-      subject { create(:provider) }
-
-      its(:can_add_more_sites?) { is_expected.to be_truthy }
-    end
-
-    context "when provider has the max sites allowed" do
-      let(:all_site_codes) { ("A".."Z").to_a + %w[0 -] + ("1".."9").to_a }
-      let(:sites) do
-        all_site_codes.map { |code| build(:site, code: code) }
-      end
-
-      subject { create(:provider, sites: sites) }
-
-      its(:can_add_more_sites?) { is_expected.to be_falsey }
-    end
+    its(:can_add_more_sites?) { is_expected.to be_truthy }
   end
 
   it "defines an enum for accrediting_provider" do

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -15,7 +15,12 @@ describe Site, type: :model do
   it { is_expected.to validate_uniqueness_of(:location_name).scoped_to(:provider_id) }
   it { is_expected.to validate_uniqueness_of(:code).case_insensitive.scoped_to(:provider_id) }
   it { is_expected.to validate_presence_of(:code) }
-  it { is_expected.to validate_inclusion_of(:code).in_array(Site::POSSIBLE_CODES).with_message("must be A-Z, 0-9 or -") }
+
+  it "validates that code can only contain A-Z, 0-9 or -" do
+    subject.code = "22,A"
+    subject.valid?
+    expect(subject.errors[:code]).to include("must contain only A-Z, 0-9 or -")
+  end
 
   it "validates that URN cannot be letters" do
     subject.urn = "XXXXXX"
@@ -66,12 +71,6 @@ describe Site, type: :model do
     it "is assigned a valid code by default" do
       expect { subject.valid? }.to change { subject.code.blank? }.from(true).to(false)
       expect(subject.errors[:code]).to be_empty
-    end
-
-    it "is assigned easily-confused codes only when all others have been used up" do
-      (Site::DESIRABLE_CODES - %w[A]).each { |code| create(:site, code: code, provider: provider) }
-      subject.validate
-      expect(subject.code).to eq("A")
     end
   end
 

--- a/spec/requests/api/v1/provider_spec.rb
+++ b/spec/requests/api/v1/provider_spec.rb
@@ -25,6 +25,21 @@ describe "Providers API", type: :request do
 
     let(:get_index) { get "/api/v1/#{current_year}/providers", headers: { "HTTP_AUTHORIZATION" => credentials } }
 
+    context "when provider has more than 37 sites" do
+      let(:provider) { create(:provider) }
+
+      before do
+        Site::POSSIBLE_CODES.each { |code| create(:site, code: code, provider: provider) }
+        create_list(:site, 2, code: nil, provider: provider)
+        get_index
+      end
+
+      it "includes only the first 37 sites" do
+        json = JSON.parse(response.body)
+        expect(json[0]["campuses"].map { |campus| campus["campus_code"] }).to match_array(Site::POSSIBLE_CODES)
+      end
+    end
+
     context "without changed_since parameter" do
       provider = nil
       provider2 = nil

--- a/spec/requests/api/v2/providers/providers_show_spec.rb
+++ b/spec/requests/api/v2/providers/providers_show_spec.rb
@@ -156,22 +156,6 @@ describe "Providers API v2", type: :request do
       end
     end
 
-    context "with the maximum number of sites" do
-      let(:sites) {
-        [*"A".."Z", "0", "-", *"1".."9"].map { |code|
-          build(:site, code: code)
-        }
-      }
-      let(:provider) { create(:provider, sites: sites, organisations: [organisation]) }
-
-      it "has can_add_more_sites? set to false" do
-        perform_request
-
-        expect(json_response["data"])
-          .to have_attribute(:can_add_more_sites?).with_value(false)
-      end
-    end
-
     describe "JSON generated for a provider" do
       it "has a data section with the correct attributes" do
         perform_request

--- a/spec/serializers/course_provider_serializer_spec.rb
+++ b/spec/serializers/course_provider_serializer_spec.rb
@@ -6,4 +6,14 @@ RSpec.describe CourseProviderSerializer do
   subject { serialize(provider, serializer_class: described_class) }
 
   it { is_expected.to include(accrediting_provider: provider.accrediting_provider_before_type_cast) }
+
+  describe "campuses" do
+    before do
+      create_list(:site, 40, code: nil, provider: provider)
+    end
+
+    subject { serialize(provider, serializer_class: described_class)["campuses"] }
+
+    its(:count) { is_expected.to eq(37) }
+  end
 end

--- a/spec/serializers/provider_serializer_spec.rb
+++ b/spec/serializers/provider_serializer_spec.rb
@@ -26,6 +26,16 @@ describe ProviderSerializer do
     it { is_expected.to eq provider.ucas_preferences.type_of_gt12_before_type_cast }
   end
 
+  describe "campuses" do
+    before do
+      create_list(:site, 40, code: nil, provider: provider)
+    end
+
+    subject { serialize(provider)["campuses"] }
+
+    its(:count) { is_expected.to eq(37) }
+  end
+
   describe "utt_application_alerts" do
     subject { serialize(provider)["utt_application_alerts"] }
 

--- a/spec/services/sites/code_generator_spec.rb
+++ b/spec/services/sites/code_generator_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+describe Sites::CodeGenerator do
+  let(:provider) { create(:provider) }
+
+  subject { described_class.call(provider: provider) }
+
+  it "generates a UCAS style code (one of A-Z, 0-9 or -)" do
+    expect(subject).to match(/\A[A-Z0-9\-]{1}\z/)
+  end
+
+  context "when UCAS style codes exist" do
+    before do
+      (Site::DESIRABLE_CODES - %w[A]).each { |code| create(:site, code: code, provider: provider) }
+    end
+
+    it "generates easily-confused codes only when all others have been used up" do
+      expect(subject).to eq("A")
+    end
+  end
+
+  context "when all of UCAS style POSSIBLE_CODES are assigned" do
+    before do
+      Site::POSSIBLE_CODES.each { |code| create(:site, code: code, provider: provider) }
+    end
+
+    it "generates codes starting with AA" do
+      expect(subject).to eq("AA")
+    end
+  end
+
+  context "when sequential codes exist" do
+    before do
+      Site::POSSIBLE_CODES.each { |code| create(:site, code: code, provider: provider) }
+      create_list(:site, 3, code: nil, provider: provider)
+    end
+
+    it "generates the next available code" do
+      expect(subject).to eq("AD")
+    end
+  end
+end


### PR DESCRIPTION
### Context
Providers will be allowed to add more than 37 locations (sites) next cycle. We should remove the validations enforcing this allowing them to do so.

### Changes proposed in this pull request
1. The first 37 sites will continue to have a UCAS style code, i.e(one of A-Z, 0-9 or -), after which the next set of locations will have a sequential code from "AA", "AB" and so on.
2. v1 of the API will only fetch 37 sites, which have the UCAS code.
3. v2, v3 and public v1 will show all available sites.

### Guidance to review

### Checklist
- [x] Remove https://github.com/DFE-Digital/teacher-training-api/pull/2025/commits/7c4fcb4aa5bba5b24b3b247944253e3a9611d46d commit
- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
