### PR TITLE
Add oj for faster JSON parsing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -126,6 +126,9 @@ gem "omniauth-rails_csrf_protection"
 # Data integration with BigQuery
 gem "google-cloud-bigquery"
 
+# Faster JSON serialization
+gem "oj"
+
 group :development, :test do
   # Prettyprint in console
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,7 @@ GEM
       shellany (~> 0.0)
     notifications-ruby-client (5.1.1)
       jwt (>= 1.5, < 3)
+    oj (3.13.4)
     omniauth (1.9.1)
       hashie (>= 3.4.6)
       rack (>= 1.6.2, < 3)
@@ -673,6 +674,7 @@ DEPENDENCIES
   jwt
   kaminari
   listen (>= 3.0.5, < 3.8)
+  oj
   omniauth (~> 1.9)
   omniauth-rails_csrf_protection
   omniauth_openid_connect (~> 0.3)

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,1 @@
+Oj.default_options = { mode: :rails }


### PR DESCRIPTION
### Context

https://trello.com/c/y5aY2dH0

Oj performs better than the default Rails JSON serializer, and can be used as a drop-in replacement.

The following are Apache Bench results for 500 requests made to`/api/v3/courses`:

#### Without oj
Time taken for tests:   283.719 seconds
Time per request:       567.437 [ms] (mean)

#### With oj
Time taken for tests:   251.801 seconds
Time per request:       503.602 [ms] (mean)


### Changes proposed in this pull request

- Add oj gem
- Add initializer to configure for Rails

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
