### PR TITLE
[2422] Course can be published without site URN

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -276,7 +276,6 @@ class Course < ApplicationRecord
   validate :validate_site_statuses_publishable, on: :publish
   validate :validate_provider_visa_sponsorship_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
   validate :validate_provider_urn_ukprn_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
-  validate :validate_all_sites_publishable, on: :publish, if: -> { recruitment_cycle_after_2021? }
   validate :validate_degree_requirements_publishable, on: :publish
   validate :validate_gcse_requirements_publishable, on: :publish
   validate :validate_enrichment
@@ -846,12 +845,6 @@ private
     end
     @services.register(:content_status) do
       Courses::ContentStatusService.new
-    end
-  end
-
-  def validate_all_sites_publishable
-    if sites.any? { |s| s.urn.blank? }
-      errors.add(:sites, :site_urn_not_publishable)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,7 +104,6 @@ en:
               blank: "^Complete your course information before publishing"
             sites:
               blank: "^Select at least one location for this course"
-              site_urn_not_publishable: "^Enter a Unique Reference Number (URN) for all course locations"
             age_range_in_years:
               blank: "^Select an age range"
             program_type:

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -77,10 +77,6 @@ describe API::V2::CoursesController, type: :controller do
             expect(validation_errors).to include("Enter a UK Provider Reference Number (UKPRN)")
           end
 
-          it "has a validation error about locations not having a URN" do
-            expect(validation_errors).to include("Enter a Unique Reference Number (URN) for all course locations")
-          end
-
           context "provider is a lead school" do
             let(:provider_type) { :lead_school }
 


### PR DESCRIPTION
### Context

Some sites don't have a URN and this is a problem for providers.

Follows on from https://github.com/DFE-Digital/teacher-training-api/pull/2088

### Changes proposed in this pull request

Remove the validation that checked that all sites had a URN before
allowing a course to be published.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
