### PR TITLE
RAILS_MAX_THREADS for db connection pool size

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,12 +1,16 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   username: <%= ENV['DB_USERNAME'] %>
   password: <%= ENV['DB_PASSWORD'] %>
   host: <%= ENV['DB_HOSTNAME'] %>
   port: <%= ENV['DB_PORT'] %>
   database: <%= ENV['DB_DATABASE'] %>
+  keepalives: 1
+  keepalives_idle: 60
+  keepalives_interval: 10
+  keepalives_count: 3
 
 development:
   <<: *default


### PR DESCRIPTION
### Changes proposed in this pull request

Set connection pool size to be same as RAILS_MAX_THEADS if available.

keepalive settings from https://www.postgresql.org/docs/11/libpq-connect.html

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
