### PR TITLE
Update error messages

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -205,7 +205,7 @@ module API
         # This is because sites = [] is something that we can validate against,
         # but we can't actually revert easily from what I can tell because of the
         #  remove_site! side effects that occur when it's called.
-        @course.errors.add(:sites, message: "^You must choose at least one location") if site_ids.empty?
+        @course.errors.add(:sites, message: "^Select at least one location") if site_ids.empty?
         @updated_site_names = @course.sites.map(&:location_name) unless site_ids.empty?
       end
 

--- a/app/services/courses/validate_custom_age_range_service.rb
+++ b/app/services/courses/validate_custom_age_range_service.rb
@@ -1,7 +1,7 @@
 module Courses
   class ValidateCustomAgeRangeService
     def execute(age_range_in_years, course)
-      error_message = "#{age_range_in_years.to_s.tr('_', ' ')} is invalid. You must enter a valid age range."
+      error_message = "#{age_range_in_years.to_s.tr('_', ' ')} is invalid. Enter a valid age range."
       valid_age_range_regex = Regexp.new(/^(?<from>\d{1,2})_to_(?<to>\d{1,2})$/)
 
       if valid_age_range_regex.match(age_range_in_years)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,20 +8,20 @@ en:
   components:
     page_titles:
       sign_in:
-        index: Sign in
-        new: User not found
+        index: "Sign in"
+        new: "User not found"
       support:
         providers:
-          index: Providers
+          index: "Providers"
           courses:
-            index: Courses
+            index: "Courses"
         users:
-          index: Users
-          show: User overview
+          index: "Users"
+          show: "User overview"
         data_exports:
-          index: Data exports
+          index: "Data exports"
     filter:
-      text_search: Name or code
+      text_search: "Name or code"
   course:
     update_email:
       name: "title"
@@ -48,17 +48,17 @@ en:
         not_required: "Not required"
   provider_suggestion:
     errors:
-      bad_request: Unknown provider code or name, please check the query string.
+      bad_request: "Unknown provider code or name, please check the query string."
   support:
     data_exports:
       index:
         users:
-          name: Only users affiliated with a provider
+          name: "Only users affiliated with a provider"
           description: "The list of all users affiliated with a provider from current recruitment cycle with columns: provider_code, provider_name, provider_type, first_name, last_name, email_address"
   activerecord:
     attributes:
       course:
-        name: Title
+        name: "Title"
       course_enrichment:
         fee_uk_eu: "Course fees for UK and EU students"
         fee_international: "Course fees for international students"
@@ -90,37 +90,37 @@ en:
         course:
           attributes:
             level:
-              blank: "^You need to pick a level"
+              blank: "^Select a course level"
             qualification:
-              blank: "^You need to pick an outcome"
+              blank: "^Select an outcome"
             maths:
-              inclusion: "^Pick an option for Maths"
+              inclusion: "^Select an option for maths"
             english:
-              inclusion: "^Pick an option for English"
+              inclusion: "^Select an option for English"
             science:
-              inclusion: "^Pick an option for Science"
+              inclusion: "^Select an option for science"
             enrichments:
               blank: "^Complete your course information before publishing"
             sites:
-              blank: "^You must pick at least one location for this course"
+              blank: "^Select at least one location for this course"
               site_urn_not_publishable: "^Enter a Unique Reference Number (URN) for all course locations"
             age_range_in_years:
-              blank: "^You need to pick an age range"
+              blank: "^Select an age range"
             program_type:
-              blank: "^You need to pick an option"
+              blank: "^Select a program type"
             subjects:
               blank: "^There is a problem with this course. Contact support to fix it (Error: S)"
-              course_creation: "^You must pick at least one subject"
-              duplicate: "^You've already selected this subject - you can only select a subject once"
+              course_creation: "^Select at least one subject"
+              duplicate: "^You have already selected this subject. You can only select a subject once"
             modern_languages_subjects:
-              select_a_language: "^You must pick at least one language"
+              select_a_language: "^Select at least one language"
             study_mode:
