### PR TITLE
Expose the new visa/GCSE/Degree attributes on the public API

### DIFF
--- a/app/serializers/api/public/v1/serializable_course.rb
+++ b/app/serializers/api/public/v1/serializable_course.rb
@@ -33,7 +33,15 @@ module API
                    :qualifications,
                    :scholarship_amount,
                    :study_mode,
-                   :uuid
+                   :uuid,
+                   :degree_grade,
+                   :degree_subject_requirements,
+                   :accept_pending_gcse,
+                   :accept_gcse_equivalency,
+                   :accept_english_gcse_equivalency,
+                   :accept_maths_gcse_equivalency,
+                   :accept_science_gcse_equivalency,
+                   :additional_gcse_equivalencies
 
         attribute :about_accredited_body do
           @object.accrediting_provider_description

--- a/app/serializers/api/public/v1/serializable_provider.rb
+++ b/app/serializers/api/public/v1/serializable_provider.rb
@@ -17,7 +17,9 @@ module API
                    :latitude,
                    :longitude,
                    :telephone,
-                   :email
+                   :email,
+                   :can_sponsor_skilled_worker_visa,
+                   :can_sponsor_student_visa
 
         attribute :accredited_body do
           @object.accredited_body?

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -214,6 +214,75 @@ RSpec.describe API::Public::V1::CoursesController do
 
           expect(meta["count"]).to be(2)
         end
+
+        context "default fields" do
+          let(:fields) do
+            %w[ accredited_body_code
+                age_maximum
+                age_minimum
+                bursary_amount
+                bursary_requirements
+                created_at
+                funding_type
+                gcse_subjects_required
+                level
+                name
+                program_type
+                qualifications
+                scholarship_amount
+                study_mode
+                uuid
+                degree_grade
+                degree_subject_requirements
+                accept_pending_gcse
+                accept_gcse_equivalency
+                accept_english_gcse_equivalency
+                accept_maths_gcse_equivalency
+                accept_science_gcse_equivalency
+                additional_gcse_equivalencies
+                about_accredited_body
+                applications_open_from
+                changed_at
+                code
+                findable
+                has_early_career_payments
+                has_scholarship
+                has_vacancies
+                is_send
+                last_published_at
+                open_for_applications
+                required_qualifications_english
+                required_qualifications_maths
+                required_qualifications_science
+                running
+                start_date
+                state
+                summary
+                subject_codes
+                required_qualifications
+                about_course
+                course_length
+                fee_details
+                fee_international
+                fee_domestic
+                financial_support
+                how_school_placements_work
+                interview_process
+                other_requirements
+                personal_qualities
+                salary_details]
+          end
+
+          before do
+            get :index, params: {
+              recruitment_cycle_year: recruitment_cycle.year,
+            }
+          end
+
+          it "returns the default fields" do
+            expect(json_response["data"].first["attributes"].keys).to match_array(fields)
+          end
+        end
       end
     end
   end

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -297,7 +297,9 @@ RSpec.describe API::Public::V1::ProvidersController do
                 latitude
                 longitude
                 telephone
-                email]
+                email
+                can_sponsor_skilled_worker_visa
+                can_sponsor_student_visa]
           end
 
           before do
@@ -405,6 +407,8 @@ RSpec.describe API::Public::V1::ProvidersController do
             "longitude" => provider.longitude,
             "telephone" => provider.telephone,
             "email" => provider.email,
+            "can_sponsor_student_visa" => provider.can_sponsor_student_visa,
+            "can_sponsor_skilled_worker_visa" => provider.can_sponsor_skilled_worker_visa,
           },
         }
       end

--- a/spec/serializers/api/public/v1/serializable_course_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_course_spec.rb
@@ -83,4 +83,13 @@ RSpec.describe API::Public::V1::SerializableCourse do
   it { is_expected.to have_attribute(:study_mode).with_value("full_time") }
   it { is_expected.to have_attribute(:summary).with_value("PGCE with QTS full time teaching apprenticeship") }
   it { is_expected.to have_attribute(:subject_codes).with_value(%w[00]) }
+
+  it { is_expected.to have_attribute(:degree_grade).with_value(course.degree_grade) }
+  it { is_expected.to have_attribute(:degree_subject_requirements).with_value(course.degree_subject_requirements) }
+  it { is_expected.to have_attribute(:accept_pending_gcse).with_value(course.accept_pending_gcse) }
+  it { is_expected.to have_attribute(:accept_gcse_equivalency).with_value(course.accept_gcse_equivalency) }
+  it { is_expected.to have_attribute(:accept_english_gcse_equivalency).with_value(course.accept_english_gcse_equivalency) }
+  it { is_expected.to have_attribute(:accept_maths_gcse_equivalency).with_value(course.accept_maths_gcse_equivalency) }
+  it { is_expected.to have_attribute(:accept_science_gcse_equivalency).with_value(course.accept_science_gcse_equivalency) }
+  it { is_expected.to have_attribute(:additional_gcse_equivalencies).with_value(course.additional_gcse_equivalencies) }
 end

--- a/spec/serializers/api/public/v1/serializable_provider_spec.rb
+++ b/spec/serializers/api/public/v1/serializable_provider_spec.rb
@@ -32,4 +32,6 @@ describe API::Public::V1::SerializableProvider do
   it { is_expected.to have_attribute(:longitude).with_value(provider.longitude) }
   it { is_expected.to have_attribute(:telephone).with_value(provider.telephone) }
   it { is_expected.to have_attribute(:email).with_value(provider.email) }
