### PR TITLE
Update error message to match question wording

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -120,7 +120,7 @@ en:
               blank: "^Select when applications will open and enter the date if applicable"
             base:
               duplicate: "This course already exists. You should add further locations for this course to the existing profile in Publish"
-              visa_sponsorship_not_publishable: "Select if you can sponsor visas"
+              visa_sponsorship_not_publishable: "Select if visas can be sponsored"
               provider_ukprn_not_publishable: "Enter a UK Provider Reference Number (UKPRN)"
               provider_ukprn_and_urn_not_publishable: "Enter a UK Provider Reference Number (UKPRN) and URN"
               degree_requirements_not_publishable: "Enter degree requirements"

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -70,7 +70,7 @@ describe API::V2::CoursesController, type: :controller do
           end
 
           it "has a validation error about provider not having visa sponsorship information" do
-            expect(validation_errors).to include("Select if you can sponsor visas")
+            expect(validation_errors).to include("Select if visas can be sponsored")
           end
 
           it "has a validation error about provider not having a UKPRN" do
@@ -117,7 +117,7 @@ describe API::V2::CoursesController, type: :controller do
           end
 
           it "returns no validation error about missing visa information" do
-            expect(response.body).not_to match(/Select if you can sponsor visas/)
+            expect(response.body).not_to match(/Select if visas can be sponsored/)
           end
         end
       end


### PR DESCRIPTION
This updates the error message if you try to publish a course without answering the visa sponsorship questions.

See https://github.com/DFE-Digital/publish-teacher-training/pull/1890 for full context