-              blank: "^You need to pick an option"
+              blank: "^Select a study mode"
             applications_open_from:
-              blank: "^You must say when applications open from"
+              blank: "^Select when applications will open and enter the date if applicable"
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
-              visa_sponsorship_not_publishable: "You must say whether you can sponsor visas"
+              visa_sponsorship_not_publishable: "Select if you can sponsor visas"
               provider_ukprn_not_publishable: "Enter a UK Provider Reference Number (UKPRN)"
               provider_ukprn_and_urn_not_publishable: "Enter a UK Provider Reference Number (UKPRN) and URN"
               degree_requirements_not_publishable: "Enter degree requirements"
@@ -128,9 +128,9 @@ en:
         course_enrichment:
           attributes:
             salary_details:
-              blank: "^Give details about the salary for this course"
+              blank: "^Enter details about the salary for this course"
             fee_uk_eu:
-              blank: "^Give details about the fee for UK and EU students"
+              blank: "^Enter details about the fee for UK and EU students"
               greater_than_or_equal_to: "must be greater than or equal to £0"
               less_than_or_equal_to: "must be less than or equal to £100,000"
               not_an_integer: "must not include pence, like 1000 or 1500"
@@ -149,7 +149,7 @@ en:
         provider:
           attributes:
             provider_name:
-              too_long: "Your provider name is too long, it must be fewer than 100 characters"
+              too_long: "Enter a provider name that is 100 characters or fewer"
             email:
               blank: "^Enter email address"
             website:
@@ -193,4 +193,4 @@ en:
       title: SERVER_ERROR
       detail: "Something has gone wrong, please try again in a few minutes"
   pagy:
-    overflow: The requested page param was out of range and invalid for this request.
+    overflow: "The requested page param was out of range and invalid for this request."

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -70,7 +70,7 @@ describe API::V2::CoursesController, type: :controller do
           end
 
           it "has a validation error about provider not having visa sponsorship information" do
-            expect(validation_errors).to include("You must say whether you can sponsor visas")
+            expect(validation_errors).to include("Select if you can sponsor visas")
           end
 
           it "has a validation error about provider not having a UKPRN" do
@@ -121,7 +121,7 @@ describe API::V2::CoursesController, type: :controller do
           end
 
           it "returns no validation error about missing visa information" do
-            expect(response.body).not_to match(/You must say whether you can sponsor visas/)
+            expect(response.body).not_to match(/Select if you can sponsor visas/)
           end
         end
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -298,7 +298,7 @@ describe Course, type: :model do
     it {
       expect(subject).to validate_presence_of(:level)
         .on(:publish)
-        .with_message("^You need to pick a level")
+        .with_message("^Select a course level")
     }
 
     it "validates scoped to provider_id and only on create and update" do
@@ -318,13 +318,13 @@ describe Course, type: :model do
         it "Requires a level" do
           error = errors[:level]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick a level")
+          expect(error.first).to include("Select a course level")
         end
 
         it "Requires a subject" do
           error = errors[:subjects]
           expect(error).not_to be_empty
-          expect(error.first).to include("You must pick at least one subject")
+          expect(error.first).to include("Select at least one subject")
         end
 
         context "With modern languages as a subject" do
@@ -333,7 +333,7 @@ describe Course, type: :model do
           it "Requires a language to be selected" do
             error = errors[:modern_languages_subjects]
             expect(error).not_to be_empty
-            expect(error.first).to include("You must pick at least one language")
+            expect(error.first).to include("Select at least one language")
           end
 
           it "Does not add an error if a language is selected" do
@@ -347,32 +347,32 @@ describe Course, type: :model do
         it "Requires an age range" do
           error = errors[:age_range_in_years]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick an age range")
+          expect(error.first).to include("Select an age range")
         end
 
         it "Requires an outcome" do
           error = errors[:qualification]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick an outcome")
