### PR TITLE
[xxx] BigQuery key is JSON

### DIFF
--- a/config/initializers/bigquery.rb
+++ b/config/initializers/bigquery.rb
@@ -3,7 +3,7 @@ require "google/cloud/bigquery"
 if FeatureService.enabled?(:send_request_data_to_bigquery)
   Google::Cloud::Bigquery.configure do |config|
     config.project_id  = Settings.google.bigquery.project_id
-    config.credentials = JSON.parse(Settings.google.bigquery.api_json_key.to_json)
+    config.credentials = JSON.parse(Settings.google.bigquery.api_json_key)
   end
 
   Google::Cloud::Bigquery.new


### PR DESCRIPTION
### Context

We integrate with BigQuery and store the key In secrets as JSON. Using `to_json` is breaking things.

### Changes proposed in this pull request

Don't convert the JSON `to_json`

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
