### PR TITLE
[2187] Make previously published courses rollable

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -296,16 +296,12 @@ class Course < ApplicationRecord
 
   after_validation :remove_unnecessary_enrichments_validation_message
 
-  def rollable_published?
-    content_status == :published
-  end
-
   def rollable_withdrawn?
     content_status == :withdrawn
   end
 
   def rollable?
-    rollable_published? || rollable_withdrawn?
+    is_published? || rollable_withdrawn?
   end
 
   def update_notification_attributes

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -5,8 +5,8 @@ module Courses
       @enrichments_copy_to_course = enrichments_copy_to_course
     end
 
-    def execute(course:, new_provider:)
-      return nil unless course.rollable?
+    def execute(course:, new_provider:, force: false)
+      return nil unless course.rollable? || force
       return nil if course_code_already_exists_on_provider?(course: course, new_provider: new_provider)
 
       new_course = nil

--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -1,16 +1,14 @@
 module Providers
   class CopyToRecruitmentCycleService
     attr :logger
-    attr_reader :force
 
-    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil, force: false)
+    def initialize(copy_course_to_provider_service:, copy_site_to_provider_service:, logger: nil)
       @copy_course_to_provider_service = copy_course_to_provider_service
       @copy_site_to_provider_service = copy_site_to_provider_service
       @logger = logger || Logger.new("/dev/null")
-      @force = force
     end
 
-    def execute(provider:, new_recruitment_cycle:)
+    def execute(provider:, new_recruitment_cycle:, force: false)
       providers_count = 0
       sites_count = 0
       courses_count = 0

--- a/app/services/rollover_service.rb
+++ b/app/services/rollover_service.rb
@@ -39,11 +39,10 @@ private
           copy_course_to_provider_service: copy_courses_to_provider_service,
           copy_site_to_provider_service: Sites::CopyToProviderService.new,
           logger: Logger.new(STDOUT),
-          force: force,
         )
 
         counts = copy_provider_to_recruitment_cycle.execute(
-          provider: provider, new_recruitment_cycle: new_recruitment_cycle,
+          provider: provider, new_recruitment_cycle: new_recruitment_cycle, force: force,
         )
       end
     end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2422,4 +2422,34 @@ describe Course, type: :model do
       end
     end
   end
+
+  describe "rollable?" do
+    subject do
+      create(
+        :course,
+        level: "secondary",
+        name: "Classics",
+        course_code: "AAAA",
+        enrichments: [enrichment],
+      ).rollable?
+    end
+
+    context "course is published" do
+      let(:enrichment) { create(:course_enrichment, :published) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "course is withdrawn" do
+      let(:enrichment) { create(:course_enrichment, :withdrawn) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context "course is published with unpublished changes" do
+      let(:enrichment) { create(:course_enrichment, :subsequent_draft) }
+
+      it { is_expected.to eq(true) }
+    end
+  end
 end

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -157,5 +157,19 @@ describe Providers::CopyToRecruitmentCycleService do
         courses: 1,
       )
     end
+
+    context "provider is not rollable?" do
+      context "force: true" do
+        before do
+          allow(provider).to receive(:rollable?).and_return(false)
+        end
+
+        it "still copies the provider" do
+          expect {
+            service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle, force: true)
+          }.to(change { new_recruitment_cycle.providers.count })
+        end
+      end
+    end
   end
 end

--- a/spec/services/rollover_service_spec.rb
+++ b/spec/services/rollover_service_spec.rb
@@ -2,215 +2,145 @@ require "rails_helper"
 
 describe RolloverService do
   let!(:next_recruitment_cycle) { find_or_create :recruitment_cycle, :next }
-  let(:email) { "user@education.gov.uk" }
-  let(:published_course)              { build :course, enrichments: [published_course_enrichment] }
-  let(:published_course_enrichment)   { build :course_enrichment, :published }
-  let(:withdrawn_course)              { build :course, enrichments: [withdrawn_course_enrichment] }
-  let(:withdrawn_course_enrichment)   { build :course_enrichment, :withdrawn }
-  let(:rolled_over_course)                   { build :course, enrichments: [rolled_over_course_enrichment] }
-  let(:rolled_over_course_enrichment)        { build :course_enrichment, :rolled_over }
-  let(:initial_draft_course)                 { build :course, enrichments: [initial_draft_course_enrichment] }
-  let(:initial_draft_course_enrichment)      { build :course_enrichment, :initial_draft }
-  let(:subsequent_draft_course)              { build :course, enrichments: [subsequent_draft_course_enrichment] }
-  let(:subsequent_draft_course_enrichment)   { build :course_enrichment, :subsequent_draft }
-  let(:site) { build :site }
 
-  let!(:site_status) do
-    create :site_status,
-           :published,
-           :with_no_vacancies,
-           course: published_course,
-           site: site
-  end
-
-  let(:current_cycle_provider) do
-    create :provider,
-           courses: [published_course],
-           sites: [site]
-  end
+  let(:copy_course_to_provider_service) { instance_double(Courses::CopyToProviderService) }
+  let(:copy_provider_to_recruitment_cycle_service) { instance_double(Providers::CopyToRecruitmentCycleService) }
 
   before do
