### PR TITLE
Add 'degree grade' filter

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -255,6 +255,10 @@ class Course < ApplicationRecord
     where(program_type: program_types)
   end
 
+  scope :with_degree_grades, ->(degree_grades) do
+    where(degree_grade: degree_grades)
+  end
+
   def self.entry_requirement_options_without_nil_choice
     ENTRY_REQUIREMENT_OPTIONS.reject { |option| option == :not_set }.keys.map(&:to_s)
   end

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -27,6 +27,7 @@ class CourseSearchService
     scope = scope.with_send if send_courses_filter?
     scope = scope.within(filter[:radius], origin: origin) if locations_filter?
     scope = scope.with_funding_types(funding_types) if funding_types.any?
+    scope = scope.with_degree_grades(degree_grades) if degree_grades.any?
     scope = scope.changed_since(filter[:updated_since]) if updated_since_filter?
 
     # The 'where' scope will remove duplicates
@@ -204,6 +205,12 @@ private
     return [] if filter[:funding_type].blank?
 
     filter[:funding_type].split(",")
+  end
+
+  def degree_grades
+    return [] if filter[:degree_grade].blank?
+
+    filter[:degree_grade].split(",")
   end
 
   def subject_codes

--- a/spec/docs/courses_spec.rb
+++ b/spec/docs/courses_spec.rb
@@ -24,6 +24,7 @@ describe "API" do
                   has_vacancies: true,
                   subjects: "00,01",
                   updated_since: "2020-11-13T11:21:55Z",
+                  degree_grade: "two_two",
                 }
       parameter name: :sort,
                 in: :query,

--- a/spec/docs/providers/courses_spec.rb
+++ b/spec/docs/providers/courses_spec.rb
@@ -30,6 +30,7 @@ describe "API" do
                   has_vacancies: true,
                   subjects: "00,01",
                   updated_since: "2020-11-13T11:21:55Z",
+                  degree_grade: "two_two",
                 }
       parameter name: :sort,
                 in: :query,

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1016,6 +1016,15 @@ describe Course, type: :model do
           expect(subject).to contain_exactly(minimum_degree_not_required_course)
         end
       end
+
+      context "third_class degree course and 2:2 degree course" do
+        let(:degree_grades) { %w[two_two third_class] }
+
+        it "returns courses that require a minimum of a two degree or a third class degree" do
+          expect(subject.count).to eq(2)
+          expect(subject).to eq([two_two_course, third_class_course])
+        end
+      end
     end
 
     describe ".with_salary" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -996,7 +996,7 @@ describe Course, type: :model do
       context "2:2 courses" do
         let(:degree_grades) { %w[two_two] }
 
-        it "returns courses that require a minimum of a 2:2 degree" do
+        it "returns courses with a 'two_two' degree grade" do
           expect(subject).to contain_exactly(two_two_course)
         end
       end
@@ -1004,15 +1004,15 @@ describe Course, type: :model do
       context "third class degree courses" do
         let(:degree_grades) { %w[third_class] }
 
-        it "returns courses that require a minimum of a third class degree" do
+        it "returns courses with a 'third_class' degree grade" do
           expect(subject).to contain_exactly(third_class_course)
         end
       end
 
-      context "courses without a minimum degree requirement" do
+      context "no requirement degree courses" do
         let(:degree_grades) { %w[not_required] }
 
-        it "returns courses without a minimum degree requirement" do
+        it "returns courses with a 'not_required' degree grade" do
           expect(subject).to contain_exactly(minimum_degree_not_required_course)
         end
       end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1016,15 +1016,6 @@ describe Course, type: :model do
           expect(subject).to contain_exactly(minimum_degree_not_required_course)
         end
       end
-
-      context "third_class degree course and 2:2 degree course" do
-        let(:degree_grades) { %w[two_two third_class] }
-
-        it "returns courses that require a minimum of a two degree or a third class degree" do
-          expect(subject.count).to eq(2)
-          expect(subject).to eq([two_two_course, third_class_course])
-        end
-      end
     end
 
     describe ".with_salary" do

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -980,6 +980,44 @@ describe Course, type: :model do
       end
     end
 
