### PR TITLE
Wait for review app deployment to finish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,21 @@ jobs:
         GIT_BRANCH: ${{env.BRANCH_TAG}}
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
+    - name: Wait for review app deployment
+      id: wait_for_review_app_deployment
+      if: ${{ github.event_name == 'pull_request' && github.actor != 'dependabot[bot]' }}
+      uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        ref: ${{ github.head_ref }}
+        checkName: ${{ github.event.pull_request.number }} Deployment
+        timeoutSeconds:  1800
+        intervalSeconds: 10
+
+    - name: Exit if review app deployment failed
+      if: ${{ steps.wait_for_review_app_deployment.outputs.conclusion != '' && steps.wait_for_review_app_deployment.outputs.conclusion != 'success' }}
+      run: exit 1
+
     - name: Trigger Deployment
       if: ${{ success() && github.ref == 'refs/heads/master' }}
       uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
### Context

Currently the review app deployment is asynchronous from the build workflow,
so it is not visible in the PR checks if the app deployment has failed.

### Changes proposed in this pull request

Add an action to wait for the deployment workflow
Fail the PR build check, if the review app deployment fails

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
