### PR TITLE
[18] add nctl_organisation table to BigQuery

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -86,6 +86,11 @@ shared:
     - user_id
     - created_at
     - updated_at
+  nctl_organisation:
+    - id
+    - name
+    - nctl_id
+    - organisation_id
   organisation:
     - id
     - name


### PR DESCRIPTION
### Context

Upon review we decided we want to import the values from the nctl_organisation table into BigQuery.

https://trello.com/c/krlbZnL4/18-import-existing-db-entities-into-bigquery

### Changes proposed in this pull request

Add nctl_organisation and fields to `analytics.yml` file.

### Guidance to review

I don't think there any tests for this ...

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
