### PR TITLE
Appease rubocop 1.18.1

### DIFF
--- a/app/mailers/course_vacancies/updated_mailer.rb
+++ b/app/mailers/course_vacancies/updated_mailer.rb
@@ -38,8 +38,8 @@ module CourseVacancies
 
     def create_course_url(course)
       "#{Settings.find_url}" \
-      "/course/#{course.provider.provider_code}" \
-      "/#{course.course_code}"
+        "/course/#{course.provider.provider_code}" \
+        "/#{course.course_code}"
     end
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -189,20 +189,20 @@ class Provider < ApplicationRecord
   # less time rendering because there's less data to comb through.
   def self.include_courses_counts
     joins(
-      %{
+      <<~EOSQL,
         LEFT OUTER JOIN (
           SELECT b.provider_id, COUNT(*) courses_count
           FROM course b
           WHERE b.discarded_at IS NULL
           GROUP BY b.provider_id
         ) a ON a.provider_id = provider.id
-      },
+      EOSQL
     ).select("provider.*, COALESCE(a.courses_count, 0) AS included_courses_count")
   end
 
   def self.include_accredited_courses_counts(provider_code)
     joins(
-      %{
+      <<~EOSQL,
         LEFT OUTER JOIN (
           SELECT b.provider_id, COUNT(*) courses_count
           FROM course b
@@ -210,7 +210,7 @@ class Provider < ApplicationRecord
           AND b.accredited_body_code = #{ActiveRecord::Base.connection.quote(provider_code)}
           GROUP BY b.provider_id
         ) a ON a.provider_id = provider.id
-      },
+      EOSQL
     ).select("provider.*, COALESCE(a.courses_count, 0) AS included_accredited_courses_count")
   end
 

--- a/app/services/rollover_service.rb
+++ b/app/services/rollover_service.rb
@@ -13,10 +13,10 @@ class RolloverService
     end
 
     puts "Rollover done: " \
-           "#{total_counts[:providers]} providers, " \
-           "#{total_counts[:sites]} sites, " \
-           "#{total_counts[:courses]} courses " \
-           "in %.3f seconds" % total_bm.real
+         "#{total_counts[:providers]} providers, " \
+         "#{total_counts[:sites]} sites, " \
+         "#{total_counts[:courses]} courses " \
+         "in %.3f seconds" % total_bm.real
   end
 
 private
@@ -47,9 +47,9 @@ private
     end
 
     puts "provider #{counts[:providers].zero? ? 'skipped' : 'copied'}, " \
-            "#{counts[:sites]} sites copied, " \
-            "#{counts[:courses]} courses copied " \
-            "in %.3f seconds" % bm.real
+         "#{counts[:sites]} sites copied, " \
+         "#{counts[:courses]} courses copied " \
+         "in %.3f seconds" % bm.real
 
     total_counts.merge!(counts) { |_, total, count| total + count }
   end

--- a/config/initializers/canonical_rails.rb
+++ b/config/initializers/canonical_rails.rb
@@ -16,7 +16,7 @@ CanonicalRails.setup do |config|
   # Trailing slash represents semantics of a directory, ie a collection view - implying an :index get route;
   # otherwise we have to assume semantics of an instance of a resource type, a member view - implying a :show get route
   #
-  # Acts as a whitelist for routes to have trailing slashes
+  # Acts as an allowlist for routes to have trailing slashes
 
   config.collection_actions # = [:index]
 

--- a/db/migrate/20200303163136_remove_self_accrediting_provider_on_course.rb
+++ b/db/migrate/20200303163136_remove_self_accrediting_provider_on_course.rb
@@ -1,11 +1,14 @@
 class RemoveSelfAccreditingProviderOnCourse < ActiveRecord::Migration[6.0]
   def up
     say_with_time "remove accrediting provider code" do
