### PR TITLE
Bug fix - order courses correctly when ordering by distance and filtering by  'has_vacancies'

### DIFF
--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -91,6 +91,18 @@ private
     # Only running and published site statuses
     running_and_published_criteria = site_status[:status].eq(SiteStatus.statuses[:running]).and(site_status[:publish].eq(SiteStatus.publishes[:published]))
 
+    running_and_published_and_vacancy_criteria = if has_vacancies?
+                                                   running_and_published_criteria
+                                                     .and(site_status[:vac_status])
+                                                     .eq_any([
+                                                       SiteStatus.vac_statuses[:full_time_vacancies],
+                                                       SiteStatus.vac_statuses[:part_time_vacancies],
+                                                       SiteStatus.vac_statuses[:both_full_time_and_part_time_vacancies],
+                                                     ])
+                                                 else
+                                                   running_and_published_criteria
+                                                 end
+
     # we only want sites that have been geocoded
     has_been_geocoded_criteria = sites[:latitude].not_eq(nil).and(sites[:longitude].not_eq(nil))
 
@@ -102,7 +114,7 @@ private
 
     # Create virtual table with sites and site statuses
     site_status.join(sites).on(site_status[:site_id].eq(sites[:id]))
-     .where(running_and_published_criteria)
+     .where(running_and_published_and_vacancy_criteria)
      .where(has_been_geocoded_criteria)
      .where(locatable_address_criteria)
   end


### PR DESCRIPTION
### Context
Previously the `has_vacancies` filter was not taken into account when ordering by distance. This meant that some searches on Find would results in courses appearing higher up in search results even though they had sites with no vacancies

### Changes proposed in this pull request
Squash that bug!

### Guidance to review
Make sense? [You can see a live example of the bug on prod](https://www.find-postgraduate-teacher-training.service.gov.uk/results?c=England&l=1&lat=51.4612794&lng=-0.1156148&loc=Brixton%2C+London%2C+UK&lq=Brixton%2C+London&rad=50&sortby=2&subjects%5B%5D=24)

|Find with bug|Find without the bug|
--- | --- |
|<img width="587" alt="before_find_no_vacancies" src="https://user-images.githubusercontent.com/5256922/127507468-b9f9a916-c4d2-4094-bf92-8174691fe8de.png">|<img width="608" alt="find_after" src="https://user-images.githubusercontent.com/5256922/127507508-060f2fe7-2e27-4d76-84af-7eda3da4ee71.png">|

### Trello
https://trello.com/c/Vo3H6vAP/3453-find-locations-bug

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
