### PR TITLE
[2392] Import existing db entities into BigQuery

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -22,6 +22,7 @@ Lint/ConstantDefinitionInBlock:
     - "spec/validators/email_validator_spec.rb"
     - "spec/validators/phone_validator_spec.rb"
     - "spec/validators/reference_number_format_validator_spec.rb"
+    - "lib/tasks/big_query.rake"
 
 # Offense count: 3
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.

--- a/app/jobs/send_event_to_big_query_job.rb
+++ b/app/jobs/send_event_to_big_query_job.rb
@@ -1,4 +1,6 @@
 class SendEventToBigQueryJob < ApplicationJob
+  queue_as :low_priority
+
   def perform(event_json, dataset = Settings.google.bigquery.dataset, table = Settings.google.bigquery.table_name)
     return unless FeatureService.enabled?(:send_request_data_to_bigquery)
 

--- a/app/lib/big_query/entity_event.rb
+++ b/app/lib/big_query/entity_event.rb
@@ -1,6 +1,9 @@
 module BigQuery
   class EntityEvent
-    EVENT_TYPES = %w[create_entity update_entity].freeze
+    CREATE_ENTITY_EVENT_TYPE = "create_entity".freeze
+    UPDATE_ENTITY_EVENT_TYPE = "update_entity".freeze
+    IMPORT_EVENT_TYPE = "event_import".freeze
+    EVENT_TYPES = [CREATE_ENTITY_EVENT_TYPE, UPDATE_ENTITY_EVENT_TYPE, IMPORT_EVENT_TYPE].freeze
 
     def initialize
       @event_hash = {

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,6 +1,181 @@
 shared:
-  provider:
-    - provider_name
+  access_request:
+    - id
+    - organisation
+    - request_date_utc
+    - status
+  allocation:
+    - id
+    - provider_id
+    - accredited_body_id
+    - number_of_places
+    - created_at
+    - updated_at
+    - request_type
+    - accredited_body_code
+    - provider_code
+    - recruitment_cycle_id
+    - confirmed_number_of_places
+  contact:
+    - id
+    - provider_id
+    - type
+    - created_at
+    - updated_at
+    - permission_given
   course:
+    - id
+    - course_code
     - name
-
+    - profpost_flag
+    - program_type
+    - qualification
+    - start_date
+    - study_mode
+    - provider_id
+    - modular
+    - english
+    - maths
+    - science
+    - created_at
+    - updated_at
+    - changed_at
+    - accredited_body_code
+    - discarded_at
+    - age_range_in_years
+    - applications_open_from
+    - is_send
+    - level
+    - uuid
+    - degree_grade
+    - additional_degree_subject_requirements
+    - degree_subject_requirements
+    - accept_pending_gcse
+    - accept_gcse_equivalency
+    - accept_english_gcse_equivalency
+    - accept_maths_gcse_equivalency
+    - accept_science_gcse_equivalency
+    - additional_gcse_equivalencies
+  course_site:
+    - id
+    - course_id
+    - publish
+    - site_id
+    - status
+    - vac_status
+  course_subject:
+    - id
+    - course_id
+    - subject_id
+    - created_at
+    - updated_at
+    - position
+  financial_incentive:
+    - id
+    - subject_id
+    - bursary_amount
+    - early_career_payments
+    - scholarship
+    - created_at
+    - updated_at
+    - subject_knowledge_enhancement_course_available
+  interrupt_page_acknowledgement:
+    - id
+    - page
+    - recruitment_cycle_id
+    - user_id
+    - created_at
+    - updated_at
+  organisation:
+    - id
+    - name
+    - org_id
+  organisation_provider:
+    - id
+    - provider_id
+    - organisation_id
+  organisation_user:
+    - id
+    - organisation_id
+    - user_id
+  provider:
+    - id
+    - address4
+    - provider_name
+    - scheme_member
+    - year_code
+    - provider_code
+    - provider_type
+    - postcode
+    - website
+    - address1
+    - address2
+    - address3
+    - region_code
+    - created_at
+    - updated_at
+    - accrediting_provider
+    - changed_at
+    - recruitment_cycle_id
+    - discarded_at
+    - train_with_us
+    - train_with_disability
+    - accrediting_provider_enrichments
+    - latitude
+    - longitude
+    - ukprn
+    - urn
+    - can_sponsor_skilled_worker_visa
+    - can_sponsor_student_visa
+  recruitment_cycle:
+    - id
+    - year
+    - application_start_date
+    - application_end_date
+    - created_at
+    - updated_at
+  site:
+    - id
+    - address2
+    - address3
+    - address4
+    - code
+    - location_name
+    - postcode
+    - address1
+    - provider_id
+    - region_code
+    - created_at
+    - updated_at
+    - latitude
+    - longitude
+    - urn
+  subject:
+    - id
+    - type
+    - subject_code
+    - subject_name
+  subject_area:
+    - typename
+    - name
+    - created_at
+    - updated_at
+  user:
+    - id
+    - first_login_date_utc
+    - last_login_date_utc
+    - welcome_email_date_utc
+    - invite_date_utc
+    - accept_terms_date_utc
+    - state
+    - admin
+    - discarded_at
+    - magic_link_token_sent_at
+  user_notification:
+    - id
+    - user_id
+    - provider_code
+    - course_update
+    - created_at
+    - updated_at
+    - course_publish

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,7 @@
 ---
 :queues:
   - default
+  - mailers
   - geocoding
   - save_statistic
-  - mailers
+  - low_priority

--- a/lib/tasks/big_query.rake
+++ b/lib/tasks/big_query.rake
@@ -1,0 +1,25 @@
+require "csv"
+
+namespace :big_query do
+  desc <<~DESC
+    Send import events for configured entities
+  DESC
+
+  task send_import_events: :environment do
+    class CourseSite < ApplicationRecord; end
+
+    class OrganisationProvider < ApplicationRecord; end
+
+    class Session < ApplicationRecord; end
+
+    conf = Rails.configuration.analytics
+
+    classes = conf.keys.map { |k| k.to_s.camelize.constantize }
+
+    classes.each do |c|
+      puts "Queueing: #{c.count} #{c} entities"
+
+      c.find_each(batch_size: 200, &:send_import_event)
+    end
+  end
+end

--- a/spec/models/concerns/emits_entity_events_spec.rb
+++ b/spec/models/concerns/emits_entity_events_spec.rb
@@ -56,4 +56,22 @@ RSpec.describe EmitsEntityEvents do
       end
     end
   end
+
+  describe "send_import_event" do
+    let(:provider) { create(:provider) }
+
+    before do
+      provider
+      clear_enqueued_jobs
+    end
+
+    it "sends an event" do
+      provider.send_import_event
+      expect(SendEventToBigQueryJob).to have_been_enqueued
+    end
+
+    it "sets the event type" do
+      expect(provider.send_import_event.as_json["event_type"]).to eq("event_import")
+    end
+  end
 end


### PR DESCRIPTION
### Context

We are sending create and update events to BigQuery.

### Changes proposed in this pull request

* Add a `EmitsEntityEvents#send_import_event` - method to send an import event for a model
* Add config/analytics.yml which specifies the entities (db table names) and the fields that should be included in the entity event (generally, excluding PII)
* Add a rake task that will loop through the entities in the config file and queue up a job to send the entity.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
