### PR TITLE
Use static endpoint for instance healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,5 +53,6 @@ RUN ls /app/public/ && \
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
+RUN echo ${COMMIT_SHA} > public/check
 
 CMD bundle exec rails db:migrate:ignore_concurrent_migration_exceptions && bundle exec rails server -b 0.0.0.0

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -2,7 +2,7 @@ resource cloudfoundry_app web_app {
   name                       = local.web_app_name
   space                      = data.cloudfoundry_space.space.id
   health_check_type          = "http"
-  health_check_http_endpoint = "/ping"
+  health_check_http_endpoint = "/check"
   instances                  = var.web_app_instances
   memory                     = var.web_app_memory
   disk_quota                 = 1500


### PR DESCRIPTION
### Context
Use a static page for per instance healthcheck.

### Changes proposed in this pull request

Write current commit_sha to `public/check`
Use `/check` as the per instance healthcheck endpoint

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
