### PR TITLE
Ensure UCAS GCSE requirements are set to not_required for fe courses on creation

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -343,6 +343,9 @@ module API
 
       def update_further_education_fields
         @course.funding_type = "fee"
+        @course.english = "not_required"
+        @course.maths = "not_required"
+        @course.science = "not_required"
         @course.subjects << FurtherEducationSubject.instance
       end
 

--- a/spec/requests/api/v2/providers/courses/create_spec.rb
+++ b/spec/requests/api/v2/providers/courses/create_spec.rb
@@ -218,6 +218,13 @@ describe "Course POST #create API V2", type: :request do
         created_course = provider.reload.courses.last
         expect(created_course.subjects).to eq([further_education_subject])
       end
+
+      it "Creates a course with maths, English and science set to `not_required`" do
+        created_course = provider.reload.courses.last
+        expect(created_course.english).to eq("not_required")
+        expect(created_course.maths).to eq("not_required")
+        expect(created_course.science).to eq("not_required")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

UCAS Apply is breaking for some FE courses as the UCAS GCSE requirements is set to nil.

I've backfilled the current cycles data to not_required where necessary. This PR ensures that the correct value is set on course creation.

### Changes proposed in this pull request

- Set english, maths and science to not required on course creation for FE courses

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