-    perform_rollover
+    allow(Courses::CopyToProviderService).to receive(:new).with(
+      sites_copy_to_course: instance_of(Sites::CopyToCourseService),
+      enrichments_copy_to_course: instance_of(Enrichments::CopyToCourseService),
+    ).and_return(copy_course_to_provider_service)
+
+    allow(Providers::CopyToRecruitmentCycleService).to receive(:new).with(
+      copy_course_to_provider_service: copy_course_to_provider_service,
+      copy_site_to_provider_service: instance_of(Sites::CopyToProviderService),
+      logger: instance_of(Logger),
+    ).and_return(copy_provider_to_recruitment_cycle_service)
   end
 
-  subject(:next_cycle_provider) do
-    next_recruitment_cycle.providers.find_by(
-      provider_code: current_cycle_provider.provider_code,
-    )
-  end
+  describe ".call" do
+    context "with provider codes" do
+      let(:provider) { create(:provider, provider_code: "AB1") }
+      let(:provider_to_ignore) { create(:provider, provider_code: "CD2") }
 
-  let(:new_published_course) do
-    next_cycle_provider.courses.find_by(
-      course_code: published_course.course_code,
-    )
-  end
+      before do
+        provider
+        provider_to_ignore
 
-  it "copies the provider" do
-    expect(next_cycle_provider).not_to be_nil
-    expect(next_cycle_provider).not_to eq current_cycle_provider
-  end
+        allow(copy_provider_to_recruitment_cycle_service).to receive(:execute).and_return(
+          {
+            providers: 0,
+            sites: 0,
+            courses: 0,
+          },
+        )
+      end
 
-  it "copies the provider's site" do
-    new_site = next_cycle_provider.sites.find_by(code: site.code)
-    expect(new_site).not_to be_nil
-    expect(new_site).not_to eq site
-  end
+      it "passes the providers in provider_codes to the `CopyToRecruitmentCycle` service" do
+        expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+        )
 
-  it "copies the published course" do
-    expect(new_published_course).not_to be_nil
-    expect(new_published_course).not_to eq published_course
-  end
+        no_output { described_class.call(provider_codes: ["AB1"]) }
+      end
 
-  it "copies the course enrichments" do
-    expect(new_published_course.enrichments.count).to eq 1
-    expect(new_published_course.enrichments.first).to be_rolled_over
-  end
+      it "doesn't pass other providers" do
+        expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
+          provider: provider_to_ignore, new_recruitment_cycle: next_recruitment_cycle, force: false,
+        )
 
-  it "copies the course's site" do
-    new_site = next_cycle_provider.sites.find_by(code: site.code)
-    expect(new_published_course.sites).to eq [new_site]
-    expect(new_published_course.site_statuses.first).to be_full_time_vacancies
-    expect(new_published_course.site_statuses.first).to be_status_new_status
-  end
+        no_output { described_class.call(provider_codes: ["AB1"]) }
+      end
 
-  context "when provider already rolled over" do
-    it "copies a new published course" do
-      course2 = create(:course, provider: current_cycle_provider, enrichments: [build(:course_enrichment, :published)])
-      current_cycle_provider.courses.reload
+      context "when providers exist in other cycles" do
+        let(:previous_cycle) { create(:recruitment_cycle, :previous) }
+        let(:past_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "AB1") }
+        let(:future_provider) { create(:provider, recruitment_cycle: next_recruitment_cycle) }
 
-      rollover_again
-      duplicated_course2 = next_cycle_provider.courses.find_by(course_code: course2.course_code)
-      expect(duplicated_course2).not_to be_nil
-      expect(duplicated_course2).not_to eq(course2)
-      expect(next_cycle_provider.courses.length).to eq(current_cycle_provider.courses.length)
-    end
+        it "doesn't pass other providers" do
+          expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
 
-    it "copies a new site" do
-      site2 = create(:site, provider: current_cycle_provider)
-      current_cycle_provider.sites.reload
+          expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
 
-      rollover_again
+          expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
 