-      ids = Course.find_by_sql("
-      SELECT c.* FROM course AS c
-      INNER JOIN provider AS p
-        ON p.id = c.provider_id
-        AND c.accrediting_provider_code = p.provider_code").map(&:id)
+      ids = Course.find_by_sql(
+        <<~EOSQL,
+          SELECT c.* FROM course AS c
+          INNER JOIN provider AS p
+            ON p.id = c.provider_id
+            AND c.accrediting_provider_code = p.provider_code
+        EOSQL
+      ).map(&:id)
 
       Course.where(id: ids).update_all(accrediting_provider_code: nil)
     end

--- a/lib/mcb/commands/az/apps/pg_dump.rb
+++ b/lib/mcb/commands/az/apps/pg_dump.rb
@@ -16,10 +16,10 @@ run do |opts, _args, _cmd|
   ENV["PGPASSWORD"] = ENV["DB_PASSWORD"]
   target_file = opts[:target_file]
   target_file ||= "#{opts[:env] || ENV['DB_HOSTNAME']}_" \
-    "#{ENV['DB_DATABASE']}_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}.sql"
+                  "#{ENV['DB_DATABASE']}_#{Time.now.utc.strftime('%Y%m%d_%H%M%S')}.sql"
   cmd = "pg_dump --encoding utf8 --clean --if-exists " \
-      "-h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} " \
-      "--file '#{target_file}'"
+        "-h #{ENV['DB_HOSTNAME']} -U #{ENV['DB_USERNAME']} -d #{ENV['DB_DATABASE']} " \
+        "--file '#{target_file}'"
 
   MCB::exec_command(cmd)
 end

--- a/lib/mcb/commands/db.rb
+++ b/lib/mcb/commands/db.rb
@@ -2,7 +2,7 @@ name "psql"
 summary "connect to the psql server for an app"
 # h is used for help so used H instead
 option :H, "host", "override hostname of database - useful for connecting to restored copies."\
-       " Just the hostname, not the fully qualified name. E.g. bat-mcapi-restore-psql",
+                   " Just the hostname, not the fully qualified name. E.g. bat-mcapi-restore-psql",
        argument: :optional
 option :f, "source_file", "source sql file to pass to psql to run",
        argument: :optional

--- a/spec/mailers/course_publish_email_mailer_spec.rb
+++ b/spec/mailers/course_publish_email_mailer_spec.rb
@@ -45,8 +45,8 @@ describe CoursePublishEmailMailer, type: :mailer do
 
     it "includes the URL for the course in the personalisation" do
       url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
+            "/course/#{course.provider.provider_code}" \
+            "/#{course.course_code}"
       expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
     end
   end

--- a/spec/mailers/course_sites_update_email_mailer_spec.rb
+++ b/spec/mailers/course_sites_update_email_mailer_spec.rb
@@ -54,8 +54,8 @@ describe CourseSitesUpdateEmailMailer, type: :mailer do
 
     it "includes the URL for the course in the personalisation" do
       url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
+            "/course/#{course.provider.provider_code}" \
+            "/#{course.course_code}"
       expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
     end
   end

--- a/spec/mailers/course_update_email_mailer_spec.rb
+++ b/spec/mailers/course_update_email_mailer_spec.rb
@@ -76,8 +76,8 @@ describe CourseUpdateEmailMailer, type: :mailer do
 
     it "includes the URL for the course in the personalisation" do
       url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
+            "/course/#{course.provider.provider_code}" \
+            "/#{course.course_code}"
       expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
     end
   end

--- a/spec/mailers/course_vacancies/updated_mailer_spec.rb
+++ b/spec/mailers/course_vacancies/updated_mailer_spec.rb
@@ -48,8 +48,8 @@ module CourseVacancies
 
         it "includes the URL for the course in the personalisation" do
           url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
+                "/course/#{course.provider.provider_code}" \
+                "/#{course.course_code}"
           expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
         end
 
@@ -117,8 +117,8 @@ module CourseVacancies
 
         it "includes the URL for the course in the personalisation" do
           url = "#{Settings.find_url}" \
-        "/course/#{course.provider.provider_code}" \
-        "/#{course.course_code}"
+                "/course/#{course.provider.provider_code}" \
+                "/#{course.course_code}"
           expect(mail.govuk_notify_personalisation[:course_url]).to eq(url)
         end
 

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -456,7 +456,7 @@ describe "/api/v2/build_new_course", type: :request do
 
   def do_get(params)
     get "/api/v2/build_new_course?year=#{recruitment_cycle.year}" \
-          "&provider_code=#{provider.provider_code}",
+        "&provider_code=#{provider.provider_code}",
         headers: { "HTTP_AUTHORIZATION" => credentials },
         params: params
     response

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "POST /providers/:provider_code/courses/:course_code" do
     )
 
     post "/api/v2/recruitment_cycles/#{recruitment_cycle.year}/providers/" \