+          expect(error.first).to include("Select an outcome")
         end
 
         it "Requires a program type to have been specified" do
           error = errors[:program_type]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick an option")
+          expect(error.first).to include("Select a program type")
         end
 
         it "Requires a study mode" do
           error = errors[:study_mode]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick an option")
+          expect(error.first).to include("Select a study mode")
         end
 
         context "Applications open" do
           it "Empty" do
             error = errors[:applications_open_from]
             expect(error).not_to be_empty
-            expect(error.first).to include("You must say when applications open")
+            expect(error.first).to include("Select when applications will open and enter the date if applicable")
           end
 
           it "A date outside of the current recruitment cycle" do
@@ -387,7 +387,7 @@ describe Course, type: :model do
         it "Requires at least one location" do
           error = errors[:sites]
           expect(error).not_to be_empty
-          expect(error.first).to include("You must pick at least one location")
+          expect(error.first).to include("Select at least one location")
         end
       end
 
@@ -400,7 +400,7 @@ describe Course, type: :model do
         it "requires age_range_in_years" do
           error = errors[:age_range_in_years]
           expect(error).not_to be_empty
-          expect(error.first).to include("You need to pick an age range")
+          expect(error.first).to include("Select an age range")
         end
       end
 
@@ -434,26 +434,26 @@ describe Course, type: :model do
         context "age_range_in_years" do
           let(:blank_field) { { age_range_in_years: nil } }
 
-          it { is_expected.to include "You need to pick an age range" }
+          it { is_expected.to include "Select an age range" }
         end
 
         context "for a provider in the 2021 cycle" do
           context "maths" do
             let(:blank_field) { { maths: nil } }
 
-            it { is_expected.to include "Pick an option for Maths" }
+            it { is_expected.to include "Select an option for maths" }
           end
 
           context "english" do
             let(:blank_field) { { english: nil } }
 
-            it { is_expected.to include "Pick an option for English" }
+            it { is_expected.to include "Select an option for English" }
           end
 
           context "science" do
             let(:blank_field) { { science: nil } }
 
-            it { is_expected.to include "Pick an option for Science" }
+            it { is_expected.to include "Select an option for science" }
           end
         end
 
