### PR TITLE
[2299] Add persona login

### DIFF
--- a/app/components/persona/view.html.erb
+++ b/app/components/persona/view.html.erb
@@ -1,0 +1,15 @@
+<h2 class="govuk-heading-m">Colin</h2>
+
+  <p class="govuk-body"><%= govuk_tag(text: "Admin", colour: "blue") %></p>
+
+  <p class="govuk-body">
+    Colin is a DfE support agent who has administrator access to all organisations.
+  </p>
+</h2>
+
+<%= form_tag("/auth/developer/callback") do %>
+  <%= hidden_field_tag "email", email_address %>
+  <%= hidden_field_tag "first_name", first_name %>
+  <%= hidden_field_tag "last_name", last_name %>
+  <%= submit_tag "Login as Colin", class: "govuk-button govuk-!-margin-bottom-2" %>
+<% end %>

--- a/app/components/persona/view.rb
+++ b/app/components/persona/view.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Persona
+  class View < GovukComponent::Base
+    attr_accessor :email_address, :first_name, :last_name
+
+    def initialize(email_address:, first_name:, last_name:)
+      super({})
+      @email_address = email_address
+      @first_name = first_name
+      @last_name = last_name
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,17 @@ class ApplicationController < ActionController::Base
 
   include Pundit
 
+  before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
+
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
 private
+
+  def enforce_basic_auth
+    authenticate_or_request_with_http_basic do |username, password|
+      BasicAuthenticable.authenticate(username, password)
+    end
+  end
 
   def user_session
     @user_session ||= UserSession.load_from_session(session)

--- a/app/controllers/concerns/basic_authenticable.rb
+++ b/app/controllers/concerns/basic_authenticable.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Enforces HTTP Basic Auth
+module BasicAuthenticable
+  class << self
+    def required?
+      Settings.basic_auth.enabled
+    end
+
+    def authenticate(username, password)
+      validate(username, password)
+    end
+
+    def validate(username, password)
+      utils.secure_compare(::Digest::SHA256.hexdigest(auth_username), ::Digest::SHA256.hexdigest(username)) &
+        utils.secure_compare(::Digest::SHA256.hexdigest(auth_password), ::Digest::SHA256.hexdigest(password))
+    end
+
+    def auth_username
+      @auth_username ||= Settings.basic_auth.username
+    end
+
+    def auth_password
+      @auth_password ||= Settings.basic_auth.password
+    end
+
+    def utils
+      ActiveSupport::SecurityUtils
+    end
+  end
+end

--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,0 +1,7 @@
+if AuthenticationService.persona?
+  class PersonasController < ActionController::Base
+    layout "application"
+
+    def index; end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -2,7 +2,11 @@ class SessionsController < ApplicationController
   skip_before_action :authenticate
 
   def sign_out
-    redirect_to "/auth/dfe/signout"
+    if AuthenticationService.persona?
+      redirect_to "/auth/developer/signout"
+    else
+      redirect_to "/auth/dfe/signout"
+    end
   end
 
   def callback

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -48,7 +48,11 @@ class UserSession
   end
 
   def logout_url
-    dfe_logout_url
+    if AuthenticationService.persona?
+      "/sign-in"
+    else
+      dfe_logout_url
+    end
   end
 
 private

--- a/app/services/authentication_service.rb
+++ b/app/services/authentication_service.rb
@@ -5,6 +5,23 @@ class AuthenticationService
     @logger = logger
   end
 
+  class << self
+    DFE_SIGNIN = "dfe_signin".freeze
+    PERSONA = "persona".freeze
+
+    def mode
+      Settings.authentication.mode == PERSONA ? PERSONA : DFE_SIGNIN
+    end
+
+    def dfe_signin?
+      mode == DFE_SIGNIN
+    end
+
+    def persona?
+      mode == PERSONA
+    end
+  end
+
   def execute(encoded_token)
     @encoded_token = encoded_token
     @user = find_user_by_sign_in_user_id || find_user_by_email

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, I18n.t("components.page_titles.sign_in.personas") %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-caption-xl">
+    Teacher Training API
+  </span>
+  Personas
+</h1>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+<%= render Persona::View.new(email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
+                              first_name: "Support agent",
+                              last_name: "Colin")
+%>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -5,11 +5,14 @@
 
     <h1 class="govuk-heading-l">Sign in to <%= I18n.t("service_name") %></h1>
 
