### PR TITLE
Add structured degree fields to V3 API

### DIFF
--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -24,7 +24,9 @@ module API
                  :accredited_body_code, :level, :changed_at, :uuid, :program_type,
                  :accept_pending_gcse, :accept_gcse_equivalency,
                  :accept_english_gcse_equivalency, :accept_maths_gcse_equivalency,
-                 :accept_science_gcse_equivalency, :additional_gcse_equivalencies
+                 :accept_science_gcse_equivalency, :additional_gcse_equivalencies,
+                 :degree_grade, :additional_degree_subject_requirements,
+                 :degree_subject_requirements
 
       attribute :start_date do
         written_month_year(@object.start_date) if @object.start_date

--- a/spec/requests/api/v3/providers/courses/index_spec.rb
+++ b/spec/requests/api/v3/providers/courses/index_spec.rb
@@ -119,6 +119,9 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
                 "accept_maths_gcse_equivalency" => provider.courses[0].accept_maths_gcse_equivalency,
                 "accept_science_gcse_equivalency" => provider.courses[0].accept_science_gcse_equivalency,
                 "additional_gcse_equivalencies" => provider.courses[0].additional_gcse_equivalencies,
+                "degree_grade" => provider.courses[0].degree_grade,
+                "additional_degree_subject_requirements" => provider.courses[0].additional_degree_subject_requirements,
+                "degree_subject_requirements" => provider.courses[0].degree_subject_requirements,
               },
               "relationships" => {
                 "accrediting_provider" => { "meta" => { "included" => false } },

--- a/spec/requests/api/v3/providers/courses/show_spec.rb
+++ b/spec/requests/api/v3/providers/courses/show_spec.rb
@@ -153,6 +153,9 @@ describe "GET v3/recruitment_cycle/:recruitment_cycle_year/providers/:provider_c
             "accept_maths_gcse_equivalency" => course.accept_maths_gcse_equivalency,
             "accept_science_gcse_equivalency" => course.accept_science_gcse_equivalency,
             "additional_gcse_equivalencies" => course.additional_gcse_equivalencies,
+            "degree_grade" => course.degree_grade,
+            "additional_degree_subject_requirements" => course.additional_degree_subject_requirements,
+            "degree_subject_requirements" => course.degree_subject_requirements,
           },
           "relationships" => {
             "accrediting_provider" => { "meta" => { "included" => false } },


### PR DESCRIPTION
### Context

The structured degree fields have already been added to the DB schema and the V2 API, see https://github.com/DFE-Digital/teacher-training-api/pull/1968

This PR just brings the V3 API up to date with these new columns.

### Changes proposed in this pull request

- [x] Add new fields to `API::V3::SerializableCourse`
- [x] Extend existing request specs to cover these changes

### Guidance to review

- Are the tests adequate?
- Is there any documentation that needs to be updated?
- Are there any potential knock on effects of this change?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
