### PR TITLE
Add legacy support for 'required_qualifications' attribute in public API

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -590,6 +590,10 @@ class Course < ApplicationRecord
     false
   end
 
+  def required_qualifications
+    RequiredQualificationsSummary.new(self).extract
+  end
+
 private
 
   def add_site!(site:)

--- a/app/models/required_qualifications_summary.rb
+++ b/app/models/required_qualifications_summary.rb
@@ -23,6 +23,11 @@ private
     output << gcse_equivalency_content
     output << "\n"
     output << (course.additional_gcse_equivalencies || "")
+    output << "\n"
+    output << degree_grade_content
+    output << "\n"
+    output << degree_subject_requirements_content
+    output << "\n"
   end
 
   def required_gcse_content
@@ -65,5 +70,23 @@ private
       maths: course.accept_maths_gcse_equivalency?,
       science: course.accept_science_gcse_equivalency?,
     }.select { |_k, v| v }.keys
+  end
+
+  def degree_grade_content
+    {
+      "two_one" => "An undergraduate degree at class 2:1 or above, or equivalent.",
+      "two_two" => "An undergraduate degree at class 2:2 or above, or equivalent.",
+      "third_class" => "An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.",
+      "not_required" => "An undergraduate degree, or equivalent.",
+      nil => "",
+    }[course.degree_grade]
+  end
+
+  def degree_subject_requirements_content
+    if course.additional_degree_subject_requirements?
+      course.degree_subject_requirements
+    else
+      ""
+    end
   end
 end

--- a/app/models/required_qualifications_summary.rb
+++ b/app/models/required_qualifications_summary.rb
@@ -1,0 +1,69 @@
+class RequiredQualificationsSummary
+  attr_reader :course
+
+  def initialize(course)
+    @course = course
+  end
+
+  def extract
+    legacy_qualifications_attribute = course.latest_published_enrichment&.required_qualifications
+    return legacy_qualifications_attribute if legacy_qualifications_attribute.present?
+
+    generate_summary_text
+  end
+
+private
+
+  def generate_summary_text
+    output = ""
+    output << required_gcse_content
+    output << "\n"
+    output << pending_gcse_content
+    output << "\n"
+    output << gcse_equivalency_content
+    output << "\n"
+    output << (course.additional_gcse_equivalencies || "")
+  end
+
+  def required_gcse_content
+    case course.level
+    when "primary"
+      "Grade 4 (C) or above in English, maths and science, or equivalent qualification."
+    when "secondary"
+      "Grade 4 (C) or above in English and maths, or equivalent qualification."
+    else
+      ""
+    end
+  end
+
+  def pending_gcse_content
+    if course.accept_pending_gcse?
+      "Candidates with pending GCSEs will be considered."
+    else
+      "Candidates with pending GCSEs will not be considered."
+    end
+  end
+
+  def gcse_equivalency_content
+    return "Equivalency tests will not be accepted." unless course.accept_gcse_equivalency?
+
+    case gcse_equivalencies.count
+    when 0
+      "" # Assume that course.additional_gcse_equivalencies is populated instead
+    when 1
+      "Equivalency tests will be accepted in #{gcse_equivalencies[0].capitalize}."
+    when 2
+      "Equivalency tests will be accepted in #{gcse_equivalencies[0].capitalize} and #{gcse_equivalencies[1]}."
+    when 3
+      "Equivalency tests will be accepted in #{gcse_equivalencies[0].capitalize}, #{gcse_equivalencies[1]} and #{gcse_equivalencies[2]}."
+    end
+  end
+
+  def gcse_equivalencies
+    {
+      english: course.accept_english_gcse_equivalency?,
+      maths: course.accept_maths_gcse_equivalency?,
+      science: course.accept_science_gcse_equivalency?,
+    }.select { |_k, v| v }.keys
+  end
+end

--- a/app/models/required_qualifications_summary.rb
+++ b/app/models/required_qualifications_summary.rb
@@ -29,9 +29,9 @@ private
   def required_gcse_content
     case course.level
     when "primary"
-      "Grade 4 (C) or above in English, maths and science, or equivalent qualification."
+      "Grade #{course.gcse_grade_required} (C) or above in English, maths and science, or equivalent qualification."
     when "secondary"
-      "Grade 4 (C) or above in English and maths, or equivalent qualification."
+      "Grade #{course.gcse_grade_required} (C) or above in English and maths, or equivalent qualification."
     else
       ""
     end

--- a/app/models/required_qualifications_summary.rb
+++ b/app/models/required_qualifications_summary.rb
@@ -16,18 +16,14 @@ private
 
   def generate_summary_text
     output = ""
-    output << required_gcse_content
-    output << "\n"
-    output << pending_gcse_content
-    output << "\n"
-    output << gcse_equivalency_content
-    output << "\n"
-    output << (course.additional_gcse_equivalencies || "")
-    output << "\n"
-    output << degree_grade_content
-    output << "\n"
+    output << required_gcse_content << "\n"
+    output << pending_gcse_content << "\n"
+    output << gcse_equivalency_content << "\n"
+    output << (course.additional_gcse_equivalencies || "") << "\n"
+    output << degree_grade_content << "\n"
     output << degree_subject_requirements_content
