### PR TITLE
Remove validation for CourseEnrichment#required_qualifications from 2022

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -70,7 +70,7 @@ class CourseEnrichment < ApplicationRecord
 
   # Requirements and qualifications
 
-  validates :required_qualifications, presence: true, on: :publish
+  validates :required_qualifications, presence: true, on: :publish, if: :required_qualifications_needed?
   validates :required_qualifications, words_count: { maximum: 100 }
 
   validates :personal_qualities, words_count: { maximum: 100 }
@@ -99,5 +99,9 @@ class CourseEnrichment < ApplicationRecord
 
   def withdraw
     update(status: "withdrawn")
+  end
+
+  def required_qualifications_needed?
+    (course&.provider&.recruitment_cycle&.year.to_i) < Course::DEGREE_REQUIREMENTS_REQUIRED_FROM
   end
 end

--- a/spec/models/course_enrichment_spec.rb
+++ b/spec/models/course_enrichment_spec.rb
@@ -140,8 +140,11 @@ describe CourseEnrichment, type: :model do
 
   describe "required_qualifications attribute" do
     let(:required_qualifications_text) { "this course is great" }
+    let(:recruitment_cycle) { build(:recruitment_cycle, year: "2021") }
+    let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+    let(:course) { build(:course, provider: provider) }
 
-    subject { build :course_enrichment, required_qualifications: required_qualifications_text }
+    subject { build :course_enrichment, required_qualifications: required_qualifications_text, course: course }
 
     context "with over 100 words" do
       let(:required_qualifications_text) { Faker::Lorem.sentence(word_count: 100 + 1) }
@@ -155,7 +158,15 @@ describe CourseEnrichment, type: :model do
       it { is_expected.to be_valid }
 
       describe "on publish" do
-        it { is_expected.to_not be_valid :publish }
+        context "in recruitment cycle 2021" do
+          it { is_expected.to_not be_valid :publish }
+        end
+
+        context "in recruitment cycle 2022" do
+          let(:recruitment_cycle) { build(:recruitment_cycle, year: "2022") }
+
+          it { is_expected.to be_valid :publish }
+        end
       end
     end
   end
@@ -215,7 +226,6 @@ describe CourseEnrichment, type: :model do
 
     context "fee based course" do
       it { is_expected.to validate_presence_of(:fee_uk_eu).on(:publish) }
-      it { is_expected.to validate_presence_of(:required_qualifications).on(:publish) }
       it { is_expected.to validate_presence_of(:fee_uk_eu).on(:publish) }
       it { is_expected.to validate_numericality_of(:fee_uk_eu).on(:publish) }
       it { is_expected.to validate_numericality_of(:fee_international).on(:publish) }
@@ -250,7 +260,6 @@ describe CourseEnrichment, type: :model do
       let(:course_enrichment) { build(:course_enrichment, :with_salary_based_course) }
 
       it { is_expected.to validate_presence_of(:salary_details).on(:publish) }
-      it { is_expected.to validate_presence_of(:required_qualifications).on(:publish) }
       it { is_expected.to_not validate_presence_of(:fee_uk_eu).on(:publish) }
       it { is_expected.to_not validate_numericality_of(:fee_uk_eu).on(:publish) }
       it { is_expected.to_not validate_numericality_of(:fee_international).on(:publish) }


### PR DESCRIPTION
### Context

This validation for the presence of `CourseEnrichment#required_qualifications` should not be active after the 2021 recruitment cycle. It has been replaced by new attributes.

https://trello.com/c/bCnjk5oa/3561-remove-the-qualifications-needed-section-from-the-course-page-on-publish-for-2022-courses

### Changes proposed in this pull request

- Make the `presence` validation conditional on recruitment cycle and update specs.

### Guidance to review

- Does this validation make sense?
- Can be manually tested by finding a draft 2022 course, setting it's _Qualifications needed_ to blank and attempting to publish.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
