### PR TITLE
[2170] Update UKPRN validation message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -103,7 +103,7 @@ en:
               blank: "^Complete your course information before publishing"
             sites:
               blank: "^You must pick at least one location for this course"
-              site_urn_not_publishable: "^You must provide a Unique Reference Number (URN) for all course locations"
+              site_urn_not_publishable: "^Enter a Unique Reference Number (URN) for all course locations"
             age_range_in_years:
               blank: "^You need to pick an age range"
             program_type:
@@ -121,8 +121,8 @@ en:
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
               visa_sponsorship_not_publishable: "You must say whether you can sponsor visas"
-              provider_ukprn_not_publishable: "You must provide a UK provider reference number (UKPRN)"
-              provider_ukprn_and_urn_not_publishable: "You must provide a UK provider reference number (UKPRN) and URN"
+              provider_ukprn_not_publishable: "Enter a UK Provider Reference Number (UKPRN)"
+              provider_ukprn_and_urn_not_publishable: "Enter a UK Provider Reference Number (UKPRN) and URN"
               degree_requirements_not_publishable: "Enter degree requirements"
               gcse_requirements_not_publishable: "Enter GCSE requirements"
         course_enrichment:

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -74,18 +74,18 @@ describe API::V2::CoursesController, type: :controller do
           end
 
           it "has a validation error about provider not having a UKPRN" do
-            expect(validation_errors).to include("You must provide a UK provider reference number (UKPRN)")
+            expect(validation_errors).to include("Enter a UK Provider Reference Number (UKPRN)")
           end
 
           it "has a validation error about locations not having a URN" do
-            expect(validation_errors).to include("You must provide a Unique Reference Number (URN) for all course locations")
+            expect(validation_errors).to include("Enter a Unique Reference Number (URN) for all course locations")
           end
 
           context "provider is a lead school" do
             let(:provider_type) { :lead_school }
 
             it "has a validation error about provider not having a UKPRN and URN" do
-              expect(validation_errors).to include("You must provide a UK provider reference number (UKPRN) and URN")
+              expect(validation_errors).to include("Enter a UK Provider Reference Number (UKPRN) and URN")
             end
 
             context "when only URN is nil" do
@@ -98,7 +98,7 @@ describe API::V2::CoursesController, type: :controller do
               end
 
               it "has a validation error about provider not having a UKPRN and URN" do
-                expect(validation_errors).to include("You must provide a UK provider reference number (UKPRN) and URN")
+                expect(validation_errors).to include("Enter a UK Provider Reference Number (UKPRN) and URN")
               end
             end
           end


### PR DESCRIPTION
### Context

We've had some conversations about this and settled here for now. This change affects behaviour in publish so this PR -> https://github.com/DFE-Digital/publish-teacher-training/pull/1799 supports the old and new formats and needs to be merged before this is deployed.

### Changes proposed in this pull request

Capitalise for consistency.

### Guidance to review

Run publish (from the PR above if it isn't merged) against this PR. Ensure that the course validation links for UKPRN still link to the UKPRN form.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
