### PR TITLE
Remove validation for UCAS entry requirements for 2022 cycles courses

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -256,9 +256,9 @@ class Course < ApplicationRecord
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end
 
-  validates :maths,   inclusion: { in: entry_requirement_options_without_nil_choice }, unless: :further_education_course?
-  validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }, unless: :further_education_course?
-  validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: :gcse_science_required?
+  validates :maths,   inclusion: { in: entry_requirement_options_without_nil_choice }, unless: -> { further_education_course? || recruitment_cycle.after_2021? }
+  validates :english, inclusion: { in: entry_requirement_options_without_nil_choice }, unless: -> { further_education_course? || recruitment_cycle.after_2021? }
+  validates :science, inclusion: { in: entry_requirement_options_without_nil_choice }, if: -> { gcse_science_required? && !recruitment_cycle.after_2021? }
   validates :is_send, inclusion: { in: [true, false] }
   validates :sites, presence: true, on: %i[publish new]
   validates :subjects, presence: true, on: :publish

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -437,22 +437,57 @@ describe Course, type: :model do
           it { is_expected.to include "You need to pick an age range" }
         end
 
-        context "maths" do
-          let(:blank_field) { { maths: nil } }
+        context "for a provider in the 2021 cycle" do
+          context "maths" do
+            let(:blank_field) { { maths: nil } }
 
-          it { is_expected.to include "Pick an option for Maths" }
+            it { is_expected.to include "Pick an option for Maths" }
+          end
+
+          context "english" do
+            let(:blank_field) { { english: nil } }
+
+            it { is_expected.to include "Pick an option for English" }
+          end
+
+          context "science" do
+            let(:blank_field) { { science: nil } }
+
+            it { is_expected.to include "Pick an option for Science" }
+          end
         end
 
-        context "english" do
-          let(:blank_field) { { english: nil } }
+        context "for a provider in the 2022 cycle" do
+          let(:recruitment_cycle) { build(:recruitment_cycle, :next) }
+          let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
+          let(:course) do
+            create(
+              :course,
+              provider: provider,
+              level: "secondary",
+              name: "Biology",
+              course_code: "3X9F",
+              subjects: [find_or_create(:secondary_subject, :biology)],
+            )
+          end
 
-          it { is_expected.to include "Pick an option for English" }
-        end
+          context "maths" do
+            let(:blank_field) { { maths: nil } }
 
-        context "science" do
-          let(:blank_field) { { science: nil } }
+            it { is_expected.to eq nil }
+          end
 
-          it { is_expected.to include "Pick an option for Science" }
+          context "english" do
+            let(:blank_field) { { english: nil } }
+
+            it { is_expected.to eq nil }
+          end
+
+          context "science" do
+            let(:blank_field) { { science: nil } }
+
+            it { is_expected.to eq nil }
+          end
         end
       end
 


### PR DESCRIPTION
### Context

We shouldn't be validating that maths, english and science UCAS equivalency sections have been completed for rolled over courses and it's being deprecated from the next cycle onwards.

### Changes proposed in this pull request

- Ensure that we are not validating the maths, english and science fields for courses in the 2022 cycle

### Guidance to review

There were some issues with tests failing due to race conditions. John very kindly added the 2nd commit that fixed them.
