### PR TITLE
[xxx] Fix BigQuery current user bug

### DIFF
--- a/app/controllers/api/public/v1/application_controller.rb
+++ b/app/controllers/api/public/v1/application_controller.rb
@@ -1,9 +1,7 @@
 module API
   module Public
     module V1
-      class ApplicationController < ActionController::API
-        include Pagy::Backend
-        include ErrorHandlers::Pagy
+      class ApplicationController < PublicAPIController
         include PagyPagination
       end
     end

--- a/app/controllers/api/v3/application_controller.rb
+++ b/app/controllers/api/v3/application_controller.rb
@@ -1,9 +1,6 @@
 module API
   module V3
-    class ApplicationController < ActionController::API
-      include Pagy::Backend
-      include ErrorHandlers::Pagy
-
+    class ApplicationController < PublicAPIController
       rescue_from ActiveRecord::RecordNotFound, with: :jsonapi_404
 
       before_action :store_request_id

--- a/app/controllers/concerns/emits_request_events.rb
+++ b/app/controllers/concerns/emits_request_events.rb
@@ -11,7 +11,9 @@ module EmitsRequestEvents
       request_event = BigQuery::RequestEvent.new do |event|
         event.with_request_details(request)
         event.with_response_details(response)
-        event.with_user(current_user)
+        if respond_to?(:current_user, true)
+          event.with_user(current_user)
+        end
       end
 
       SendEventToBigQueryJob.perform_later(request_event.as_json)

--- a/app/controllers/public_api_controller.rb
+++ b/app/controllers/public_api_controller.rb
@@ -1,0 +1,5 @@
+class PublicAPIController < ActionController::API
+  include EmitsRequestEvents
+  include Pagy::Backend
+  include ErrorHandlers::Pagy
+end

--- a/spec/requests/send_data_to_big_query_spec.rb
+++ b/spec/requests/send_data_to_big_query_spec.rb
@@ -16,7 +16,7 @@ class TestController < ::ApplicationController
   attr_reader :current_user
 end
 
-class UnauthenticatedTestController < ::API::Public::V1::ApplicationController
+class UnauthenticatedTestController < PublicAPIController
   def test
     render plain: "Booyah"
   end

--- a/spec/requests/send_data_to_big_query_spec.rb
+++ b/spec/requests/send_data_to_big_query_spec.rb
@@ -12,6 +12,14 @@ class TestController < ::ApplicationController
   def authenticate
     @current_user = User.last
   end
+
+  attr_reader :current_user
+end
+
+class UnauthenticatedTestController < ::API::Public::V1::ApplicationController
+  def test
+    render plain: "Booyah"
+  end
 end
 
 describe EmitsRequestEvents, type: :request do
@@ -20,6 +28,7 @@ describe EmitsRequestEvents, type: :request do
   before do
     Rails.application.routes.draw do
       get "/test", to: "test#test"
+      get "/unauthenticated_test", to: "unauthenticated_test#test"
     end
   end
 
@@ -52,6 +61,22 @@ describe EmitsRequestEvents, type: :request do
           "X-Request-Id" => "iamauuid",
         }
       }.not_to(have_enqueued_job(SendEventToBigQueryJob))
+    end
+  end
+
+  context "controller doesn't have a current_user" do
+    before do
+      stub_feature(true)
+    end
+
+    it "does send to big query" do
+      expect {
+        get "/unauthenticated_test?foo=bar", headers: {
+          "HTTP_USER_AGENT" => "Toaster/1.23",
+          "HTTP_REFERER" => "https://example.com/",
+          "X-Request-Id" => "iamauuid",
+        }
+      }.to(have_enqueued_job(SendEventToBigQueryJob))
     end
   end
 


### PR DESCRIPTION
### Context

We are sending request events to BigQuery. The existing concern `EmitsRequestEvents` expects the controller to implement `current_user` and the v1, v3 and public/v1 controller don't. So v1 is erroring currently. v3 and public/v1 were missed from the original PR to add this functionality.

### Changes proposed in this pull request

* Check for current_user before calling
* Refactor the public API controllers to use a common base class that includes the concern

### Guidance to review

Check that all API versions are responding without error when the send_data_to_bigquery feature is enabled.

The app will need to be deployed to check that BigQuery is receiving the events in all envs.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