+    describe ".with_degree_grades" do
+      let(:two_two_course) { create(:course, degree_grade: :two_two) }
+      let(:third_class_course) { create(:course, degree_grade: :third_class) }
+      let(:minimum_degree_not_required_course) { create(:course, degree_grade: :not_required) }
+
+      subject { described_class.with_degree_grades(degree_grades) }
+
+      before do
+        two_two_course
+        third_class_course
+        minimum_degree_not_required_course
+      end
+
+      context "2:2 courses" do
+        let(:degree_grades) { %w[two_two] }
+
+        it "returns courses that require a minimum of a 2:2 degree" do
+          expect(subject).to contain_exactly(two_two_course)
+        end
+      end
+
+      context "third class degree courses" do
+        let(:degree_grades) { %w[third_class] }
+
+        it "returns courses that require a minimum of a third class degree" do
+          expect(subject).to contain_exactly(third_class_course)
+        end
+      end
+
+      context "courses without a minimum degree requirement" do
+        let(:degree_grades) { %w[not_required] }
+
+        it "returns courses without a minimum degree requirement" do
+          expect(subject).to contain_exactly(minimum_degree_not_required_course)
+        end
+      end
+    end
+
     describe ".with_salary" do
       let(:course_higher_education_programme) do
         create(:course, program_type: :higher_education_programme)

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -302,6 +302,38 @@ describe "GET v3/courses" do
     end
   end
 
+  describe "degree grade filter" do
+    let(:request_path) { "/api/v3/courses?filter[degree_grade]=two_two" }
+
+    context "with a course that has a 2:2 degree grade minimum requirement" do
+      let(:course_with_two_two_degree) { create(:course, degree_grade: :two_two, site_statuses: [findable_status]) }
+
+      before { course_with_two_two_degree }
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+
+        expect(course_hashes.count).to eq(1)
+      end
+    end
+
+    context "with a course that does not have a 2:2 degree grade minimum requirement" do
+      let(:course_with_third_class_degree) { create(:course, degree_grade: :third_class, site_statuses: [findable_status]) }
+
+      before { course_with_third_class_degree }
+
+      it "is returned" do
+        get request_path
+        json_response = JSON.parse(response.body)
+        course_hashes = json_response["data"]
+
+        expect(course_hashes.count).to eq(0)
+      end
+    end
+  end
+
   describe "qualifications filter" do
     let(:request_path) { "/api/v3/courses?filter[qualification]=pgce" }
 

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -305,7 +305,7 @@ describe "GET v3/courses" do
   describe "degree grade filter" do
     let(:request_path) { "/api/v3/courses?filter[degree_grade]=two_two,third_class" }
 
-    context "with a course that has a 2:2 degree grade minimum requirement or no requirements" do
+    context "with one course that has a 2:2 degree grade and another that has a third class degree grade" do
       let(:course_with_two_two_degree) { create(:course, degree_grade: :two_two, site_statuses: [findable_status]) }
       let(:course_with_third_class_degree) { create(:course, degree_grade: :third_class, site_statuses: [build(:site_status, :findable)]) }
 
@@ -323,7 +323,7 @@ describe "GET v3/courses" do
       end
     end
 
-    context "with a course that does not have a 2:2 degree grade minimum requirement or no requirements" do
+    context "with a course that has a 'not_required' degree grade" do
       let(:minimum_degree_not_required_course) { create(:course, degree_grade: :not_required, site_statuses: [findable_status]) }
 
       before { minimum_degree_not_required_course }

--- a/spec/requests/api/v3/courses/index_spec.rb
+++ b/spec/requests/api/v3/courses/index_spec.rb
@@ -303,28 +303,32 @@ describe "GET v3/courses" do
   end
 
   describe "degree grade filter" do
-    let(:request_path) { "/api/v3/courses?filter[degree_grade]=two_two" }
+    let(:request_path) { "/api/v3/courses?filter[degree_grade]=two_two,third_class" }
 
-    context "with a course that has a 2:2 degree grade minimum requirement" do
+    context "with a course that has a 2:2 degree grade minimum requirement or no requirements" do
       let(:course_with_two_two_degree) { create(:course, degree_grade: :two_two, site_statuses: [findable_status]) }
+      let(:course_with_third_class_degree) { create(:course, degree_grade: :third_class, site_statuses: [build(:site_status, :findable)]) }
 
-      before { course_with_two_two_degree }
+      before do
+        course_with_two_two_degree
+        course_with_third_class_degree
+      end
 
       it "is returned" do
         get request_path
         json_response = JSON.parse(response.body)
         course_hashes = json_response["data"]
 
-        expect(course_hashes.count).to eq(1)
+        expect(course_hashes.count).to eq(2)
       end
     end
 