-    <p class="govuk-body-m"> Use DfE Sign-in to access your account. You need to be a registered administrator to login to these pages.</p>
-
-    <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
-
-    <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name") %>,   email <%= support_email %>.
-    </p>
+    <% if AuthenticationService.dfe_signin? %>
+        <p class="govuk-body-m">Use DfE Sign-in to access your account. You need to be a registered administrator to login to these pages.</p>
+        <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
+        <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to<%= I18n.t("service_name") %>,   email <%= support_email %>.
+        </p>
+    <% else %>
+        <p class="govuk-body-m">Use Personas to access an account.</p>
+        <%= govuk_link_to "Sign in using a Persona", "/personas", button: true %>
+    <% end %>
   </div>
 </div>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,29 +1,42 @@
 # frozen_string_literal: true
 
-OmniAuth.config.logger = Rails.logger
+require_relative "../../app/services/authentication_service"
 
-dfe_sign_in_issuer_uri = URI.parse(Settings.dfe_signin.issuer)
-dfe_sign_in_redirect_uri = URI.join(Settings.base_url, "/auth/dfe/callback")
+if AuthenticationService.persona?
 
-client_options = {
-  identifier: Settings.dfe_signin.identifier,
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :developer,
+             fields: %i[uid email first_name last_name],
+             uid_field: :uid
+  end
+else
 
-  port: dfe_sign_in_issuer_uri.port,
-  scheme: dfe_sign_in_issuer_uri.scheme,
-  host: dfe_sign_in_issuer_uri.host,
+  OmniAuth.config.logger = Rails.logger
 
-  secret: Settings.dfe_signin.secret,
-  redirect_uri: dfe_sign_in_redirect_uri&.to_s,
-}
+  dfe_sign_in_issuer_uri = URI.parse(Settings.dfe_signin.issuer)
+  dfe_sign_in_redirect_uri = URI.join(Settings.base_url, "/auth/dfe/callback")
 
-options = {
-  name: :dfe,
-  discovery: true,
-  response_type: :code,
-  scope: %i[email profile],
-  path_prefix: "/auth",
-  callback_path: "/auth/dfe/callback",
-  client_options: client_options,
-}
+  client_options = {
+    identifier: Settings.dfe_signin.identifier,
 
-Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
+    port: dfe_sign_in_issuer_uri.port,
+    scheme: dfe_sign_in_issuer_uri.scheme,
+    host: dfe_sign_in_issuer_uri.host,
+
+    secret: Settings.dfe_signin.secret,
+    redirect_uri: dfe_sign_in_redirect_uri&.to_s,
+  }
+
+  options = {
+    name: :dfe,
+    discovery: true,
+    response_type: :code,
+    scope: %i[email profile],
+    path_prefix: "/auth",
+    callback_path: "/auth/dfe/callback",
+    client_options: client_options,
+  }
+
+  Rails.application.config.middleware.use OmniAuth::Strategies::OpenIDConnect, options
+
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,7 @@ en:
       sign_in:
         index: "Sign in"
         new: "User not found"
+        personas: Teacher Training API Personas
       support:
         providers:
           index: "Providers"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,14 @@ Rails.application.routes.draw do
   get "/user-not-found", to: "sign_in#new"
   get "/sign-out", to: "sessions#sign_out"
 