-      duplicated_site2 = next_cycle_provider.sites.find_by(code: site2.code)
-      expect(duplicated_site2).not_to be_nil
-      expect(duplicated_site2).not_to eq(site2)
-      expect(next_cycle_provider.sites.length).to eq(current_cycle_provider.sites.length)
-    end
-  end
-
-  context "when provider has 1 published, 1 withdrawn and 1 rolled_over course" do
-    let(:current_cycle_provider) do
-      create :provider,
-             courses: [published_course, withdrawn_course, rolled_over_course],
-             sites: [site]
-    end
-
-    let(:new_withdrawn_course) do
-      next_cycle_provider.courses.find_by(
-        course_code: withdrawn_course.course_code,
-      )
-    end
-
-    let(:new_rolled_over_course) do
-      next_cycle_provider.courses.find_by(
-        course_code: rolled_over_course.course_code,
-      )
-    end
-
-    it "onlies rollover published and withdrawn courses" do
-      expect(current_cycle_provider.rollable?).to eq(true)
-      expect(next_cycle_provider.courses.count).to eq(2)
-      expect(new_withdrawn_course).not_to be_nil
-      expect(new_published_course).not_to be_nil
-      expect(new_withdrawn_course).not_to eq withdrawn_course
-      expect(new_published_course).not_to eq published_course
-      expect(new_rolled_over_course).to be_nil
-      expect(Course.all.count).to eq(5)
-      expect(next_cycle_provider.rollable?).to eq(false)
-      rollover_again
-      expect(Course.all.count).to eq(5)
-    end
-  end
-
-  context "provider with only non rollable courses" do
-    let(:current_cycle_provider) do
-      create :provider,
-             courses: [rolled_over_course, initial_draft_course, subsequent_draft_course],
-             sites: [site]
-    end
-
-    it "does not copy the provider" do
-      expect(current_cycle_provider.rollable?).to eq(false)
-      expect(next_cycle_provider).to be_nil
-    end
-  end
-
-  context "provider with no courses" do
-    let(:current_cycle_provider) do
-      create :provider
-    end
-
-    it "does not copy the provider" do
-      expect(current_cycle_provider.rollable?).to eq(false)
-      expect(next_cycle_provider).to be_nil
-    end
-  end
-
-  context "provider who accredits courses but has no courses of their own" do
-    let(:current_cycle_provider) do
-      create :provider,
-             :accredited_body,
-             accredited_courses: [published_course],
-             sites: [site]
-    end
-
-    it "copies the provider" do
-      expect(current_cycle_provider.rollable?).to eq(true)
-      expect(next_cycle_provider).to_not be_nil
-    end
-  end
-
-  context "accredited_body with 2 rollable courses" do
-    let(:current_cycle_provider) do
-      create :provider,
-             :accredited_body,
-             courses: [published_course, withdrawn_course, rolled_over_course],
-             accredited_courses: [published_course],
-             sites: [site]
-    end
-
-    it "copies the rollable courses" do
-      expect(current_cycle_provider.rollable?).to eq(true)
-      expect(next_cycle_provider.courses.count).to eq(2)
-    end
-  end
-
-  context "force: true" do
-    let(:current_cycle_provider) do
-      create :provider
-    end
-
-    before do
-      allow(current_cycle_provider).to receive(:rollable?).and_return(false)
-    end
-
-    context "when the provider is not rollable" do
-      it "still copies the provider" do
-        perform_rollover(force: true)
-        expect(next_cycle_provider).not_to be_nil
+          no_output { described_class.call(provider_codes: ["AB1"]) }
+        end
       end
     end
-  end
 
-  def perform_rollover(force: false)
-    stderr = nil
-    output = with_stubbed_stdout(stderr: stderr) do
-      RolloverService.call(provider_codes: [current_cycle_provider.provider_code], force: force)
+    context "without provider codes" do
+      let(:provider) { create(:provider, provider_code: "AB1") }
+      let(:other_provider) { create(:provider, provider_code: "CD2") }
+
+      before do
+        provider
+        other_provider
+
+        allow(copy_provider_to_recruitment_cycle_service).to receive(:execute).and_return(
+          {
+            providers: 0,
+            sites: 0,
+            courses: 0,
+          },
+        )
+      end
+
+      it "passes all providers `CopyToRecruitmentCycle` service" do
+        expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+          provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+        )
+        expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+          provider: other_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+        )
+
+        no_output { described_class.call(provider_codes: []) }
+      end
+
+      context "when providers exist in other cycles" do
+        let(:previous_cycle) { create(:recruitment_cycle, :previous) }
+        let(:past_provider) { create(:provider, recruitment_cycle: previous_cycle, provider_code: "AB1") }
+        let(:future_provider) { create(:provider, recruitment_cycle: next_recruitment_cycle) }
+
+        it "doesn't pass other providers" do
+          expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
+
+          expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
+            provider: past_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
+
+          expect(copy_provider_to_recruitment_cycle_service).not_to receive(:execute).with(
+            provider: future_provider, new_recruitment_cycle: next_recruitment_cycle, force: false,
+          )
+
+          no_output { described_class.call(provider_codes: []) }
+        end
+      end
+
+      context "force: true" do
+        it "passes the argument to the `CopyToRecruitmentCycle` service" do
+          expect(copy_provider_to_recruitment_cycle_service).to receive(:execute).with(
+            provider: provider, new_recruitment_cycle: next_recruitment_cycle, force: true,
+          )
+
+          no_output { described_class.call(provider_codes: [], force: true) }
+        end
+      end
     end
-    [output, stderr]
-  end
 
-  def rollover_again
-    perform_rollover
+    def no_output(&block)
+      stderr = nil
+      output = with_stubbed_stdout(stderr: stderr, &block)
+      [output, stderr]
+    end
   end
 end


### PR DESCRIPTION
### Context

Courses that have been published but have unpublished changes should be included in rollover.

### Changes proposed in this pull request

* Make those courses rollable
* Add a `force:` argument to allow us to manually rollover any courses
* Refactor the `RolloverService` spec to stop it failing when unrelated code is changed

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