-    context "with a course that does not have a 2:2 degree grade minimum requirement" do
-      let(:course_with_third_class_degree) { create(:course, degree_grade: :third_class, site_statuses: [findable_status]) }
+    context "with a course that does not have a 2:2 degree grade minimum requirement or no requirements" do
+      let(:minimum_degree_not_required_course) { create(:course, degree_grade: :not_required, site_statuses: [findable_status]) }
 
-      before { course_with_third_class_degree }
+      before { minimum_degree_not_required_course }
 
-      it "is returned" do
+      it "is not returned" do
         get request_path
         json_response = JSON.parse(response.body)
         course_hashes = json_response["data"]

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -465,6 +465,67 @@ RSpec.describe CourseSearchService do
       end
     end
 
+    describe "filter[degree_grade]" do
+      context "when two_two" do
+        let(:filter) { { degree_grade: "two_two" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_degree_grades scope" do
+          expect(scope).to receive(:with_degree_grades).with(%w(two_two)).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when third_class" do
+        let(:filter) { { degree_grade: "third_class" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_degree_grades scope" do
+          expect(scope).to receive(:with_degree_grades).with(%w(third_class)).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when not_required" do
+        let(:filter) { { degree_grade: "not_required" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_degree_grades scope" do
+          expect(scope).to receive(:with_degree_grades).with(%w(not_required)).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when all" do
+        let(:filter) { { degree_grade: "two_one,two_two,third_class,not_required" } }
+        let(:expected_scope) { double }
+
+        it "adds the with_degree_grades scope" do
+          expect(scope).to receive(:with_degree_grades).with(%w(two_two third_class not_required)).and_return(course_ids_scope)
+          expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+
+      context "when absent" do
+        let(:filter) { {} }
+
+        it "doesn't add the scope" do
+          expect(scope).not_to receive(:with_degree_grades)
+          expect(scope).to receive(:select).and_return(inner_query_scope)
+          expect(course_with_includes).to receive(:where).and_return(expected_scope)
+          expect(subject).to eq(expected_scope)
+        end
+      end
+    end
+
     describe "filter[subjects]" do
       context "a single subject code" do
         let(:filter) { { subjects: "A1" } }

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe CourseSearchService do
         let(:expected_scope) { double }
 
         it "adds the with_degree_grades scope" do
-          expect(scope).to receive(:with_degree_grades).with(%w(two_two third_class not_required)).and_return(course_ids_scope)
+          expect(scope).to receive(:with_degree_grades).with(%w(two_one two_two third_class not_required)).and_return(course_ids_scope)
           expect(course_ids_scope).to receive(:select).and_return(inner_query_scope)
           expect(course_with_includes).to receive(:where).and_return(expected_scope)
           expect(subject).to eq(expected_scope)

--- a/swagger/public_v1/api_spec.json
+++ b/swagger/public_v1/api_spec.json
@@ -515,6 +515,17 @@
               "fee"
             ]
           },
+          "degree_grade": {
+            "description": "Return courses based on their degree grade. This is a comma delimited string. If multiple degree grade types are provided then any course matching any one of the options provided will be returned, i.e. the OR operator is used.",
+            "type": "string",
+            "example": "two_two,third_class",
+            "enum": [
+              "two_one",
+              "two_two",
+              "third_class",
+              "not_required"
+            ]
+          },
           "qualification": {
             "description": "Search courses based on the award given on course completion. This is a comma delimited string. If multiple qualifications are given then any course matching any one of the qualifications provided will be returned, i.e. the OR operator is used.",
             "type": "string",

--- a/swagger/public_v1/component_schemas/CourseFilter.yml
+++ b/swagger/public_v1/component_schemas/CourseFilter.yml
@@ -103,3 +103,12 @@ properties:
     description: "Return courses have been updated since the date (ISO 8601 date format)"
     type: string
     example: "2020-11-13T11:21:55Z"
+  degree_grade:
+    description: "Return courses based on their degree grade. This is a comma delimited string. If multiple degree grade types are provided then any course matching any one of the options provided will be returned, i.e. the OR operator is used."
+    type: string
+    example: "two_two,third_class"
+    enum:
+      - two_one
+      - two_two
+      - third_class
+      - not_required


### PR DESCRIPTION
### Context

```
As an... international user of Find 
I need to... find courses that accept my degree grade
So that... I don’t end up making an unsuccessful application
```

### Changes proposed in this pull request
- Add a degree grade filter
- Update API docs

### Trello
https://trello.com/c/UO2ZC9E0/3843-%F0%9F%93%90-dev-ttapi-add-minimum-degree-grade-filter

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
