### PR TITLE
[16] Added rescue if changed_since value is invalid

### DIFF
--- a/app/controllers/api/public/v1/courses_controller.rb
+++ b/app/controllers/api/public/v1/courses_controller.rb
@@ -7,6 +7,8 @@ module API
                  include: include_param,
                  meta: { count: courses.count("course.id") },
                  class: API::Public::V1::SerializerService.call
+        rescue ActiveRecord::StatementInvalid
+          render json: { status: 400, message: "Invalid changed_since value, the format should be an ISO8601 UTC timestamp, for example: `2019-01-01T12:01:00Z`" }.to_json, status: :bad_request
         end
 
       private


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/LtIVZbq7/16-public-v1-course-endpoints-date-validation)

### Changes proposed in this pull request

- Added an error rescue notifying the user of the correct date time format if they enter an invalid `changed_since` value

### Guidance to review

- Go to `api/public/v1/recruitment_cycles/2022/courses?filter%5Bupdated_since%5D="something_invalid"` to see the error catching with a 400, and custom error message

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
