### PR TITLE
Configure load test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,13 @@ rollover: ## Set DEPLOY_ENV to rollover
 	$(eval space=bat-staging)
 	$(eval paas_env=rollover)
 
+.PHONY: loadtest
+loadtest: ## Set DEPLOY_ENV to rollover
+	$(eval DEPLOY_ENV=loadtest)
+	$(eval AZ_SUBSCRIPTION=s121-findpostgraduateteachertraining-development)
+	$(eval space=bat-qa)
+	$(eval paas_env=loadtest)
+
 .PHONY: ci
 ci:	## Run in automation environment
 	$(eval export DISABLE_PASSCODE=true)

--- a/config/environments/loadtest.rb
+++ b/config/environments/loadtest.rb
@@ -1,0 +1,1 @@
+require Rails.root.join("config/environments/production")

--- a/config/settings/loadtest.yml
+++ b/config/settings/loadtest.yml
@@ -1,0 +1,17 @@
+gcp_api_key: please_change_me
+publish_api_url: https://teacher-training-api-loadtest.london.cloudapps.digital
+publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
+find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+
+# URL of this app for the callback after sigining in
+base_url: https://teacher-training-api-loadtest.london.cloudapps.digital
+
+bg_jobs:
+  save_statistic:
+    cron: "0 0 * * *" # daily at midnight
+    class: "SaveStatisticJob"
+    queue: save_statistic
+skylight:
+  enable: true
+environment:
+  name: "loadtest"

--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -31,3 +31,8 @@ review:
   <<: *default
   RAILS_ENV: review
   RACK_ENV: review
+
+loadtest:
+  <<: *default
+  RAILS_ENV: loadtest
+  RACK_ENV: loadtest

--- a/terraform/workspace_variables/loadtest.sh
+++ b/terraform/workspace_variables/loadtest.sh
@@ -1,0 +1,3 @@
+export TF_VAR_key_vault_name=s121d01-shared-kv-01
+export TF_VAR_key_vault_app_secret_name=TTAPI-APP-SECRETS-QA
+export TF_VAR_key_vault_infra_secret_name=BAT-INFRA-SECRETS-QA

--- a/terraform/workspace_variables/loadtest.tfvars
+++ b/terraform/workspace_variables/loadtest.tfvars
@@ -1,0 +1,13 @@
+#PaaS
+cf_space                   = "bat-qa"
+paas_app_environment       = "loadtest"
+paas_web_app_host_name     = "loadtest"
+paas_web_app_instances     = 8
+paas_web_app_memory        = 1536
+paas_worker_app_instances  = 1
+paas_worker_app_memory     = 1024
+paas_postgres_service_plan = "small-11"
+paas_redis_service_plan    = "micro-ha-5_x"
+
+# KeyVault
+key_vault_resource_group = "s121d01-shared-rg"

--- a/terraform/workspace_variables/loadtest_backend.tfvars
+++ b/terraform/workspace_variables/loadtest_backend.tfvars
@@ -1,0 +1,4 @@
+resource_group_name  = "s121d01-ttapi-rg"
+storage_account_name = "s121d01ttapiterraform"
+container_name       = "loadtest-paas-tfstate"
+key                  = "terraform.tfstate"


### PR DESCRIPTION
### Context

Apply requires a TTAPI env to use for its load testing.

### Changes proposed in this pull request

Config for deploying a load test environment.
It is deployed manually using `make loadtest` commands.

Deployed and available at https://teacher-training-api-loadtest.london.cloudapps.digital

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
