### PR TITLE
Add program type to the v2 serialiser

### DIFF
--- a/app/serializers/api/v2/serializable_course.rb
+++ b/app/serializers/api/v2/serializable_course.rb
@@ -22,7 +22,8 @@ module API
                  :additional_degree_subject_requirements,
                  :degree_subject_requirements, :accept_pending_gcse, :accept_gcse_equivalency,
                  :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency,
-                 :accept_science_gcse_equivalency, :additional_gcse_equivalencies
+                 :accept_science_gcse_equivalency, :additional_gcse_equivalencies,
+                 :program_type
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/spec/requests/api/v2/providers/courses_spec.rb
+++ b/spec/requests/api/v2/providers/courses_spec.rb
@@ -156,6 +156,7 @@ describe "Courses API v2", type: :request do
                 "accept_maths_gcse_equivalency" => nil,
                 "accept_science_gcse_equivalency" => nil,
                 "additional_gcse_equivalencies" => nil,
+                "program_type" => provider.courses[0].program_type,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },
@@ -735,6 +736,7 @@ describe "Courses API v2", type: :request do
               "accept_maths_gcse_equivalency" => nil,
               "accept_science_gcse_equivalency" => nil,
               "additional_gcse_equivalencies" => nil,
+              "program_type" => provider.courses[0].program_type,
             },
             "relationships" => {
               "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -43,6 +43,7 @@ describe API::V2::SerializableCourse do
   it { is_expected.to have_attribute(:accept_maths_gcse_equivalency).with_value(nil) }
   it { is_expected.to have_attribute(:accept_science_gcse_equivalency).with_value(nil) }
   it { is_expected.to have_attribute(:additional_gcse_equivalencies) }
+  it { is_expected.to have_attribute(:program_type) }
 
   context "with a provider" do
     let(:provider) { course.provider }


### PR DESCRIPTION
### Context

We need program type for some conditional content on the preview page 

### Changes proposed in this pull request

- expose program type on the v2 course serialiser