-    output << "\n"
+
+    output.strip
   end
 
   def required_gcse_content

--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -115,6 +115,10 @@ module API
           @object.subjects.pluck(:subject_code).compact
         end
 
+        attribute :required_qualifications do
+          @object.required_qualifications
+        end
+
         enrichment_attribute :about_course
         enrichment_attribute :course_length
         enrichment_attribute :fee_details
@@ -125,7 +129,6 @@ module API
         enrichment_attribute :interview_process
         enrichment_attribute :other_requirements
         enrichment_attribute :personal_qualities
-        enrichment_attribute :required_qualifications
         enrichment_attribute :salary_details
       end
     end

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -24,7 +24,7 @@ FactoryBot.define do
     }
     degree_grade { :two_one }
     additional_degree_subject_requirements { true }
-    degree_subject_requirements { Faker::Lorem.sentence.to_s }
+    degree_subject_requirements { "Completed at least one programming module." }
 
     trait :with_gcse_equivalency do
       accept_pending_gcse { [true, false].sample }

--- a/spec/models/required_qualifications_summary_spec.rb
+++ b/spec/models/required_qualifications_summary_spec.rb
@@ -35,6 +35,15 @@ describe RequiredQualificationsSummary, type: :model do
         expect(summary).not_to include "Grade 4 (C) or above in English and maths, or equivalent qualification"
       end
 
+      it "specifies a GCSE grade requirement defined by the course" do
+        course = create(:course, :primary)
+        allow(course).to receive(:gcse_grade_required).and_return 5
+        summary = described_class.new(course).extract
+
+        expect(summary).to include "Grade 5 (C) or above in English, maths and science, or equivalent qualification"
+        expect(summary).not_to include "Grade 5 (C) or above in English and maths, or equivalent qualification"
+      end
+
       it "does not mention science as a required GCSE if course is secondary" do
         course = create(:course, :secondary)
         summary = described_class.new(course).extract

--- a/spec/models/required_qualifications_summary_spec.rb
+++ b/spec/models/required_qualifications_summary_spec.rb
@@ -1,0 +1,112 @@
+require "rails_helper"
+
+describe RequiredQualificationsSummary, type: :model do
+  describe "#extract" do
+    context "when a published required_qualifications enrichment attribute is present" do
+      let(:enrichment) { build(:course_enrichment, :published, required_qualifications: "GCSE Computer Science") }
+      let(:course) { create(:course, enrichments: [enrichment]) }
+
+      it "returns the value of required_qualifications" do
+        summary = described_class.new(course).extract
+        expect(summary).to eq "GCSE Computer Science"
+      end
+    end
+
+    context "when required_qualifications enrichment attribute is blank" do
+      it "assembles a whole summary based on course attributes" do
+        course = create(:course, :primary)
+        summary = described_class.new(course).extract
+
+        expect(summary).to eq <<~SUMMARY
+          Grade 4 (C) or above in English, maths and science, or equivalent qualification
+          Candidates with pending GCSEs will not be considered
+          Equivalency tests will not be accepted
+        SUMMARY
+      end
+
+      it "includes science as a required GCSE if course is primary" do
+        course = create(:course, :primary)
+        summary = described_class.new(course).extract
+
+        expect(summary).to include "Grade 4 (C) or above in English, maths and science, or equivalent qualification"
+        expect(summary).not_to include "Grade 4 (C) or above in English and maths, or equivalent qualification"
+      end
+
+      it "does not mention science as a required GCSE if course is secondary" do
+        course = create(:course, :secondary)
+        summary = described_class.new(course).extract
+
+        expect(summary).not_to include "Grade 4 (C) or above in English, maths and science, or equivalent qualification"
+        expect(summary).to include "Grade 4 (C) or above in English and maths, or equivalent qualification"
+      end
+
+      it "does not include required GCSE content if course is neither primary or secondary" do
+        course = create(:course, level: :further_education)
+        summary = described_class.new(course).extract
+
+        expect(summary).not_to include "Grade 4 (C) or above in English, maths and science, or equivalent qualification"
+        expect(summary).not_to include "Grade 4 (C) or above in English and maths, or equivalent qualification"
+      end
+
+      it "states pending GCSEs will be considered if accept_pending_gcse? is true" do
+        course = create(:course, accept_pending_gcse: true)
+        summary = described_class.new(course).extract
+
+        expect(summary).to include "Candidates with pending GCSEs will be considered"
+      end
+
+      it "states pending GCSEs will NOT be considered if accept_pending_gcse? is false" do
+        course = create(:course, accept_pending_gcse: false)
+        summary = described_class.new(course).extract
+
+        expect(summary).to include "Candidates with pending GCSEs will not be considered"
+      end
+
+      context "course.accept_gcse_equivalency? is false" do
+        let(:course) { create(:course, accept_gcse_equivalency: false) }
+
+        it "states equivalency tests not accepted" do
+          summary = described_class.new(course).extract
+
+          expect(summary).to include "Equivalency tests will not be accepted"
+        end
+      end
+
+      context "course.accept_gcse_equivalency? is true" do
+        let(:course) { create(:course, accept_gcse_equivalency: true) }
+
+        it "states one equivalency accepted if only one accepted" do
+          course.update!(accept_english_gcse_equivalency: true)
+          summary = described_class.new(course).extract
+
+          expect(summary).to include "Equivalency tests will be accepted in English"
+        end
+
+        it "states two equivalencies accepted if two accepted" do
+          course.update!(accept_english_gcse_equivalency: true, accept_maths_gcse_equivalency: true)
+          summary = described_class.new(course).extract
+
+          expect(summary).to include "Equivalency tests will be accepted in English and maths"
+        end
+
+        it "states three equivalencies accepted if three accepted" do
+          course.update!(
+            accept_english_gcse_equivalency: true,
+            accept_maths_gcse_equivalency: true,
+            accept_science_gcse_equivalency: true,
+          )
+          summary = described_class.new(course).extract
+
+          expect(summary).to include "Equivalency tests will be accepted in English, maths and science"
+        end
+
+        it "shows additional GCSE equivalencies if present" do
+          course.update!(additional_gcse_equivalencies: "Some additional GCSE equivalencies")
+          summary = described_class.new(course).extract
+
+          expect(summary).to include "Some additional GCSE equivalencies"
+        end
+      end
+    end
+  end
+end

