### PR TITLE
Add validations to the backend for publishing structured GCSE requirements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -55,7 +55,7 @@ class Course < ApplicationRecord
     not_set: nil,
   }.freeze
 
-  DEGREE_REQUIREMENTS_REQUIRED_FROM = 2022
+  STRUCTURED_REQUIREMENTS_REQUIRED_FROM = 2022
 
   # Most providers require GCSE grade 4 ("C"),
   # but some require grade 5 ("strong C")
@@ -268,6 +268,7 @@ class Course < ApplicationRecord
   validate :validate_provider_urn_ukprn_publishable, on: :publish, if: -> { recruitment_cycle.after_2021? }
   validate :validate_all_sites_publishable, on: :publish, if: -> { recruitment_cycle.after_2021? }
   validate :validate_degree_requirements_publishable, on: :publish
+  validate :validate_gcse_requirements_publishable, on: :publish
   validate :validate_enrichment
   validate :validate_qualification, on: %i[update new]
   validate :validate_start_date, on: :update, if: -> { provider.present? && start_date.present? }
@@ -586,9 +587,16 @@ class Course < ApplicationRecord
   end
 
   def validate_degree_requirements_publishable
-    return true if recruitment_cycle.year.to_i < DEGREE_REQUIREMENTS_REQUIRED_FROM || degree_grade.present?
+    return true if recruitment_cycle.year.to_i < STRUCTURED_REQUIREMENTS_REQUIRED_FROM || degree_grade.present?
 
     errors.add(:base, :degree_requirements_not_publishable)
+    false
+  end
+
+  def validate_gcse_requirements_publishable
+    return true if recruitment_cycle.year.to_i < STRUCTURED_REQUIREMENTS_REQUIRED_FROM || !accept_pending_gcse.nil? || !accept_gcse_equivalency.nil?
+
+    errors.add(:base, :gcse_requirements_not_publishable)
     false
   end
 

--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -102,6 +102,6 @@ class CourseEnrichment < ApplicationRecord
   end
 
   def required_qualifications_needed?
-    (course&.provider&.recruitment_cycle&.year.to_i) < Course::DEGREE_REQUIREMENTS_REQUIRED_FROM
+    (course&.provider&.recruitment_cycle&.year.to_i) < Course::STRUCTURED_REQUIREMENTS_REQUIRED_FROM
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -124,6 +124,7 @@ en:
               provider_ukprn_not_publishable: "You must provide a UK provider reference number (UKPRN)"
               provider_ukprn_and_urn_not_publishable: "You must provide a UK provider reference number (UKPRN) and URN"
               degree_requirements_not_publishable: "Enter degree requirements"
+              gcse_requirements_not_publishable: "Enter GCSE requirements"
         course_enrichment:
           attributes:
             salary_details:

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -6,6 +6,7 @@ describe API::V2::CoursesController, type: :controller do
   let(:provider) { create(:provider) }
   let(:course) do
     create(:course,
+           :with_gcse_equivalency,
            site_statuses: [site_status],
            enrichments: [enrichment],
            subjects: [dfe_subject],

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -9,7 +9,6 @@ describe "Publish API v2", type: :request do
 
   describe "POST publish" do
     let(:status) { 200 }
-    let(:course) { findable_open_course }
     let(:publish_path) do
       "/api/v2/recruitment_cycles/#{provider.recruitment_cycle.year}/providers/#{provider.provider_code}" +
         "/courses/#{course.course_code}/publish"
@@ -20,6 +19,7 @@ describe "Publish API v2", type: :request do
     let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
     let(:course) {
       create(:course,
+             :with_gcse_equivalency,
              provider: provider,
              site_statuses: [site_status],
              enrichments: [enrichment],
@@ -54,6 +54,7 @@ describe "Publish API v2", type: :request do
       let(:dfe_subjects) { [find_or_create(:primary_subject, :primary_with_mathematics)] }
       let!(:course) do
         create(:course,
+               :with_gcse_equivalency,
                level: "primary",
                provider: provider,
                site_statuses: [site_status],


### PR DESCRIPTION
### Context

https://trello.com/c/oLvRx47b/3497-add-the-structured-gcse-requirements-section-to-publish

We're not stopping providers from publishing their courses without completing the new structured GCSE section.

We should be from courses in the 2022 cycle

### Changes proposed in this pull request

- Add validation to the publish action which checks that `accept_pending_gcse` and `accept_gcse_equivalency` are not nil for providers in the 2022 cycle

### Guidance to review

This follows the established pattern from the degree and visa work

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
