### PR TITLE
Add structured GCSE requirements fields to V3 API

### DIFF
--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -21,7 +21,10 @@ module API
                  :content_status, :ucas_status, :funding_type,
                  :level, :is_send?, :english, :maths, :science, :gcse_subjects_required,
                  :age_range_in_years, :accrediting_provider,
-                 :accredited_body_code, :level, :changed_at, :uuid, :program_type
+                 :accredited_body_code, :level, :changed_at, :uuid, :program_type,
+                 :accept_pending_gcse, :accept_gcse_equivalency,
+                 :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency,
+                 :accept_science_gcse_equivalency, :additional_gcse_equivalencies
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -12,7 +12,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
 
   let(:applications_open_from) { Time.now.utc }
   let(:findable_open_course) do
-    create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship,
+    create(:course, :resulting_in_pgce_with_qts, :with_apprenticeship, :with_gcse_equivalency,
            level: "primary",
            name: "Mathematics",
            provider: provider,
@@ -113,6 +113,12 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "accredited_body_code" => nil,
                 "uuid" => provider.courses[0].uuid,
                 "program_type" => provider.courses[0].program_type,
+                "accept_pending_gcse" => provider.courses[0].accept_pending_gcse,
+                "accept_gcse_equivalency" => provider.courses[0].accept_gcse_equivalency,
+                "accept_english_gcse_equivalency" => provider.courses[0].accept_english_gcse_equivalency,
+                "accept_maths_gcse_equivalency" => provider.courses[0].accept_maths_gcse_equivalency,
+                "accept_science_gcse_equivalency" => provider.courses[0].accept_science_gcse_equivalency,
+                "additional_gcse_equivalencies" => provider.courses[0].additional_gcse_equivalencies,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -32,6 +32,7 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
   }
   let(:course) {
     create :course,
+           :with_gcse_equivalency,
            provider: provider,
            enrichments: enrichments,
            site_statuses: [courses_site_status],
@@ -146,6 +147,12 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "accredited_body_code" => nil,
             "uuid" => course.uuid,
             "program_type" => course.program_type,
+            "accept_pending_gcse" => course.accept_pending_gcse,
+            "accept_gcse_equivalency" => course.accept_gcse_equivalency,
+            "accept_english_gcse_equivalency" => course.accept_english_gcse_equivalency,
+            "accept_maths_gcse_equivalency" => course.accept_maths_gcse_equivalency,
+            "accept_science_gcse_equivalency" => course.accept_science_gcse_equivalency,
+            "additional_gcse_equivalencies" => course.additional_gcse_equivalencies,
           },
           "relationships" => {
             "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context

These have already been added to the DB schema and the V2 API, see https://github.com/DFE-Digital/teacher-training-api/pull/1986/files

This PR just brings the V3 API up to date with these new columns.

https://trello.com/c/ZWSEnlXK/3535-📐-add-structured-gcse-requirements-fields-to-the-v3-api

### Changes proposed in this pull request

- [x] Add new fields to `API::V3::SerializableCourse`
- [x] Extend existing request specs to cover these changes

### Guidance to review

- Are the tests adequate?
- Is there any documentation that needs to be updated?
- Are there any potential knock on effects of this change?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