@@ -533,7 +533,7 @@ describe Course, type: :model do
         it "gives an error for the subjects" do
           expect(subject.errors.full_messages).to match_array([
             "There is a problem with this course. Contact support to fix it (Error: S)",
-            "You must pick at least one subject",
+            "Select at least one subject",
           ])
         end
       end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -183,42 +183,42 @@ describe "/api/v2/build_new_course", type: :request do
       expected["data"]["errors"] = [
         {
           "title" => "Invalid maths",
-          "detail" => "Pick an option for Maths",
+          "detail" => "Select an option for maths",
           "source" => {
             "pointer" => "/data/attributes/maths",
           },
         },
         {
           "title" => "Invalid english",
-          "detail" => "Pick an option for English",
+          "detail" => "Select an option for English",
           "source" => {
             "pointer" => "/data/attributes/english",
           },
         },
         {
           "title" => "Invalid sites",
-          "detail" => "You must pick at least one location for this course",
+          "detail" => "Select at least one location for this course",
           "source" => {
             "pointer" => "/data/attributes/sites",
           },
         },
         {
           "title" => "Invalid qualification",
-          "detail" => "You need to pick an outcome",
+          "detail" => "Select an outcome",
           "source" => {
             "pointer" => "/data/attributes/qualification",
           },
         },
         {
           "title" => "Invalid applications open from",
-          "detail" => "You must say when applications open from",
+          "detail" => "Select when applications will open and enter the date if applicable",
           "source" => {
             "pointer" => "/data/attributes/applications_open_from",
           },
         },
         {
           "title" => "Invalid subjects",
-          "detail" => "You must pick at least one subject",
+          "detail" => "Select at least one subject",
           "source" => {
             "pointer" => "/data/attributes/subjects",
           },
@@ -239,7 +239,7 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid program type",
-          "detail" => "You need to pick an option",
+          "detail" => "Select a program type",
           "source" => {
             "pointer" => "/data/attributes/program_type",
           },
@@ -253,21 +253,21 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid study mode",
-          "detail" => "You need to pick an option",
+          "detail" => "Select a study mode",
           "source" => {
             "pointer" => "/data/attributes/study_mode",
           },
         },
         {
           "title" => "Invalid age range in years",
-          "detail" => "You need to pick an age range",
+          "detail" => "Select an age range",
           "source" => {
             "pointer" => "/data/attributes/age_range_in_years",
           },
         },
         {
           "title" => "Invalid level",
-          "detail" => "You need to pick a level",
+          "detail" => "Select a course level",
           "source" => {
             "pointer" => "/data/attributes/level",
           },
@@ -299,21 +299,21 @@ describe "/api/v2/build_new_course", type: :request do
       expected_errors = [
         {
           "title" => "Invalid maths",
-          "detail" => "Pick an option for Maths",
+          "detail" => "Select an option for maths",
           "source" => {
             "pointer" => "/data/attributes/maths",
           },
         },
         {
           "title" => "Invalid english",
-          "detail" => "Pick an option for English",
+          "detail" => "Select an option for English",
           "source" => {
             "pointer" => "/data/attributes/english",
           },
         },
         {
           "title" => "Invalid subjects",
-          "detail" => "You must pick at least one subject",
+          "detail" => "Select at least one subject",
           "source" => {
             "pointer" => "/data/attributes/subjects",
           },
@@ -334,14 +334,14 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid program type",
-          "detail" => "You need to pick an option",
+          "detail" => "Select a program type",
           "source" => {
             "pointer" => "/data/attributes/program_type",
           },
         },
         {
           "title" => "Invalid qualification",
-          "detail" => "You need to pick an outcome",
+          "detail" => "Select an outcome",
           "source" => {
             "pointer" => "/data/attributes/qualification",
           },
@@ -355,35 +355,35 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid study mode",
-          "detail" => "You need to pick an option",
+          "detail" => "Select a study mode",
           "source" => {
             "pointer" => "/data/attributes/study_mode",
           },
         },
         {
           "title" => "Invalid age range in years",
-          "detail" => "You need to pick an age range",
+          "detail" => "Select an age range",
           "source" => {
             "pointer" => "/data/attributes/age_range_in_years",
           },
         },
         {
           "title" => "Invalid level",
-          "detail" => "You need to pick a level",
+          "detail" => "Select a course level",
           "source" => {
             "pointer" => "/data/attributes/level",
           },
         },
         {
           "title" => "Invalid sites",
-          "detail" => "You must pick at least one location for this course",
+          "detail" => "Select at least one location for this course",
           "source" => {
             "pointer" => "/data/attributes/sites",
           },
         },
         {
           "title" => "Invalid applications open from",
-          "detail" => "You must say when applications open from",
+          "detail" => "Select when applications will open and enter the date if applicable",
           "source" => {
             "pointer" => "/data/attributes/applications_open_from",
           },

--- a/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create/age_range_in_years_spec.rb
@@ -57,12 +57,12 @@ RSpec.describe "POST /providers/:provider_code/courses/:course_code" do
 
     it "returns an error" do
       expect(json_data.count).to eq 1
-      expect(response.body).to include "You need to pick an age range"
+      expect(response.body).to include "Select an age range"
     end
   end
 
   context "an invalid age range" do
-    let(:error_message) { "is invalid. You must enter a valid age range." }
+    let(:error_message) { "is invalid. Enter a valid age range." }
 
     context "with an age range of with a gap of less than 4 years" do
       let(:age_range_in_years) { "5_to_8" }

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -151,7 +151,7 @@ describe "Course POST #create API V2", type: :request do
         response_body = JSON.parse(response.body)
         expect(response_body["errors"].first).to eq(
           "title" => "Invalid sites",
-          "detail" => "You must pick at least one location for this course",
+          "detail" => "Select at least one location for this course",
           "source" => {},
         )
       end

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -134,11 +134,11 @@ describe "Publish API v2", type: :request do
 
         it "has validation errors" do
           expect(json_data.map { |error| error["detail"] }).to match_array([
-            "You must pick at least one location for this course",
+            "Select at least one location for this course",
             "Enter details about this course",
             "Enter details about school placements",
             "Enter a course length",
-            "Give details about the salary for this course",
+            "Enter details about the salary for this course",
             "Enter details about the qualifications needed",
           ])
         end
@@ -162,7 +162,7 @@ describe "Publish API v2", type: :request do
               "Enter details about this course",
               "Enter details about school placements",
               "Enter a course length",
-              "Give details about the fee for UK and EU students",
+              "Enter details about the fee for UK and EU students",
               "Enter details about the qualifications needed",
             ])
           end
@@ -197,7 +197,7 @@ describe "Publish API v2", type: :request do
               "Enter details about this course",
               "Enter details about school placements",
               "Enter a course length",
-              "Give details about the salary for this course",
+              "Enter details about the salary for this course",
               "Enter details about the qualifications needed",
             ])
           end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -61,9 +61,9 @@ describe "Publishable API v2", type: :request do
             "Enter details about this course",
             "Enter details about school placements",
             "Enter a course length",
