### PR TITLE
[2392] Throttle on Redis out of memory

### DIFF
--- a/lib/tasks/big_query.rake
+++ b/lib/tasks/big_query.rake
@@ -1,6 +1,9 @@
 require "csv"
 
 namespace :big_query do
+  ON_REDIS_ERROR_WAIT_TIME_IN_SECONDS = 10
+  ON_REDIS_ERROR_RETRY_ATTEMPTS = 5
+
   desc <<~DESC
     Send import events for configured entities
   DESC
@@ -19,7 +22,20 @@ namespace :big_query do
     classes.each do |c|
       puts "Queueing: #{c.count} #{c} entities"
 
-      c.find_each(batch_size: 200, &:send_import_event)
+      c.find_each(batch_size: 200) do |entity|
+        attempt_count = 0
+        begin
+          entity.send_import_event
+        rescue Redis::CommandError
+          attempt_count += 1
+          abort if attempt_count > ON_REDIS_ERROR_RETRY_ATTEMPTS
+
+          Rails.logger.info "sleeping for #{ON_REDIS_ERROR_WAIT_TIME_IN_SECONDS} - redis error"
+
+          sleep ON_REDIS_ERROR_WAIT_TIME_IN_SECONDS
+          retry
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Context

The redis client will raise a `Redis::CommandError` when an operation is attempted that will cause it to breach its configured memory limit. When we ran this task on staging we almost reached that limit so as an extra bit of safety this commit will cause a sleep to allow Sidekiq to reduce the queue size back below the threshold. The staging data is effectively identical to production so it is unlikely that we'll hit this limit with more workers running in production. This should be sufficient to deal with an unexpected peak.

### Changes proposed in this pull request

* Retry 5 times on Redis::CommandError
* Sleep for 10 seconds to give Sidekiq time to clear some jobs

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
