### PR TITLE
[2540] Course#updated_changed_at touches Provider

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -378,6 +378,7 @@ class Course < ApplicationRecord
     # itself, so we don't want to alter the semantics of updated_at which
     # represents changes to just the course record.
     update_columns changed_at: timestamp
+    touch_provider
   end
 
   def study_mode_description

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2462,4 +2462,26 @@ describe Course, type: :model do
       it { is_expected.to eq(true) }
     end
   end
+
+  describe "update_changed_at" do
+    around do |example|
+      Timecop.freeze do
+        example.run
+      end
+    end
+
+    before do
+      course.update_columns(changed_at: 1.day.ago)
+      course.provider.update_columns(changed_at: 1.day.ago)
+      course.update_changed_at
+    end
+
+    it "sets changed_at" do
+      expect(course.changed_at).to eq(Time.zone.now)
+    end
+
+    it "touches the provider" do
+      expect(course.provider.changed_at).to eq(Time.zone.now)
+    end
+  end
 end


### PR DESCRIPTION
### Context

When a course has its vacancy status changed we expect the provider to be returned in a /providers API call with an updated_since filter. They currently are not as the `Provider#changed_at` is not updated when the `Course#site_statuses` are updated.

### Changes proposed in this pull request

`touch_provider` when the `Course#update_changed_at` is called. `update_columns` skips callbacks so we need to call `touch_provider` explicitly.

### Guidance to review

Retrieve a course with vacancies in the console: `course = Course.with_vacancies.last`
Update the vacancy status: `course.site_statuses.each(&:no_vacancies!)`
Check the changed at on Course: `course.changed_at`
Check the changed at on Provider: `course.provider.changed_at`

They should match (pretty much). This provider should now appear on `/api/public/v1/recruitment_cycles/2021/providers?updated_since=<a bit ago>`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