-            "Give details about the salary for this course",
+            "Enter details about the salary for this course",
             "Enter details about the qualifications needed",
-            "You must pick at least one location for this course",
+            "Select at least one location for this course",
           ])
         end
       end
@@ -85,7 +85,7 @@ describe "Publishable API v2", type: :request do
             expect(json_data.map { |error| error["detail"] }).to match_array([
               "Enter details about this course",
               "Enter a course length",
-              "Give details about the fee for UK and EU students",
+              "Enter details about the fee for UK and EU students",
               "Enter details about the qualifications needed",
               "Enter details about school placements",
             ])

--- a/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_additional_gcse_equivalencies_spec.rb
@@ -36,7 +36,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   end
 
   context "course has different additional_gcse_equivalencies" do
-    let(:updated_additional_gcse_equivalencies) { { additional_gcse_equivalencies: "Must have a Physics A level." } }
+    let(:updated_additional_gcse_equivalencies) { { additional_gcse_equivalencies: "Must have a physics A level." } }
 
     it "returns http success" do
       perform_request(updated_additional_gcse_equivalencies)
@@ -47,7 +47,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect {
         perform_request(updated_additional_gcse_equivalencies)
       }.to change { course.reload.additional_gcse_equivalencies }
-            .from("Must have a cycling proficiency certificate.").to("Must have a Physics A level.")
+            .from("Must have a cycling proficiency certificate.").to("Must have a physics A level.")
     end
   end
 

--- a/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_degree_subject_requirements_spec.rb
@@ -29,14 +29,14 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
   let(:course)            {
     create :course,
            provider: provider,
-           degree_subject_requirements: "Must have a Maths A level."
+           degree_subject_requirements: "Must have an A level in maths."
   }
   let(:permitted_params) do
     %i[degree_subject_requirements]
   end
 
   context "course has different degree_subject_requirements" do
-    let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Physics A level." } }
+    let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a physics A level." } }
 
     it "returns http success" do
       perform_request(updated_degree_subject_requirements)
@@ -47,13 +47,13 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect {
         perform_request(updated_degree_subject_requirements)
       }.to change { course.reload.degree_subject_requirements }
-            .from("Must have a Maths A level.").to("Must have a Physics A level.")
+            .from("Must have an A level in maths.").to("Must have a physics A level.")
     end
   end
 
   context "course has the same degree_subject_requirements" do
     context "with values passed into the params" do
-      let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have a Maths A level." } }
+      let(:updated_degree_subject_requirements) { { degree_subject_requirements: "Must have an A level in maths." } }
 
       it "returns http success" do
         perform_request(updated_degree_subject_requirements)
