### PR TITLE
[xxx] Add extra fields to users export

### DIFF
--- a/app/services/support/data_exports/users_export.rb
+++ b/app/services/support/data_exports/users_export.rb
@@ -21,12 +21,15 @@ module Support
 
       def user_data(user, provider)
         {
+          user_id: user.id,
           provider_code: provider.provider_code,
           provider_name: provider.provider_name,
           provider_type: provider.provider_type,
           first_name: user.first_name,
           last_name: user.last_name,
           email_address: user.email,
+          first_login_at: user.first_login_date_utc,
+          last_login_at: user.last_login_date_utc,
         }
       end
     end

--- a/spec/services/support/data_exports/users_export_spec.rb
+++ b/spec/services/support/data_exports/users_export_spec.rb
@@ -8,19 +8,22 @@ RSpec.describe Support::DataExports::UsersExport do
   end
 
   describe ".user_data" do
-    let(:user) { build(:user) }
+    let(:user) { build(:user, first_login_date_utc: 2.days.ago, last_login_date_utc: 1.day.ago) }
     let(:provider) { build(:provider) }
 
     it "returns hash of user data" do
       res = subject.send(:user_data, user, provider)
       expect(res).to eql(
         {
+          user_id: user.id,
           provider_code: provider.provider_code,
           provider_name: provider.provider_name,
           provider_type: provider.provider_type,
           first_name: user.first_name,
           last_name: user.last_name,
           email_address: user.email,
+          first_login_at: user.first_login_date_utc,
+          last_login_at: user.last_login_date_utc,
         },
       )
     end
@@ -41,20 +44,26 @@ RSpec.describe Support::DataExports::UsersExport do
       res = subject.data
       expect(res).to eql([
         {
+          user_id: user1.id,
           provider_code: user1.providers.first.provider_code,
           provider_name: user1.providers.first.provider_name,
           provider_type: user1.providers.first.provider_type,
           first_name: user1.first_name,
           last_name: user1.last_name,
           email_address: user1.email,
+          first_login_at: user1.first_login_date_utc,
+          last_login_at: user1.last_login_date_utc,
         },
         {
+          user_id: user2.id,
           provider_code: user2.providers.first.provider_code,
           provider_name: user2.providers.first.provider_name,
           provider_type: user2.providers.first.provider_type,
           first_name: user2.first_name,
           last_name: user2.last_name,
           email_address: user2.email,
+          first_login_at: user2.first_login_date_utc,
+          last_login_at: user2.last_login_date_utc,
         },
       ])
     end


### PR DESCRIPTION
### Context

We have a CSV export of users in the support console that we use for mailing lists etc. We also have SQL pad but only on the anonymised data. 

### Changes proposed in this pull request

Add user ID, first and last login dates.

If we add user ID BAs can link this list with the anonymised data in staging for analysis without having to do said analysis on production.

First and last login dates are useful for UR to determine active users.

### Guidance to review

Run the API, open the support bit and click download users CSV in the user tab.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
