### PR TITLE
[xxx] Fix URN validation for lead schools

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -705,7 +705,7 @@ private
   end
 
   def validate_provider_urn_ukprn_publishable
-    if provider.lead_school? && provider.ukprn.blank? && provider.urn.blank?
+    if provider.lead_school? && (provider.ukprn.blank? || provider.urn.blank?)
       errors.add(:base, :provider_ukprn_and_urn_not_publishable)
     elsif provider.ukprn.blank?
       errors.add(:base, :provider_ukprn_not_publishable)

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -87,6 +87,20 @@ describe API::V2::CoursesController, type: :controller do
             it "has a validation error about provider not having a UKPRN and URN" do
               expect(validation_errors).to include("You must provide a UK provider reference number (UKPRN) and URN")
             end
+
+            context "when only URN is nil" do
+              let(:provider) do
+                create(:provider,
+                       provider_type: provider_type,
+                       can_sponsor_student_visa: nil,
+                       urn: nil,
+                       recruitment_cycle: recruitment_cycle)
+              end
+
+              it "has a validation error about provider not having a UKPRN and URN" do
+                expect(validation_errors).to include("You must provide a UK provider reference number (UKPRN) and URN")
+              end
+            end
           end
         end
       end


### PR DESCRIPTION
### Context

We want a course to be invalid when the UKPRN or URN are missing on the provider. Currently we're only failing if both are nil.

### Changes proposed in this pull request

Fail when URN OR UKPRN is nil.

This was only failing when both were nil.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