-  get "/auth/dfe/callback", to: "sessions#callback"
-  get "/auth/dfe/signout", to: "sessions#destroy"
+  if AuthenticationService.persona?
+    get "/personas", to: "personas#index"
+    post "/auth/developer/callback", to: "sessions#callback"
+    get "/auth/developer/signout", to: "sessions#destroy"
+  else
+    get "/auth/dfe/callback", to: "sessions#callback"
+    get "/auth/dfe/signout", to: "sessions#destroy"
+  end
 
   namespace :support do
     get "/" => redirect("/support/providers")

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -54,3 +54,6 @@ skylight:
   enable: false
   authentication: please_change_me
 render_json_errors: false
+
+basic_auth:
+  enabled: false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -15,3 +15,10 @@ skylight:
   enable: true
 environment:
   name: "qa"
+
+authentication:
+  # mode: dfe_signin  # default authentication mode
+  mode: persona     # none critical systems, ie localhost
+
+basic_auth:
+  enabled: true

--- a/spec/components/persona/view_preview.rb
+++ b/spec/components/persona/view_preview.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Persona
+  class ViewPreview < ViewComponent::Preview
+    def login_button
+      render(Persona::View.new(email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
+                               first_name: "Support agent", last_name: "Colin"))
+    end
+  end
+end

--- a/spec/components/persona/view_spec.rb
+++ b/spec/components/persona/view_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Persona
+  describe View do
+    alias_method :component, :page
+
+    before do
+      render_inline(described_class.new(email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
+                                        first_name: "Support agent", last_name: "Colin"))
+    end
+
+    it "renders a govuk button" do
+      expect(component).to have_selector(".govuk-button")
+    end
+
+    it "renders personas last name in the button text" do
+      expect(component).to have_button("Login as Colin")
+    end
+
+    it "redirects to the developer auth" do
+      expect(component.find("form")["action"]).to eq("/auth/developer/callback")
+    end
+  end
+end

--- a/spec/features/auth/dfe_sign_in_spec.rb
+++ b/spec/features/auth/dfe_sign_in_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "sign in page" do
+  before do
+    sign_in_page.load
+  end
+
+  scenario "navigate to sign in" do
+    expect(sign_in_page).to have_text("Sign in")
+    expect(sign_in_page).to have_title("Sign in - Teacher Training API Admin")
+    expect(sign_in_page).to have_button("Sign in using DfE Sign-in")
+  end
+end

--- a/spec/features/auth/persona_spec.rb
+++ b/spec/features/auth/persona_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "sign in page" do
+  before do
+    allow(AuthenticationService).to receive(:mode).and_return("persona")
+    sign_in_page.load
+  end
+
+  scenario "navigate to persona when mode is 'persona'" do
+    expect(sign_in_page).to have_text("Use Personas to access an account.")
+    expect(sign_in_page).to have_title("Sign in - Teacher Training API Admin")
+    expect(sign_in_page).to have_link("Sign in using a Persona")
+  end
+end


### PR DESCRIPTION
### Context

We are adding personas to the TTAPI to enable us to use review apps. DfE sign in makes it difficult to whitelist the URLs created for the review apps. 

### Changes proposed in this pull request

- Add dfe_signin and persona mode logic to the authentication_service
- Add persona view
- Add admin persona component button
- Add logic to the view which displays sign in if mode == dfe_signin
- Add logic to the view which displays persona if mode == persona
- Add logic to omniauth for new auth if AuthenticationService.persona?
- Add Persona controller with conditional if mode == persona
- Add persona routes and logic to use persona route if mode == persona
- Add sign_out logic to make signout button work
- Add admin persona details to Settings

### Guidance to review
`Product review edit`: This can now be reviewed on QA and Staging as I have manually deployed to these environments. 
- Check QA to ensure you can login correctly using Basic Auth & Personas (credentials are on Confluence, or DM me). 
- Check Staging to ensure you are still authenticated using DfE Sign in.

- Change your settings in `development.local.yml` to the below.
`authentication:`
   `mode: persona`
------------------------------------------------------------------------------------------------------------------------
- Boot up the server and ensure that you can login to the TTAPI using a Persona
- Ensure that persona is an admin and you can see all the organisations

- Check that you can login in a similar way using QA and that QA is protected by basic auth.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
