### PR TITLE
[2187] Add force rollover option

### DIFF
--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -1,11 +1,13 @@
 module Providers
   class CopyToRecruitmentCycleService
     attr :logger
+    attr_reader :force
 
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil)
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil, force: false)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
       @logger = logger || Logger.new("/dev/null")
+      @force = force
     end
 
     def execute(provider:, new_recruitment_cycle:)
@@ -13,8 +15,7 @@ module Providers
       sites_count = 0
       courses_count = 0
 
-      if provider.rollable?
-
+      if provider.rollable? || force
         ActiveRecord::Base.transaction do
           rolled_over_provider = new_recruitment_cycle.providers.find_by(provider_code: provider.provider_code)
           if rolled_over_provider == nil

--- a/app/services/rollover_service.rb
+++ b/app/services/rollover_service.rb
@@ -1,8 +1,9 @@
 class RolloverService
   include ServicePattern
 
-  def initialize(provider_codes:)
+  def initialize(provider_codes:, force: false)
     @provider_codes = provider_codes
+    @force = force
   end
 
   def call
@@ -21,7 +22,7 @@ class RolloverService
 
 private
 
-  attr_reader :provider_codes
+  attr_reader :provider_codes, :force
 
   def rollover(provider, total_counts)
     print "Copying provider #{provider.provider_code}: "
@@ -38,6 +39,7 @@ private
           copy_course_to_provider_service: copy_courses_to_provider_service,
           copy_site_to_provider_service: Sites::CopyToProviderService.new,
           logger: Logger.new(STDOUT),
+          force: force,
         )
 
         counts = copy_provider_to_recruitment_cycle.execute(

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -185,10 +185,27 @@ describe RolloverService do
     end
   end
 
-  def perform_rollover
+  context "force: true" do
+    let(:current_cycle_provider) do
+      create :provider
+    end
+
+    before do
+      allow(current_cycle_provider).to receive(:rollable?).and_return(false)
+    end
+
+    context "when the provider is not rollable" do
+      it "still copies the provider" do
+        perform_rollover(force: true)
+        expect(next_cycle_provider).not_to be_nil
+      end
+    end
+  end
+
+  def perform_rollover(force: false)
     stderr = nil
     output = with_stubbed_stdout(stderr: stderr) do
-      RolloverService.call(provider_codes: [current_cycle_provider.provider_code])
+      RolloverService.call(provider_codes: [current_cycle_provider.provider_code], force: force)
     end
     [output, stderr]
   end


### PR DESCRIPTION
### Context

Some providers are `rollable? == false` but want to be rolled over. E.g.a provider has no published courses last year but wants to start publishing courses in this cycle.

This change allows them to be rolled over.

### Changes proposed in this pull request

* Add `force: ` argument to `CopyToRecruitmentCycleService`

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