--- a/spec/models/required_qualifications_summary_spec.rb
+++ b/spec/models/required_qualifications_summary_spec.rb
@@ -17,7 +17,7 @@ describe RequiredQualificationsSummary, type: :model do
         course = create(:course, :primary)
         summary = described_class.new(course).extract
 
-        expect(summary).to eq <<~SUMMARY
+        expect(summary).to eq <<~SUMMARY.strip
           Grade 4 (C) or above in English, maths and science, or equivalent qualification.
           Candidates with pending GCSEs will not be considered.
           Equivalency tests will not be accepted.

--- a/spec/models/required_qualifications_summary_spec.rb
+++ b/spec/models/required_qualifications_summary_spec.rb
@@ -18,9 +18,12 @@ describe RequiredQualificationsSummary, type: :model do
         summary = described_class.new(course).extract
 
         expect(summary).to eq <<~SUMMARY
-          Grade 4 (C) or above in English, maths and science, or equivalent qualification
-          Candidates with pending GCSEs will not be considered
-          Equivalency tests will not be accepted
+          Grade 4 (C) or above in English, maths and science, or equivalent qualification.
+          Candidates with pending GCSEs will not be considered.
+          Equivalency tests will not be accepted.
+
+          An undergraduate degree at class 2:1 or above, or equivalent.
+          Completed at least one programming module.
         SUMMARY
       end
 
@@ -106,6 +109,33 @@ describe RequiredQualificationsSummary, type: :model do
 
           expect(summary).to include "Some additional GCSE equivalencies"
         end
+      end
+
+      it "states the appropriate degree grade requirement" do
+        course = create(:course)
+        mapping = [
+          ["two_one", "An undergraduate degree at class 2:1 or above, or equivalent."],
+          ["two_two", "An undergraduate degree at class 2:2 or above, or equivalent."],
+          ["third_class", "An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent."],
+          ["not_required", "An undergraduate degree, or equivalent."],
+        ]
+
+        mapping.each do |grade, sentence|
+          course.update!(degree_grade: grade)
+          summary = described_class.new(course).extract
+
+          expect(summary).to include sentence
+        end
+
+        course.update!(degree_grade: nil)
+        summary = described_class.new(course).extract
+        mapping.each { |_, sentence| expect(summary).not_to include sentence }
+      end
+
+      it "displays additional_degree_subject_requirements if there are any" do
+        course = create(:course, additional_degree_subject_requirements: true, degree_subject_requirements: "Can spell gud")
+        summary = described_class.new(course).extract
+        expect(summary).to include "Can spell gud"
       end
     end
   end


### PR DESCRIPTION
### Context
We've updated course creation in Publish to take structured data for
required degree and GCSE information. This will eventually replace the
free text `required_qualifications` attribute.

To maintain the existing interface of the V1 public API, we need to
transform the structured data into a value that can be returned in the
`required_qualifications` field in scenarios where a Course has no value
for that attribute.

https://trello.com/c/LR2VwtVq

### Changes proposed in this pull request

Do this by adding a RequiredQualificationsSummary object that's invoked
via the Course model. This object:

- Takes an instance of Course as an argument
- Looks for the `required_qualifications` enrichment attribute, and uses
  it if it has a value
- Otherwise generates summary text from the qualifications-specific
  attributes on Course

### Guidance to review
- Can be manually tested locally by creating a course in Publish and viewing it via the V1 public API. Could do this for both courses created with the free text field and the new structured qualifications form.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
