### PR TITLE
Add filter for courses whose provider can sponsor visas

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -259,6 +259,11 @@ class Course < ApplicationRecord
     where(degree_grade: degree_grades)
   end
 
+  scope :provider_can_sponsor_visa, -> do
+    joins(:provider)
+    .where("provider.can_sponsor_student_visa = true OR provider.can_sponsor_skilled_worker_visa = true")
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -29,6 +29,7 @@ class CourseSearchService
     scope = scope.with_funding_types(funding_types) if funding_types.any?
     scope = scope.with_degree_grades(degree_grades) if degree_grades.any?
     scope = scope.changed_since(filter[:updated_since]) if updated_since_filter?
+    scope = scope.provider_can_sponsor_visa if can_sponsor_visa_filter?
 
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
@@ -231,5 +232,9 @@ private
 
   def updated_since_filter?
     filter[:updated_since].present?
+  end
+
+  def can_sponsor_visa_filter?
+    filter[:can_sponsor_visa].to_s.downcase == "true"
   end
 end

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -25,6 +25,7 @@ describe "API" do
                   subjects: "00,01",
                   updated_since: "2020-11-13T11:21:55Z",
                   degree_grade: "two_two",
+                  provider_can_sponsor_visa: true,
                 }
       parameter name: :sort,
                 in: :query,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -31,6 +31,7 @@ describe "API" do
                   subjects: "00,01",
                   updated_since: "2020-11-13T11:21:55Z",
                   degree_grade: "two_two",
+                  provider_can_sponsor_visa: true,
                 }
       parameter name: :sort,
                 in: :query,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1181,6 +1181,40 @@ describe Course, type: :model do
         expect(described_class.findable.with_vacancies.to_a).to eql([course_in_scope])
       end
     end
+
+    describe ".provider_can_sponsor_visa" do
+      subject { described_class.provider_can_sponsor_visa }
+
+      let(:course) { create(:course, provider: provider) }
+
+      before do
+        course
+      end
+
+      context "when the provider can sponsor skilled worker visas" do
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: false)}
+
+        it "returns the course" do
+          expect(subject).to eq [course]
+        end
+      end
+
+      context "when the provider can sponsor student visas" do
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: true)}
+
+        it "returns the course" do
+          expect(subject).to eq [course]
+        end
+      end
+
+      context "when the provider cannot sponsor visas" do
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false)}
+
+        it "does not return the course" do
+          expect(subject).to eq []
+        end
+      end
+    end
   end
 
   describe "changed_at" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1192,7 +1192,7 @@ describe Course, type: :model do
       end
 
       context "when the provider can sponsor skilled worker visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: false)}
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: true, can_sponsor_student_visa: false) }
 
         it "returns the course" do
           expect(subject).to eq [course]
@@ -1200,7 +1200,7 @@ describe Course, type: :model do
       end
 
       context "when the provider can sponsor student visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: true)}
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: true) }
 
         it "returns the course" do
           expect(subject).to eq [course]
@@ -1208,7 +1208,7 @@ describe Course, type: :model do
       end
 
       context "when the provider cannot sponsor visas" do
-        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false)}
+        let(:provider) { create(:provider, can_sponsor_skilled_worker_visa: false, can_sponsor_student_visa: false) }
 
         it "does not return the course" do
           expect(subject).to eq []

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -718,6 +718,31 @@ describe "GET v3/courses" do
     end
   end
 
+  describe "visa scoping" do
+    context "with providers that can and cannot provide visas" do
+      let(:request_path) { "/api/v3/courses?filter[can_sponsor_visa]=true" }
+      let(:provider_that_can_sponsor_student_visa) { build(:provider, can_sponsor_student_visa: true, can_sponsor_skilled_worker_visa: false) }
+      let(:provider_that_can_sponsor_skilled_worker_visa) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: true) }
+      let(:provider_that_cant_sponsor_visas) { build(:provider, can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: false) }
+      let(:course1) { create(:course, provider: provider_that_can_sponsor_student_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course2) { create(:course, provider: provider_that_can_sponsor_skilled_worker_visa, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+      let(:course3) { create(:course, provider: provider_that_cant_sponsor_visas, site_statuses: [build(:site_status, :findable)], enrichments: [build(:course_enrichment, :published)]) }
+
+      before do
+        course1
+        course2
+        course3
+      end
+
+      it "returns courses where the provider can offer visas" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+        expect(course_hashes.count).to eq(2)
+      end
+    end
+  end
+
   describe "pagination" do
     let(:request_path) { "/api/v3/courses" }
 

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -612,6 +612,42 @@ RSpec.describe CourseSearchService do
         expect(subject).to eq(expected_scope)
       end
     end
+
+    describe "filter[can_sponsor_visa]" do
+      context "when true" do
+        let(:filter) { { can_sponsor_visa: true } }
+        let(:expected_scope) { double }
+
+        it "adds the provider_can_sponsor_visa scope" do
+          expect(scope).to receive(:provider_can_sponsor_visa).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when false" do
+        let(:filter) { { can_sponsor_visa: false } }
+
+        it "adds the provider_can_sponsor_visa scope" do
+          expect(scope).not_to receive(:provider_can_sponsor_visa)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the provider_can_sponsor_visa scope" do
+          expect(scope).not_to receive(:provider_can_sponsor_visa)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+    end
   end
 
   describe "expand_university" do

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -675,6 +675,11 @@
             "description": "Return courses have been updated since the date (ISO 8601 date format)",
             "type": "string",
             "example": "2020-11-13T11:21:55Z"
+          },
+          "can_sponsor_visa": {
+            "description": "Return courses where the provider can sponsor a visa.",
+            "type": "boolean",
+            "example": true
           }
         }
       },

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -112,3 +112,7 @@ properties:
       - two_two
       - third_class
       - not_required
+provider_can_sponsor_visa:
+    description: "Only return courses where the provider can sponsor either a skilled worker or student visa"
+    type: boolean
+    example: true


### PR DESCRIPTION
### Context

One of the new features that we're adding to Find is the ability to filter courses based on whether the provider can offer either a skilled worker or student visa 

This PR adds in the functionality required to allow this.

### Changes proposed in this pull request

- Add a scope to the course model which returns providers who can sponsor a visa
- Add the scope to the course search service
- Tests 

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