@@ -64,7 +64,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
         expect {
           perform_request(updated_degree_subject_requirements)
         }.to_not change { course.reload.degree_subject_requirements }
-             .from("Must have a Maths A level.")
+             .from("Must have an A level in maths.")
       end
     end
   end
@@ -81,7 +81,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect {
         perform_request(updated_degree_subject_requirements)
       }.to_not change { course.reload.degree_subject_requirements }
-           .from("Must have a Maths A level.")
+           .from("Must have an A level in maths.")
     end
   end
 
@@ -97,7 +97,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect {
         perform_request(updated_degree_subject_requirements)
       }.to change { course.reload.degree_subject_requirements }
-            .from("Must have a Maths A level.").to(nil)
+            .from("Must have an A level in maths.").to(nil)
     end
   end
 end

--- a/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_gcse_requirements_spec.rb
@@ -127,11 +127,11 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
-    it "has Maths, English and Science validation errors" do
+    it "has maths, English and science validation errors" do
       expect(json_data.count).to eq 3
-      expect(response.body).to include("Pick an option for Maths")
-      expect(response.body).to include("Pick an option for English")
-      expect(response.body).to include("Pick an option for Science")
+      expect(response.body).to include("Select an option for maths")
+      expect(response.body).to include("Select an option for English")
+      expect(response.body).to include("Select an option for science")
     end
   end
 
@@ -151,11 +151,11 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
       expect(response).to have_http_status(:unprocessable_entity)
     end
 
-    it "has Maths and English validation errors" do
+    it "has maths and English validation errors" do
       expect(json_data.count).to eq 2
-      expect(response.body).to include("Pick an option for Maths")
-      expect(response.body).to include("Pick an option for English")
-      expect(response.body).not_to include("Pick an option for Science")
+      expect(response.body).to include("Select an option for maths")
+      expect(response.body).to include("Select an option for English")
+      expect(response.body).not_to include("Select an option for science")
     end
 
     it "does not change any attribute" do

--- a/spec/requests/api/v2/providers/courses/update_sites_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_sites_spec.rb
@@ -113,7 +113,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code with sites" do
       end
 
       it "returns validation error" do
-        expect(response.body).to include("You must choose at least one location")
+        expect(response.body).to include("Select at least one location")
       end
     end
   end

--- a/spec/requests/api/v2/providers/courses/update_subject_spec.rb
+++ b/spec/requests/api/v2/providers/courses/update_subject_spec.rb
@@ -101,8 +101,7 @@ describe "PATCH /providers/:provider_code/courses/:course_code" do
 
     it "Returns an error" do
       json_response = JSON.parse(response.body)
-
-      expect(json_response["errors"][0]["detail"]).to eq("You've already selected this subject - you can only select a subject once")
+      expect(json_response["errors"][0]["detail"]).to eq("You have already selected this subject. You can only select a subject once")
     end
   end
 

--- a/spec/services/courses/validate_custom_age_range_service_spec.rb
+++ b/spec/services/courses/validate_custom_age_range_service_spec.rb
@@ -18,7 +18,7 @@ describe Courses::ValidateCustomAgeRangeService do
   end
 
   context "an invalid age range" do
-    let(:error_message) { "is invalid. You must enter a valid age range." }
+    let(:error_message) { "is invalid. Enter a valid age range." }
 
     context "with an age range of with a gap of less than 4 years" do
       let(:age_range_in_years) { "5_to_8" }


### PR DESCRIPTION
### Context

The teacher training API currently generates error messages that don’t follow GDS recommendations. Let’s fix that!

### Changes proposed in this pull request

* Capitalise reference number abbreviations (**Unique Reference Number** and **UK Provider Reference Number**)
* Don’t capitalise maths and science in error messages
* Don’t say ‘You must’
* Use ‘Select‘ not ‘Pick’

### Guidance to review

Not so much guidance, but some questions:

* Do tests on Publish need to be updated to expect these revised error messages?
* Do these changes follow the GDS recommendations? – @B-Bonner 

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
