### PR TITLE
[2094] Lead schools are required to have a URN and UKPRN

### DIFF
--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -122,9 +122,15 @@ class Provider < ApplicationRecord
 
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
-  validates :ukprn, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }
+  # TODO: Remove this validation once the 2021 recruitment cycle is over
+  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }
 
-  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: :lead_school?
+  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }, if: -> { recruitment_cycle.after_2021? }
+
+  # TODO: Remove this validation once the 2021 recruitment cycle is over
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: :lead_school?
+
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { lead_school? && recruitment_cycle.after_2021? }
 
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?
   validates :train_with_disability, presence: true, on: :update, if: :train_with_disability_changed?

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -123,14 +123,14 @@ class Provider < ApplicationRecord
   validates :telephone, phone: { message: "^Enter a valid telephone number" }, if: :telephone_changed?
 
   # TODO: Remove this validation once the 2021 recruitment cycle is over
-  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }
+  validates :ukprn, reference_number_format: { allow_blank: true, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }
 
-  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }, if: -> { recruitment_cycle.after_2021? }
+  validates :ukprn, reference_number_format: { allow_blank: false, minimum: 8, maximum: 8, message: "^UKPRN must be 8 numbers" }, if: -> { recruitment_cycle.after_2021? }, on: :update
 
   # TODO: Remove this validation once the 2021 recruitment cycle is over
-  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: :lead_school?
+  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: :lead_school?
 
-  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { lead_school? && recruitment_cycle.after_2021? }
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { lead_school? && recruitment_cycle.after_2021? }, on: :update
 
   validates :train_with_us, presence: true, on: :update, if: :train_with_us_changed?
   validates :train_with_disability, presence: true, on: :update, if: :train_with_disability_changed?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -26,9 +26,9 @@ class Site < ApplicationRecord
                    presence: true
 
   # TODO: Remove this validation once the 2021 recruitment cycle is over
-  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }
+  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }
 
-  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { provider.recruitment_cycle.after_2021? }
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { provider.present? && recruitment_cycle_after_2021? }
 
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 
@@ -37,6 +37,9 @@ class Site < ApplicationRecord
   attr_accessor :skip_geocoding
   after_commit :geocode_site, unless: :skip_geocoding
   after_commit :add_travel_to_work_area_and_london_borough, if: :needs_travel_to_work_area_and_london_borough_updated?
+
+  delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
+  delegate :after_2021?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
 
   def geocode_site
     GeocodeJob.perform_later("Site", id) if needs_geolocation?

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -25,7 +25,10 @@ class Site < ApplicationRecord
                    format: { with: /\A[A-Z0-9\-]+\z/, message: "must contain only A-Z, 0-9 or -" },
                    presence: true
 
-  validates :urn, reference_number_format: { allow_blank: true, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }
+  # TODO: Remove this validation once the 2021 recruitment cycle is over
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }
+
+  validates :urn, reference_number_format: { allow_blank: false, minimum: 5, maximum: 6, message: "^URN must be 5 or 6 numbers" }, if: -> { provider.recruitment_cycle.after_2021? }
 
   acts_as_mappable lat_column_name: :latitude, lng_column_name: :longitude
 

--- a/app/services/providers/create_fake_provider_service.rb
+++ b/app/services/providers/create_fake_provider_service.rb
@@ -8,6 +8,7 @@ module Providers
       address4: "County",
       postcode: "M1 1JG",
       region_code: "north_west",
+      ukprn: "12345678",
     }.freeze
 
     def initialize(recruitment_cycle:, provider_name:, provider_code:, provider_type:, is_accredited_body:)
@@ -45,6 +46,7 @@ module Providers
         address4: provider.address4,
         postcode: provider.postcode,
         region_code: provider.region_code,
+        urn: Faker::Number.number(digits: [5, 6].sample),
       )
 
       true

--- a/app/validators/reference_number_format_validator.rb
+++ b/app/validators/reference_number_format_validator.rb
@@ -2,9 +2,7 @@ class ReferenceNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if options[:allow_blank] && value.blank?
 
-    return record.errors.add "#{attribute.to_s.upcase} cannot be blank" if value.blank? && !options[:allow_blank]
-
-    if value.length > options[:maximum] || value.length < options[:minimum] || !value.match?(/\A-?\d+\Z/)
+    if value.blank? || value.length > options[:maximum] || value.length < options[:minimum] || !value.match?(/\A-?\d+\Z/)
       record.errors.add attribute, options[:message]
     end
   end

--- a/app/validators/reference_number_format_validator.rb
+++ b/app/validators/reference_number_format_validator.rb
@@ -2,6 +2,8 @@ class ReferenceNumberFormatValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if options[:allow_blank] && value.blank?
 
+    return record.errors.add "#{attribute.to_s.upcase} cannot be blank" if value.blank? && !options[:allow_blank]
+
     if value.length > options[:maximum] || value.length < options[:minimum] || !value.match?(/\A-?\d+\Z/)
       record.errors.add attribute, options[:message]
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,6 +53,7 @@ def create_standard_provider_and_courses_for_cycle(recruitment_cycle, superuser)
     address3: Faker::Address.city,
     address4: Faker::Address.state,
     postcode: Faker::Address.postcode,
+    urn: Faker::Number.number(digits: [5, 6].sample),
   )
 
   primary_course = Course.create!(

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -48,6 +48,22 @@ describe Provider, type: :model do
     end
   end
 
+  context "when the provider updates their ukprn in the 2022 cycle" do
+    let(:provider) do
+      create(
+        :provider,
+        ukprn: "",
+        recruitment_cycle: create(:recruitment_cycle, year: "2022"),
+      )
+    end
+
+    it "validates the presence of a ukprn" do
+      # this means that rollover happens successfully; the record is created but it will be invalid on update, because of no ukprn
+      expect { provider }.to change { Provider.count }.by(1)
+      expect(provider).to_not be_valid
+    end
+  end
+
   describe "organisation" do
     it "returns the only organisation a provider has" do
       expect(subject.organisation).to eq subject.organisations.first

--- a/spec/models/site_spec.rb
+++ b/spec/models/site_spec.rb
@@ -62,11 +62,7 @@ describe Site, type: :model do
       )
     end
 
-    it "validates the presence of a URN" do
-      # this means that rollover happens successfully; the record is created but it will be invalid on update, because of no URN
-      expect { site }.to change { Site.count }.by(1)
-      expect(site).to_not be_valid
-    end
+    it { is_expected.to validate_presence_of(:urn).with_message("^URN must be 5 or 6 numbers") }
   end
 
   describe "#touch_provider" do


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/M4m91TCf/2094-s-lead-schools-are-required-to-have-a-urn-and-a-ukprn)

### Changes proposed in this pull request

- Added custom validations to not allow blank values for URN and UKPRN on sites and providers respectively, scoped to lead schools

### Guidance to review

- On a provider that is a lead school, try and make a site without a URN. You will be met with an error message on submission of the form. 
- On a provider that is a lead school, try and submit your contact details without a UKPRN. You will be met with an error message on submission of the form. 
- 🧵  These validations are only run `on: :update` to allow for creation of providers without a urn. 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
