### PR TITLE
Ensure courses UCL accredit require 5+ for GCSE requirements

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -442,7 +442,7 @@ class Course < ApplicationRecord
   end
 
   def gcse_grade_required
-    if PROVIDERS_REQUIRING_GCSE_GRADE_5.include?(provider_code)
+    if PROVIDERS_REQUIRING_GCSE_GRADE_5.any?(provider_code) || PROVIDERS_REQUIRING_GCSE_GRADE_5.any?(accrediting_provider&.provider_code)
       5
     else
       4

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1812,6 +1812,16 @@ describe Course, type: :model do
 
       its(:gcse_grade_required) { is_expected.to eq(5) }
     end
+
+    context "when the accrediting provider is on the PROVIDERS_REQUIRING_GCSE_GRADE_5 list" do
+      let(:course) do
+        provider = create(:provider)
+        accrediting_provider = create(:provider, provider_code: Course::PROVIDERS_REQUIRING_GCSE_GRADE_5.sample)
+        create(:course, provider: provider, accrediting_provider: accrediting_provider)
+      end
+
+      its(:gcse_grade_required) { is_expected.to eq(5) }
+    end
   end
 
   context "bursaries and scholarships" do


### PR DESCRIPTION
### Context

UCL require 5+ for GCSEs for the courses they accredit.

Currently, we only check whether they are the provider. This has caused issues as a provider has noted that it says 4+ for their courses accredited by UCL.

https://trello.com/c/jYTgdnjE/3778-fix-issue-with-courses-ucl-accredit-not-showing-5-for-gcses

### Changes proposed in this pull request

- Check if UCL is the accredited provider in the `gcse_grade_required` method. If so also return 5.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