+  it { is_expected.to have_attribute(:can_sponsor_skilled_worker_visa).with_value(provider.can_sponsor_skilled_worker_visa) }
+  it { is_expected.to have_attribute(:can_sponsor_student_visa).with_value(provider.can_sponsor_student_visa) }
 end

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -487,6 +487,60 @@
               "type": "string",
               "example": "00"
             }
+          },
+          "degree_grade": {
+            "type": "string",
+            "nullable": true,
+            "description": "Minimum degree grade required for this course",
+            "example": "two_one",
+            "enum": [
+              "two_one",
+              "two_two",
+              "third_class",
+              "not_required"
+            ]
+          },
+          "degree_subject_requirements": {
+            "type": "string",
+            "nullable": true,
+            "description": "Degree subject requirements",
+            "example": "Completed at least one programming module."
+          },
+          "accept_pending_gcse": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Does the provider consider candidates with pending GCSEs for this course?",
+            "example": "true"
+          },
+          "accept_gcse_equivalency": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Does the provider consider candidates who need to take an equivalency test in English, maths or science?",
+            "example": "true"
+          },
+          "accept_english_gcse_equivalency": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Does the provider consider candidates who need to take an equivalency test in English?",
+            "example": "true"
+          },
+          "accept_maths_gcse_equivalency": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Does the provider consider candidates who need to take an equivalency test in maths?",
+            "example": "true"
+          },
+          "accept_science_gcse_equivalency": {
+            "type": "boolean",
+            "nullable": true,
+            "description": "Does the provider consider candidates who need to take an equivalency test in science?",
+            "example": "true"
+          },
+          "additional_gcse_equivalencies": {
+            "type": "string",
+            "nullable": true,
+            "description": "Details about equivalency tests the provider offers or accepts",
+            "example": "We offer our own equivalency tests."
           }
         }
       },
@@ -1130,6 +1184,16 @@
             "format": "url",
             "description": "A link to the initial teacher training or course pages of your website.",
             "example": "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/"
+          },
+          "can_sponsor_skilled_worker_visa": {
+            "type": "boolean",
+            "description": "Can this provider sponsor Skilled Worker visas?",
+            "example": "true"
+          },
+          "can_sponsor_student_visa": {
+            "type": "boolean",
+            "description": "Can this provider sponsor Student visas?",
+            "example": "true"
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseAttributes.yml
+++ b/swagger/public_v1/component_schemas/CourseAttributes.yml
@@ -340,3 +340,48 @@ properties:
     items:
       type: string
       example: "00"
+  degree_grade:
+    type: string
+    nullable: true
+    description: "Minimum degree grade required for this course"
+    example: "two_one"
+    enum:
+      - two_one
+      - two_two
+      - third_class
+      - not_required
+  degree_subject_requirements:
+    type: string
+    nullable: true
+    description: "Degree subject requirements"
+    example: "Completed at least one programming module."
+  accept_pending_gcse:
+    type: boolean
+    nullable: true
+    description: "Does the provider consider candidates with pending GCSEs for this course?"
+    example: "true"
+  accept_gcse_equivalency:
+    type: boolean
+    nullable: true
+    description: "Does the provider consider candidates who need to take an equivalency test in English, maths or science?"
+    example: "true"
+  accept_english_gcse_equivalency:
+    type: boolean
+    nullable: true
+    description: "Does the provider consider candidates who need to take an equivalency test in English?"
+    example: "true"
+  accept_maths_gcse_equivalency:
+    type: boolean
+    nullable: true
+    description: "Does the provider consider candidates who need to take an equivalency test in maths?"
+    example: "true"
+  accept_science_gcse_equivalency:
+    type: boolean
+    nullable: true
+    description: "Does the provider consider candidates who need to take an equivalency test in science?"
+    example: "true"
+  additional_gcse_equivalencies:
+    type: string
+    nullable: true
+    description: "Details about equivalency tests the provider offers or accepts"
+    example: "We offer our own equivalency tests."

--- a/swagger/public_v1/component_schemas/ProviderAttributes.yml
+++ b/swagger/public_v1/component_schemas/ProviderAttributes.yml
@@ -134,3 +134,11 @@ properties:
     format: url
     description: "A link to the initial teacher training or course pages of your website."
     example: "http://www.teamworkstsa.org/home-page-s-c-i-t-t-teacher-training/"
+  can_sponsor_skilled_worker_visa:
+    type: boolean
+    description: "Can this provider sponsor Skilled Worker visas?"
+    example: "true"
+  can_sponsor_student_visa:
+    type: boolean
+    description: "Can this provider sponsor Student visas?"
+    example: "true"


### PR DESCRIPTION
### Context

The new values for degree grade requirements need to be exposed on the public API so that they can be synced with Apply.

https://trello.com/c/BNDjZri5/3872-expose-the-new-visa-gcse-degree-values-on-the-public-ttapi

### Changes proposed in this pull request

We need to expose the following on the public TTAPI:

For Providers:

- `can_sponsor_student_visa`
- `can_sponsor_skilled_worker_visa`

For Courses:

- `degree_grade`
- `degree_subject_requirements`
- `accept_pending_gcse`
- `accept_gcse_equivalency`
- `accept_english_gcse_equivalency`
- `accept_maths_gcse_equivalency`
- `accept_science_gcse_equivalency`
- `additional_gcse_equivalencies`

### Guidance to review

- Have I missed anything here?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