-            "#{course.provider.provider_code}/courses",
+         "#{course.provider.provider_code}/courses",
          headers: { "HTTP_AUTHORIZATION" => credentials },
          params: {
            _jsonapi: { data: jsonapi_data[:data] },

--- a/spec/requests/api/v2/providers/courses/update_accrediting_provider_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_accrediting_provider_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_accredited_body_code
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_degree_subject_requirements_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_additional_degree_subject_requirements
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_additional_gcse_equivalencies
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_age_range_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_age_range_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_age_range_in_years
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_application_open_from_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_application_open_from_spec.rb
@@ -13,7 +13,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_applications_open_from
 
     patch "/api/v2/recruitment_cycles/#{course.provider.recruitment_cycle.year}/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_grade_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_degree_grade
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_degree_subject_requirements
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_english_gcse_equivalency_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_english_gcse_equivalency_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_english_gcse_equivalency
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_gcse_equivalency_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gcse_equivalency_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_gcse_equivalency
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = gcse_requirements
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_maths_gcse_equivalency_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_maths_gcse_equivalency_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_maths_gcse_equivalency
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_outcomes_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_outcomes_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_qualification
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_pending_gcse_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_pending_gcse_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_pending_gcse
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_program_type_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_program_type_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = funding_type
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_science_gcse_equivalency_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_science_gcse_equivalency_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_science_gcse_equivalency
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_send_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_send_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_is_send
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -44,7 +44,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code with sites" do
 
   def perform_request
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: {
             "HTTP_AUTHORIZATION" => credentials,
             "Content-Type": "application/json",

--- a/spec/requests/api/v2/providers/courses/update_start_date_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_start_date_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_start_date
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_study_mode_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:attributes] = updated_study_mode
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -14,7 +14,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
     jsonapi_data[:data][:relationships] = updated_subjects
 
     patch "/api/v2/providers/#{course.provider.provider_code}" \
-            "/courses/#{course.course_code}",
+          "/courses/#{course.course_code}",
           headers: { "HTTP_AUTHORIZATION" => credentials },
           params: {
             _jsonapi: jsonapi_data,

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -1040,7 +1040,7 @@ describe "Courses API v2", type: :request do
       describe "making a request for the next recruitment cycle" do
         let(:request_path) {
           "/api/v2/recruitment_cycles/#{next_cycle.year}" \
-          "/providers/#{next_provider.provider_code}/courses"
+            "/providers/#{next_provider.provider_code}/courses"
         }
 
         it "only returns data for the next recruitment cycle" do

--- a/spec/requests/api/v2/providers/providers_show_spec.rb
+++ b/spec/requests/api/v2/providers/providers_show_spec.rb
@@ -219,7 +219,7 @@ describe "Providers API v2", type: :request do
       describe "making a request for the next recruitment cycle" do
         let(:request_path) {
           "/api/v2/recruitment_cycles/#{next_recruitment_cycle.year}" \
-          "/providers/#{next_provider.provider_code}"
+            "/providers/#{next_provider.provider_code}"
         }
 
         it "only returns data for the next recruitment cycle" do

--- a/spec/requests/api/v2/providers/sites_spec.rb
+++ b/spec/requests/api/v2/providers/sites_spec.rb
@@ -174,7 +174,7 @@ describe "Sites API v2", type: :request do
       describe "when specifying the next recruitment cycle" do
         let(:request_path) {
           "/api/v2/recruitment_cycles/#{next_cycle.year}" \
-           "/providers/#{provider.provider_code}/sites"
+            "/providers/#{provider.provider_code}/sites"
         }
 
         subject do

--- a/spec/requests/api/v2/recruitment_cycle_spec.rb
+++ b/spec/requests/api/v2/recruitment_cycle_spec.rb
@@ -88,8 +88,8 @@ describe "/api/v2/recruitment_cycle", type: :request do
 
     let(:request_path) {
       "/api/v2/recruitment_cycles/#{recruitment_cycle.year}" \
-      "/providers/#{provider.provider_code}" \
-      "/recruitment_cycles"
+        "/providers/#{provider.provider_code}" \
+        "/recruitment_cycles"
     }
 
     describe "the JSON response" do

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -193,7 +193,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
       describe "making a request for the next recruitment cycle" do
         let(:request_path) {
           "/api/v3/recruitment_cycles/#{next_cycle.year}" \
-          "/providers/#{next_provider.provider_code}/courses"
+            "/providers/#{next_provider.provider_code}/courses"
         }
 
         it "only returns data for the next recruitment cycle" do

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -27,8 +27,8 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   let(:jsonapi_response) { JSON.parse(response.body) }
   let(:route) {
     "/api/v3/recruitment_cycles/#{current_year}" \
-    "/providers/#{provider.provider_code}" \
-    "/courses/#{course.course_code}"
+      "/providers/#{provider.provider_code}" \
+      "/courses/#{course.course_code}"
   }
   let(:course) {
     create :course,

--- a/spec/requests/api/v3/providers/show_spec.rb
+++ b/spec/requests/api/v3/providers/show_spec.rb
@@ -227,7 +227,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
     describe "making a request for the next recruitment cycle" do
       let(:request_path) {
         "/api/v3/recruitment_cycles/#{next_recruitment_cycle.year}" \
-        "/providers/#{next_provider.provider_code}"
+          "/providers/#{next_provider.provider_code}"
       }
 
       it "only returns data for the next recruitment cycle" do


### PR DESCRIPTION
Fixed the issues raised by the updated version of rubocop.
Layout/LineEndStringConcatenationIndentation was unable to cope with
autocorrect, so that has been dealt by replacing the curly percent
literal with heredocs, in a migration and the provider model.
