### PR TITLE
Review SQL in TTAPI course search endpoint

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -11,7 +11,7 @@ module API
         render jsonapi: paginate(course_search),
                fields: fields_param,
                include: params[:include],
-               meta: { count: course_search.count("course.id") },
+               meta: { count: course_search.count("DISTINCT course.id") },
                class: CourseSerializersServiceV3.new.execute
       end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -168,7 +168,7 @@ class Course < ApplicationRecord
   end
 
   scope :accredited_body_order, ->(provider_name) do
-    joins(:provider).merge(Provider.by_provider_name(provider_name))
+    joins(:provider).order('by_provider_name')
   end
 
   scope :changed_since, ->(timestamp) do

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -144,11 +144,11 @@ class Course < ApplicationRecord
           class_name: "CourseEnrichment"
 
   scope :within, ->(range, origin:) do
-    joins(:sites).merge(Site.within(range, origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.within(range, origin: origin))
   end
 
   scope :by_distance, ->(origin:) do
-    joins(:sites).merge(Site.by_distance(origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.by_distance(origin: origin))
   end
 
   scope :by_name_ascending, -> do

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -34,36 +34,36 @@ class CourseSearchService
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
     # This prevents 'PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list'
-    outer_scope = Course.includes(
+    scope = scope.includes(
       :enrichments,
       subjects: [:financial_incentive],
       site_statuses: [:site],
       provider: %i[recruitment_cycle ucas_preferences],
-    ).where(id: scope.select(:id))
+    )
 
     if provider_name.present?
-      outer_scope = outer_scope
+      scope = scope
                       .accredited_body_order(provider_name)
                       .ascending_canonical_order
     elsif sort_by_provider_ascending?
-      outer_scope = outer_scope.ascending_canonical_order
-      outer_scope = outer_scope.select("provider.provider_name", "course.*")
+      scope = scope.ascending_canonical_order
+      scope = scope.select("provider.provider_name", "course.*")
     elsif sort_by_provider_descending?
-      outer_scope = outer_scope.descending_canonical_order
-      outer_scope = outer_scope.select("provider.provider_name", "course.*")
+      scope = scope.descending_canonical_order
+      scope = scope.select("provider.provider_name", "course.*")
     elsif sort_by_distance?
-      outer_scope = outer_scope.joins(courses_with_distance_from_origin)
-      outer_scope = outer_scope.joins(:provider)
-      outer_scope = outer_scope.select("course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
+      scope = scope.joins(courses_with_distance_from_origin)
+      scope = scope.joins(:provider)
+      scope = scope.select("DISTINCT(course.id), course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
 
-      outer_scope = if expand_university?
-                      outer_scope.order(:boosted_distance)
+      scope = if expand_university?
+                      scope.order(:boosted_distance)
                     else
-                      outer_scope.order(:distance)
+                      scope.order(:distance)
                     end
     end
 
-    outer_scope
+    scope
   end
 
   private_class_method :new

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -43,8 +43,8 @@ class CourseSearchService
 
     if provider_name.present?
       scope = scope
-                      .accredited_body_order(provider_name)
-                      .ascending_canonical_order
+        .accredited_body_order(provider_name)
+        .ascending_canonical_order
     elsif sort_by_provider_ascending?
       scope = scope.ascending_canonical_order
       scope = scope.select("provider.provider_name", "course.*")

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -56,11 +56,12 @@ class CourseSearchService
       scope = scope.joins(:provider)
       scope = scope.select("DISTINCT(course.id), course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
 
-      scope = if expand_university?
-                      scope.order(:boosted_distance)
-                    else
-                      scope.order(:distance)
-                    end
+      scope =
+        if expand_university?
+          scope.order(:boosted_distance)
+        else
+          scope.order(:distance)
+        end
     end
 
     scope


### PR DESCRIPTION
### Context

The endpoint that Find uses for course searches is high traffic and can be slow for certain queries. Therefore we have attempted to analyse the database queries to get a handle on what they are doing, how slow or fast they are and come up with any optimisations that are possible.

https://trello.com/c/7ps7weg2/3953-review-sql-in-ttapi-course-search-endpoint



### Analysis

Find has many options for course searches. First the candidate selects one of three basic options:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/450843/134478474-6224ddd9-4f3f-4ef9-94de-2336e5890ce5.png">

If location is selected the candidate provides a location and the search results are ordered by distance from the at location. If a provider name is given then the search is filtered by provider, otherwise if the _Across England_ option is selected no location based filter is applied.

Next the candidate picks one or more course subjects:

<img width="715" alt="image" src="https://user-images.githubusercontent.com/450843/134478946-c26a48e1-07bb-4177-aa1a-e419230da151.png">
 
Then from the results page additional filters can be applied:

<img width="231" alt="image" src="https://user-images.githubusercontent.com/450843/134479064-0a3472b4-68bf-485c-9cf7-97164077292c.png">

#### Example 1

The first example is a fairly simple query _Across England_ with a few filters selected, Find path is `/results?subjects%5B%5D=31&hasvacancies=false&hasvacancies=true&fulltime=true&qualifications%5B%5D=QtsOnly&funding=8&l=2`

The log records a number of SQL statements:

```
{"name":"Rails","message":"API HIT =\u003e http://localhost:3001/api/v3/recruitment_cycles/2021/courses?filter%5Bfunding%5D=salary\u0026filter%5Bhas_vacancies%5D=true\u0026filter%5Bqualification%5D=qts\u0026filter%5Bstudy_type%5D=full_time\u0026filter%5Bsubjects%5D=00\u0026include=site_statuses.site%2Cprovider%2Csubjects\u0026page%5Bpage%5D=1\u0026page%5Bper_page%5D=10\u0026sort=provider.provider_name%2Cname"}
{"name":"Rack","message":"Started","payload":{"method":"GET","path":"/api/v3/recruitment_cycles/2021/courses?filter%5Bfunding%5D=salary\u0026filter%5Bhas_vacancies%5D=true\u0026filter%5Bqualification%5D=qts\u0026filter%5Bstudy_type%5D=full_time\u0026filter%5Bsubjects%5D=00\u0026include=site_statuses.site%2Cprovider%2Csubjects\u0026page%5Bpage%5D=1\u0026page%5Bper_page%5D=10\u0026sort=provider.provider_name%2Cname","ip":"::1"}}
{"name":"API::V3::CoursesController","message":"Processing #index"}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"year\" = $1 LIMIT $2","binds":{"year":"2021","limit":1},"allocations":8,"cached":null}}
SELECT COUNT(*) FROM \"course\" INNER JOIN \"provider\" ON \"provider\".\"id\" = \"course\".\"provider_id\" WHERE \"course\".\"id\" IN (SELECT \"course\".\"id\" FROM \"course\" INNER JOIN \"provider\" ON \"course\".\"provider_id\" = \"provider\".\"id\" INNER JOIN \"course_site\" ON \"course_site\".\"course_id\" = \"course\".\"id\" INNER JOIN \"course_subject\" ON \"course_subject\".\"course_id\" = \"course\".\"id\" INNER JOIN \"subject\" ON \"subject\".\"id\" = \"course_subject\".\"subject_id\" WHERE \"provider\".\"recruitment_cycle_id\" = $1 AND \"provider\".\"discarded_at\" IS NULL AND \"course\".\"discarded_at\" IS NULL AND \"course\".\"program_type\" IN ($2, $3) AND \"course\".\"qualification\" = $4 AND \"course_site\".\"vac_status\" != $5 AND \"course_site\".\"status\" = $6 AND \"course_site\".\"publish\" = $7 AND \"course\".\"study_mode\" IN ($8, $9) AND \"subject\".\"subject_code\" = $10)","binds":{"recruitment_cycle_id":3,"program_type":["SS","TA"],"qualification":0,"vac_status":"","status":"R","publish":"Y","study_mode":["F","B"],"subject_code":"00"},"allocations":405,"cached":null}}
SELECT COUNT(DISTINCT \"course\".\"id\") FROM \"course\" INNER JOIN \"provider\" ON \"provider\".\"id\" = \"course\".\"provider_id\" LEFT OUTER JOIN \"recruitment_cycle\" ON \"recruitment_cycle\".\"id\" = \"provider\".\"recruitment_cycle_id\" LEFT OUTER JOIN \"provider_ucas_preference\" ON \"provider_ucas_preference\".\"provider_id\" = \"provider\".\"id\" LEFT OUTER JOIN \"course_enrichment\" ON \"course_enrichment\".\"course_id\" = \"course\".\"id\" LEFT OUTER JOIN \"course_subject\" ON \"course_subject\".\"course_id\" = \"course\".\"id\" LEFT OUTER JOIN \"subject\" ON \"subject\".\"id\" = \"course_subject\".\"subject_id\" LEFT OUTER JOIN \"financial_incentive\" ON \"financial_incentive\".\"subject_id\" = \"subject\".\"id\" LEFT OUTER JOIN \"course_site\" ON \"course_site\".\"course_id\" = \"course\".\"id\" LEFT OUTER JOIN \"site\" ON \"site\".\"id\" = \"course_site\".\"site_id\" WHERE \"course\".\"id\" IN (SELECT \"course\".\"id\" FROM \"course\" INNER JOIN \"provider\" ON \"course\".\"provider_id\" = \"provider\".\"id\" INNER JOIN \"course_site\" ON \"course_site\".\"course_id\" = \"course\".\"id\" INNER JOIN \"course_subject\" ON \"course_subject\".\"course_id\" = \"course\".\"id\" INNER JOIN \"subject\" ON \"subject\".\"id\" = \"course_subject\".\"subject_id\" WHERE \"provider\".\"recruitment_cycle_id\" = $1 AND \"provider\".\"discarded_at\" IS NULL AND \"course\".\"discarded_at\" IS NULL AND \"course\".\"program_type\" IN ($2, $3) AND \"course\".\"qualification\" = $4 AND \"course_site\".\"vac_status\" != $5 AND \"course_site\".\"status\" = $6 AND \"course_site\".\"publish\" = $7 AND \"course\".\"study_mode\" IN ($8, $9) AND \"subject\".\"subject_code\" = $10)","binds":{"recruitment_cycle_id":3,"program_type":["SS","TA"],"qualification":0,"vac_status":"","status":"R","publish":"Y","study_mode":["F","B"],"subject_code":"00"},"allocations":679,"cached":null}}
SELECT \"provider\".\"provider_name\", course.* FROM \"course\" INNER JOIN \"provider\" ON \"provider\".\"id\" = \"course\".\"provider_id\" WHERE \"course\".\"id\" IN (SELECT \"course\".\"id\" FROM \"course\" INNER JOIN \"provider\" ON \"course\".\"provider_id\" = \"provider\".\"id\" INNER JOIN \"course_site\" ON \"course_site\".\"course_id\" = \"course\".\"id\" INNER JOIN \"course_subject\" ON \"course_subject\".\"course_id\" = \"course\".\"id\" INNER JOIN \"subject\" ON \"subject\".\"id\" = \"course_subject\".\"subject_id\" WHERE \"provider\".\"recruitment_cycle_id\" = $1 AND \"provider\".\"discarded_at\" IS NULL AND \"course\".\"discarded_at\" IS NULL AND \"course\".\"program_type\" IN ($2, $3) AND \"course\".\"qualification\" = $4 AND \"course_site\".\"vac_status\" != $5 AND \"course_site\".\"status\" = $6 AND \"course_site\".\"publish\" = $7 AND \"course\".\"study_mode\" IN ($8, $9) AND \"subject\".\"subject_code\" = $10) ORDER BY \"provider\".\"provider_name\" ASC, name asc, course_code asc LIMIT $11 OFFSET $12","binds":{"recruitment_cycle_id":3,"program_type":["SS","TA"],"qualification":0,"vac_status":"","status":"R","publish":"Y","study_mode":["F","B"],"subject_code":"00","limit":10,"offset":0},"allocations":678,"cached":null}}
SELECT \"course_enrichment\".* FROM \"course_enrichment\" WHERE \"course_enrichment\".\"course_id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)","binds":{"course_id":[12954225,12944992,12941095,12941113,12942478,12938281,12953561,12944047,12938982,12938743]},"allocations":766,"cached":null}}
SELECT \"course_subject\".* FROM \"course_subject\" WHERE \"course_subject\".\"course_id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ORDER BY \"course_subject\".\"position\" ASC","binds":{"course_id":[12954225,12944992,12941095,12941113,12942478,12938281,12953561,12944047,12938982,12938743]},"allocations":322,"cached":null}}
SELECT \"subject\".* FROM \"subject\" WHERE \"subject\".\"id\" = $1","binds":{"id":1},"allocations":686,"cached":null}}
SELECT \"financial_incentive\".* FROM \"financial_incentive\" WHERE \"financial_incentive\".\"subject_id\" = $1","binds":{"subject_id":1},"allocations":196,"cached":null}}
SELECT \"course_site\".* FROM \"course_site\" WHERE \"course_site\".\"course_id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)","binds":{"course_id":[12954225,12944992,12941095,12941113,12942478,12938281,12953561,12944047,12938982,12938743]},"allocations":367,"cached":null}}
SELECT \"site\".* FROM \"site\" WHERE \"site\".\"id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)","binds":{"id":[11219340,11219487,11219607,11219605,11219608,11219611,11219610,11219609,11219606,11219604,11219601,11220604,11221198,11221905,11221915,11221904,11221909,11221893,11221895,11221900,11221891,11222303,11225973,11226334]},"allocations":675,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9)","binds":{"id":[16984,16315,16028,16122,15810,16931,16240,15863,15843]},"allocations":700,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1","binds":{"id":3},"allocations":309,"cached":null}}
SELECT \"provider_ucas_preference\".* FROM \"provider_ucas_preference\" WHERE \"provider_ucas_preference\".\"provider_id\" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9)","binds":{"provider_id":[16240,15810,16315,15843,15863,16028,16984,16122,16931]},"allocations":377,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16984},"allocations":479,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16315},"allocations":530,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16028},"allocations":195,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16028},"allocations":1,"cached":true}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16122},"allocations":349,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":15810},"allocations":348,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16931},"allocations":690,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":16240},"allocations":350,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":15863},"allocations":502,"cached":null}}
SELECT COUNT(*) FROM \"course\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL","binds":{"provider_id":15843},"allocations":195,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"T89","recruitment_cycle_id":3,"limit":1},"allocations":349,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"1WR","recruitment_cycle_id":3,"limit":1},"allocations":408,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"2B5","recruitment_cycle_id":3,"limit":1},"allocations":440,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"2B5","recruitment_cycle_id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"1WR","recruitment_cycle_id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"M80","recruitment_cycle_id":3,"limit":1},"allocations":440,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"P63","recruitment_cycle_id":3,"limit":1},"allocations":439,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"C10","recruitment_cycle_id":3,"limit":1},"allocations":439,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"P85","recruitment_cycle_id":3,"limit":1},"allocations":626,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"provider_code\" = $1 AND \"provider\".\"recruitment_cycle_id\" = $2 LIMIT $3","binds":{"provider_code":"24S","recruitment_cycle_id":3,"limit":1},"allocations":254,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16984,"recruitment_cycle_id":3},"allocations":1490,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16315,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16028,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16122,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":15810,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16931,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":16240,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":15863,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT DISTINCT \"provider\".* FROM \"provider\" INNER JOIN \"course\" ON \"provider\".\"provider_code\" = \"course\".\"accredited_body_code\" WHERE \"course\".\"provider_id\" = $1 AND \"course\".\"discarded_at\" IS NULL AND \"provider\".\"recruitment_cycle_id\" = $2","binds":{"provider_id":15843,"recruitment_cycle_id":3},"allocations":401,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16984,"limit":1},"allocations":8,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":225,"cached":null}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16315,"limit":1},"allocations":401,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16028,"limit":1},"allocations":401,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16122,"limit":1},"allocations":400,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15810,"limit":1},"allocations":401,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16931,"limit":1},"allocations":400,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":401,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":16240,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":401,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15863,"limit":1},"allocations":1,"cached":true}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
SELECT \"provider\".* FROM \"provider\" WHERE \"provider\".\"id\" = $1 LIMIT $2","binds":{"id":15843,"limit":1},"allocations":402,"cached":null}}
SELECT \"recruitment_cycle\".* FROM \"recruitment_cycle\" WHERE \"recruitment_cycle\".\"id\" = $1 LIMIT $2","binds":{"id":3,"limit":1},"allocations":1,"cached":true}}
{"name":"Rails","message":"Completed JSON API rendering (302.45ms)"}
{"duration_ms":640.4970000148751,"duration":"640.5ms","name":"API::V3::CoursesController","message":"Completed #index","payload":{"controller":"API::V3::CoursesController","action":"index","params":{"filter":{"funding":"salary","has_vacancies":"true","qualification":"qts","study_type":"full_time","subjects":"00"},"include":"site_statuses.site,provider,subjects","page":{"page":"1","per_page":"10"},"sort":"provider.provider_name,name","recruitment_cycle_year":"2021"},"format":"JSONAPI","method":"GET","path":"/api/v3/recruitment_cycles/2021/courses","status":200,"view_runtime":171.79,"db_runtime":457.26,"allocations":93769,"status_message":"OK"}}
```

There is a lot happening here, including some potential 1+n queries, however the bulk of the time is spent in a couple of queries like this (the other one does a `count`):

```
SELECT provider.provider_name, course.*
FROM course
INNER JOIN provider ON provider.id = course.provider_id
WHERE course.id IN (
  SELECT course.id
  FROM course
  INNER JOIN provider ON course.provider_id = provider.id
  INNER JOIN course_site ON course_site.course_id = course.id
  INNER JOIN course_subject ON course_subject.course_id = course.id
  INNER JOIN subject ON subject.id = course_subject.subject_id
  WHERE provider.recruitment_cycle_id = 3
    AND provider.discarded_at IS NULL
    AND course.discarded_at IS NULL
    AND course.program_type IN ('SS', 'TA')
    AND course.qualification = 0
    AND course_site.vac_status != ''
    AND course_site.status = 'R'
    AND course_site.publish = 'Y'
    AND course.study_mode IN ('F', 'B')
    AND subject.subject_code = '00'
  ) ORDER BY provider.provider_name ASC, name asc, course_code asc LIMIT 10 OFFSET 0;
```

This is basically a query on the `course` table with joins to `provider`, `course_site`, `course_subject` and `subject`. It's made a little more complicated by the filters being applied in a nested query, with the outer query just providing the `SELECT` clause and handling pagination and sorting.

`EXPLAIN (ANALYSE, BUFFERS)` gives the following breakdown:

```
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                QUERY PLAN                                                                 │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=1988.96..1988.98 rows=8 width=1173) (actual time=69.144..69.152 rows=10 loops=1)                                             │
│   Buffers: shared hit=47763                                                                                                               │
│   ->  Sort  (cost=1988.96..1988.98 rows=8 width=1173) (actual time=69.143..69.149 rows=10 loops=1)                                        │
│         Sort Key: provider.provider_name, course.name, course.course_code                                                                 │
│         Sort Method: top-N heapsort  Memory: 28kB                                                                                         │
│         Buffers: shared hit=47763                                                                                                         │
│         ->  Nested Loop  (cost=1955.81..1988.84 rows=8 width=1173) (actual time=66.931..67.393 rows=69 loops=1)                           │
│               Buffers: shared hit=47763                                                                                                   │
│               ->  Nested Loop  (cost=1955.53..1985.31 rows=8 width=1144) (actual time=66.894..67.186 rows=69 loops=1)                     │
│                     Buffers: shared hit=47556                                                                                             │
│                     ->  HashAggregate  (cost=1955.11..1955.19 rows=8 width=12) (actual time=66.198..66.225 rows=69 loops=1)               │
│                           Group Key: course_1.id                                                                                          │
│                           Batches: 1  Memory Usage: 32kB                                                                                  │
│                           Buffers: shared hit=47280                                                                                       │
│                           ->  Nested Loop  (cost=27.53..1955.09 rows=8 width=12) (actual time=26.407..65.451 rows=125 loops=1)            │
│                                 Buffers: shared hit=47280                                                                                 │
│                                 ->  Nested Loop  (cost=27.25..1874.99 rows=30 width=16) (actual time=1.961..44.828 rows=176 loops=1)      │
│                                       Join Filter: (course_site.course_id = course_1.id)                                                  │
│                                       Buffers: shared hit=46752                                                                           │
│                                       ->  Nested Loop  (cost=26.83..1422.11 rows=640 width=8) (actual time=1.311..33.837 rows=3383 loops=…│
│…1)                                                                                                                                        │
│                                             Buffers: shared hit=33220                                                                     │
│                                             ->  Nested Loop  (cost=26.54..632.45 rows=1838 width=4) (actual time=1.253..7.321 rows=10655 …│
│…loops=1)                                                                                                                                  │
│                                                   Buffers: shared hit=566                                                                 │
│                                                   ->  Seq Scan on subject  (cost=0.00..1.56 rows=1 width=8) (actual time=0.017..0.024 row…│
│…s=1 loops=1)                                                                                                                              │
│                                                         Filter: (subject_code = '00'::text)                                               │
│                                                         Rows Removed by Filter: 44                                                        │
│                                                         Buffers: shared hit=1                                                             │
│                                                   ->  Bitmap Heap Scan on course_subject  (cost=26.54..612.51 rows=1838 width=8) (actual …│
│…time=1.230..5.420 rows=10655 loops=1)                                                                                                     │
│                                                         Recheck Cond: (subject_id = subject.id)                                           │
│                                                         Heap Blocks: exact=555                                                            │
│                                                         Buffers: shared hit=565                                                           │
│                                                         ->  Bitmap Index Scan on index_course_subject_on_subject_id  (cost=0.00..26.08 ro…│
│…ws=1838 width=0) (actual time=1.158..1.158 rows=10655 loops=1)                                                                            │
│                                                               Index Cond: (subject_id = subject.id)                                       │
│                                                               Buffers: shared hit=10                                                      │
│                                             ->  Index Scan using "IX_course_site_course_id" on course_site  (cost=0.29..0.42 rows=1 width…│
│…=4) (actual time=0.002..0.002 rows=0 loops=10655)                                                                                         │
│                                                   Index Cond: (course_id = course_subject.course_id)                                      │
│                                                   Filter: ((vac_status <> ''::text) AND (status = 'R'::text) AND (publish = 'Y'::text))   │
│                                                   Rows Removed by Filter: 1                                                               │
│                                                   Buffers: shared hit=32654                                                               │
│                                       ->  Index Scan using "PK_course" on course course_1  (cost=0.42..0.70 rows=1 width=8) (actual time=…│
│…0.003..0.003 rows=0 loops=3383)                                                                                                           │
│                                             Index Cond: (id = course_subject.course_id)                                                   │
│                                             Filter: ((discarded_at IS NULL) AND (program_type = ANY ('{SS,TA}'::text[])) AND (study_mode …│
│…= ANY ('{F,B}'::text[])) AND (qualification = 0))                                                                                         │
│                                             Rows Removed by Filter: 1                                                                     │
│                                             Buffers: shared hit=13532                                                                     │
│                                 ->  Index Scan using "PK_ucas_provider" on provider provider_1  (cost=0.28..2.67 rows=1 width=4) (actual …│
│…time=0.116..0.116 rows=1 loops=176)                                                                                                       │
│                                       Index Cond: (id = course_1.provider_id)                                                             │
│                                       Filter: ((discarded_at IS NULL) AND (recruitment_cycle_id = 3))                                     │
│                                       Rows Removed by Filter: 0                                                                           │
│                                       Buffers: shared hit=528                                                                             │
│                     ->  Index Scan using "PK_course" on course  (cost=0.42..3.77 rows=1 width=1144) (actual time=0.013..0.013 rows=1 loop…│
│…s=69)                                                                                                                                     │
│                           Index Cond: (id = course_site.course_id)                                                                        │
│                           Buffers: shared hit=276                                                                                         │
│               ->  Index Scan using "PK_ucas_provider" on provider  (cost=0.28..0.44 rows=1 width=33) (actual time=0.002..0.002 rows=1 loo…│
│…ps=69)                                                                                                                                    │
│                     Index Cond: (id = course.provider_id)                                                                                 │
│                     Buffers: shared hit=207                                                                                               │
│ Planning:                                                                                                                                 │
│   Buffers: shared hit=132                                                                                                                 │
│ Planning Time: 17.067 ms                                                                                                                  │
│ Execution Time: 69.672 ms                                                                                                                 │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(59 rows)

Time: 123.671 ms
```

My reading of this is that the most expensive parts of the query are joins, specifically the two inner most nested loops and associated filters. 

#### Example 2

The second example is a search by location `/results?c=England&fulltime=true&hasvacancies=true&l=1&lat=51.588868&lng=-1.426453&loc=Wantage+OX12%2C+UK&lq=Wantage&parttime=false&qualifications%5B%5D=PgdePgceWithQts&qualifications%5B%5D=Other&rad=50&sortby=2&subjects%5B%5D=31`

This one generates a more complicated main query:
```
SELECT course.*,
  distance,
  (CASE WHEN provider.provider_type = 'O' THEN (distance - 10) ELSE distance END) as boosted_distance
FROM course
  INNER JOIN (
    SELECT course_id, MIN(ACOS(least(1,COS(0.900395603976742)*COS(-0.02489630147495067)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+COS(0.900395603976742)*SIN(-0.02489630147495067)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+SIN(0.900395603976742)*SIN(RADIANS(site.latitude))))*3963.1899999999996) as distance
    FROM course_site
      INNER JOIN site ON course_site.site_id = site.id
    WHERE (course_site.status = 'R'
      AND course_site.publish = 'Y'
      AND course_site.vac_status = 'F'
      OR course_site.status = 'R'
      AND course_site.publish = 'Y'
      AND course_site.vac_status = 'P'
      OR course_site.status = 'R'
      AND course_site.publish = 'Y'
      AND course_site.vac_status = 'B'
    ) AND site.latitude IS NOT NULL
      AND site.longitude IS NOT NULL
      AND (site.address1 != '' OR site.postcode != '')
    GROUP BY course_id) distances ON course.id = distances.course_id
  INNER JOIN provider ON provider.id = course.provider_id
  WHERE course.id IN F
    SELECT course.id FROM course
    INNER JOIN provider ON course.provider_id = provider.id
    INNER JOIN course_site ON course_site.course_id = course.id
    INNER JOIN course_subject ON course_subject.course_id = course.id
    INNER JOIN subject ON subject.id = course_subject.subject_id
    INNER JOIN course_site site_statuses_course_join ON site_statuses_course_join.course_id = course.id
    INNER JOIN site ON site.id = site_statuses_course_join.site_id AND course_site.status IN ('N', 'R')
    WHERE provider.recruitment_cycle_id = 3
      AND provider.discarded_at IS NULL
      AND course.discarded_at IS NULL
      AND course.qualification IN (1, 2, 3, 4)
      AND course_site.vac_status != ''
      AND course_site.status = 'R'
      AND course_site.publish = 'Y'
      AND course.study_mode IN ('F', 'B')
      AND subject.subject_code = '00'
      AND (site.latitude IS NOT NULL AND site.longitude IS NOT NULL)
      AND (ACOS(least(1,COS(0.900395603976742)*COS(-0.02489630147495067)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+COS(0.900395603976742)*SIN(-0.02489630147495067)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+SIN(0.900395603976742)*SIN(RADIANS(site.latitude))))*3963.1899999999996) <= '50')
    ORDER BY distance ASC LIMIT 10 OFFSET 0;
```
 with query plan:
```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                                      │
├──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ Limit  (cost=17631.21..17631.24 rows=10 width=1160) (actual time=208.759..208.771 rows=10 loops=1)                                                                                                                                                                                                                                                                                                                                                                                   │
│   Buffers: shared hit=126165 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                                               │
│   ->  Sort  (cost=17631.21..17631.25 rows=14 width=1160) (actual time=208.758..208.769 rows=10 loops=1)                                                                                                                                                                                                                                                                                                                                                                              │
│         Sort Key: distances.distance                                                                                                                                                                                                                                                                                                                                                                                                                                                 │
│         Sort Method: top-N heapsort  Memory: 28kB                                                                                                                                                                                                                                                                                                                                                                                                                                    │
│         Buffers: shared hit=126165 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                                         │
│         ->  Hash Semi Join  (cost=11804.45..17630.94 rows=14 width=1160) (actual time=146.574..208.611 rows=148 loops=1)                                                                                                                                                                                                                                                                                                                                                             │
│               Hash Cond: (course.id = course_site.course_id)                                                                                                                                                                                                                                                                                                                                                                                                                         │
│               Buffers: shared hit=126165 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                                   │
│               ->  Hash Join  (cost=9670.39..15446.28 rows=19191 width=1157) (actual time=63.974..125.011 rows=11327 loops=1)                                                                                                                                                                                                                                                                                                                                                         │
│                     Hash Cond: (course.provider_id = provider.id)                                                                                                                                                                                                                                                                                                                                                                                                                    │
│                     Buffers: shared hit=6953 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                               │
│                     ->  Hash Join  (cost=6912.32..12637.81 rows=19191 width=1156) (actual time=58.980..115.908 rows=11327 loops=1)                                                                                                                                                                                                                                                                                                                                                   │
│                           Hash Cond: (course.id = distances.course_id)                                                                                                                                                                                                                                                                                                                                                                                                               │
│                           Buffers: shared hit=4370 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                         │
│                           ->  Seq Scan on course  (cost=0.00..5528.69 rows=74969 width=1144) (actual time=0.011..42.860 rows=74969 loops=1)                                                                                                                                                                                                                                                                                                                                          │
│                                 Buffers: shared hit=2961 read=1818                                                                                                                                                                                                                                                                                                                                                                                                                   │
│                           ->  Hash  (cost=6672.43..6672.43 rows=19191 width=12) (actual time=58.547..58.550 rows=11327 loops=1)                                                                                                                                                                                                                                                                                                                                                      │
│                                 Buckets: 32768  Batches: 1  Memory Usage: 743kB                                                                                                                                                                                                                                                                                                                                                                                                      │
│                                             Group Key: course_site_1.course_id                                                                                                                                                                                                                                                                                                                                                                                                       │
│                                             Batches: 1  Memory Usage: 1809kB                                                                                                                                                                                                                                                                                                                                                                                                         │
│                                             Buffers: shared hit=1409                                                                                                                                                                                                                                                                                                                                                                                                                 │
│                                             ->  Hash Join  (cost=2505.35..4998.53 rows=23456 width=20) (actual time=19.971..39.421 rows=22869 loops=1)                                                                                                                                                                                                                                                                                                                               │
│                                                   Hash Cond: (course_site_1.site_id = site_1.id)                                                                                                                                                                                                                                                                                                                                                                                     │
│                                                   Buffers: shared hit=1409                                                                                                                                                                                                                                                                                                                                                                                                           │
│                                                   ->  Bitmap Heap Scan on course_site course_site_1  (cost=791.27..3222.52 rows=23590 width=8) (actual time=1.740..15.316 rows=23104 loops=1)                                                                                                                                                                                                                                                                                        │
│                                                         Recheck Cond: (status = 'R'::text)                                                                                                                                                                                                                                                                                                                                                                                           │
│                                                         Filter: ((publish = 'Y'::text) AND ((vac_status = 'F'::text) OR (vac_status = 'P'::text) OR (vac_status = 'B'::text)))                                                                                                                                                                                                                                                                                                       │
│                                                         Rows Removed by Filter: 48085                                                                                                                                                                                                                                                                                                                                                                                                │
│                                                         Heap Blocks: exact=626                                                                                                                                                                                                                                                                                                                                                                                                       │
│                                                         Buffers: shared hit=688                                                                                                                                                                                                                                                                                                                                                                                                      │
│                                                         ->  Bitmap Index Scan on index_course_site_on_status  (cost=0.00..785.38 rows=71611 width=0) (actual time=1.677..1.677 rows=71189 loops=1)                                                                                                                                                                                                                                                                                   │
│                                                               Index Cond: (status = 'R'::text)                                                                                                                                                                                                                                                                                                                                                                                       │
│                                                               Buffers: shared hit=62                                                                                                                                                                                                                                                                                                                                                                                                 │
│                                                   ->  Hash  (cost=1264.07..1264.07 rows=36000 width=20) (actual time=17.969..17.970 rows=35914 loops=1)                                                                                                                                                                                                                                                                                                                              │
│                                                         Buckets: 65536  Batches: 1  Memory Usage: 2336kB                                                                                                                                                                                                                                                                                                                                                                             │
│                                                         Buffers: shared hit=721                                                                                                                                                                                                                                                                                                                                                                                                      │
│                                                         ->  Seq Scan on site site_1  (cost=0.00..1264.07 rows=36000 width=20) (actual time=0.011..8.971 rows=35914 loops=1)                                                                                                                                                                                                                                                                                                          │
│                                                               Filter: ((latitude IS NOT NULL) AND (longitude IS NOT NULL) AND ((address1 <> ''::text) OR (postcode <> ''::text)))                                                                                                                                                                                                                                                                                                    │
│                                                               Rows Removed by Filter: 291                                                                                                                                                                                                                                                                                                                                                                                            │
│                                                               Buffers: shared hit=721                                                                                                                                                                                                                                                                                                                                                                                                │
│                     ->  Hash  (cost=2660.81..2660.81 rows=7781 width=5) (actual time=4.939..4.939 rows=7781 loops=1)                                                                                                                                                                                                                                                                                                                                                                 │
│                           Buckets: 8192  Batches: 1  Memory Usage: 368kB                                                                                                                                                                                                                                                                                                                                                                                                             │
│                           Buffers: shared hit=2583                                                                                                                                                                                                                                                                                                                                                                                                                                   │
│                           ->  Seq Scan on provider  (cost=0.00..2660.81 rows=7781 width=5) (actual time=0.010..3.260 rows=7781 loops=1)                                                                                                                                                                                                                                                                                                                                              │
│                                 Buffers: shared hit=2583                                                                                                                                                                                                                                                                                                                                                                                                                             │
│               ->  Hash  (cost=2133.40..2133.40 rows=53 width=16) (actual time=82.086..82.091 rows=1356 loops=1)                                                                                                                                                                                                                                                                                                                                                                      │
│                     Buckets: 2048 (originally 1024)  Batches: 1 (originally 1)  Memory Usage: 80kB                                                                                                                                                                                                                                                                                                                                                                                   │
│                     Buffers: shared hit=119212                                                                                                                                                                                                                                                                                                                                                                                                                                       │
│                     ->  Nested Loop  (cost=28.11..2133.40 rows=53 width=16) (actual time=14.790..81.569 rows=1356 loops=1)                                                                                                                                                                                                                                                                                                                                                           │
│                           Buffers: shared hit=119212                                                                                                                                                                                                                                                                                                                                                                                                                                 │
│                           ->  Nested Loop  (cost=27.82..2071.32 rows=161 width=20) (actual time=14.589..49.099 rows=18388 loops=1)                                                                                                                                                                                                                                                                                                                                                   │
│                                 Join Filter: (course_site.course_id = site_statuses_course_join.course_id)                                                                                                                                                                                                                                                                                                                                                                           │
│                                 Buffers: shared hit=64048                                                                                                                                                                                                                                                                                                                                                                                                                            │
│                                 ->  Nested Loop  (cost=27.53..2030.47 rows=94 width=12) (actual time=14.583..38.029 rows=2296 loops=1)                                                                                                                                                                                                                                                                                                                                               │
│                                       Buffers: shared hit=54393                                                                                                                                                                                                                                                                                                                                                                                                                      │
│                                       ->  Nested Loop  (cost=27.25..1841.37 rows=375 width=16) (actual time=0.353..33.323 rows=2547 loops=1)                                                                                                                                                                                                                                                                                                                                         │
│                                             Join Filter: (course_site.course_id = course_1.id)                                                                                                                                                                                                                                                                                                                                                                                       │
│                                             Buffers: shared hit=46752                                                                                                                                                                                                                                                                                                                                                                                                                │
│                                             ->  Nested Loop  (cost=26.83..1435.90 rows=573 width=8) (actual time=0.346..25.608 rows=3383 loops=1)                                                                                                                                                                                                                                                                                                                                    │
│                                                   Buffers: shared hit=33220                                                                                                                                                                                                                                                                                                                                                                                                          │
│                                                   ->  Nested Loop  (cost=26.54..632.45 rows=1838 width=4) (actual time=0.333..4.212 rows=10655 loops=1)                                                                                                                                                                                                                                                                                                                              │
│                                                         Buffers: shared hit=566                                                                                                                                                                                                                                                                                                                                                                                                      │
│                                                         ->  Seq Scan on subject  (cost=0.00..1.56 rows=1 width=8) (actual time=0.009..0.014 rows=1 loops=1)                                                                                                                                                                                                                                                                                                                          │
│                                                               Filter: (subject_code = '00'::text)                                                                                                                                                                                                                                                                                                                                                                                    │
│                                                               Rows Removed by Filter: 44                                                                                                                                                                                                                                                                                                                                                                                             │
│                                                               Buffers: shared hit=1                                                                                                                                                                                                                                                                                                                                                                                                  │
│                                                         ->  Bitmap Heap Scan on course_subject  (cost=26.54..612.51 rows=1838 width=8) (actual time=0.321..2.544 rows=10655 loops=1)                                                                                                                                                                                                                                                                                                 │
│                                                               Recheck Cond: (subject_id = subject.id)                                                                                                                                                                                                                                                                                                                                                                                │
│                                                               Heap Blocks: exact=555                                                                                                                                                                                                                                                                                                                                                                                                 │
│                                                               Buffers: shared hit=565                                                                                                                                                                                                                                                                                                                                                                                                │
│                                                               ->  Bitmap Index Scan on index_course_subject_on_subject_id  (cost=0.00..26.08 rows=1838 width=0) (actual time=0.270..0.271 rows=10655 loops=1)                                                                                                                                                                                                                                                                        │
│                                                                     Index Cond: (subject_id = subject.id)                                                                                                                                                                                                                                                                                                                                                                            │
│                                                                     Buffers: shared hit=10                                                                                                                                                                                                                                                                                                                                                                                           │
│                                                   ->  Index Scan using "IX_course_site_course_id" on course_site  (cost=0.29..0.43 rows=1 width=4) (actual time=0.002..0.002 rows=0 loops=10655)                                                                                                                                                                                                                                                                                     │
│                                                         Index Cond: (course_id = course_subject.course_id)                                                                                                                                                                                                                                                                                                                                                                           │
│                                                         Filter: ((status = ANY ('{N,R}'::text[])) AND (vac_status <> ''::text) AND (status = 'R'::text) AND (publish = 'Y'::text))                                                                                                                                                                                                                                                                                                   │
│                                                         Rows Removed by Filter: 1                                                                                                                                                                                                                                                                                                                                                                                                    │
│                                                         Buffers: shared hit=32654                                                                                                                                                                                                                                                                                                                                                                                                    │
│                                             ->  Index Scan using "PK_course" on course course_1  (cost=0.42..0.70 rows=1 width=8) (actual time=0.002..0.002 rows=1 loops=3383)                                                                                                                                                                                                                                                                                                       │
│                                                   Index Cond: (id = course_subject.course_id)                                                                                                                                                                                                                                                                                                                                                                                        │
│                                                   Filter: ((discarded_at IS NULL) AND (study_mode = ANY ('{F,B}'::text[])) AND (qualification = ANY ('{1,2,3,4}'::integer[])))                                                                                                                                                                                                                                                                                                       │
│                                                   Rows Removed by Filter: 0                                                                                                                                                                                                                                                                                                                                                                                                          │
│                                                   Buffers: shared hit=13532                                                                                                                                                                                                                                                                                                                                                                                                          │
│                                       ->  Index Scan using "PK_ucas_provider" on provider provider_1  (cost=0.28..0.50 rows=1 width=4) (actual time=0.001..0.001 rows=1 loops=2547)                                                                                                                                                                                                                                                                                                  │
│                                             Index Cond: (id = course_1.provider_id)                                                                                                                                                                                                                                                                                                                                                                                                  │
│                                             Filter: ((discarded_at IS NULL) AND (recruitment_cycle_id = 3))                                                                                                                                                                                                                                                                                                                                                                          │
│                                             Rows Removed by Filter: 0                                                                                                                                                                                                                                                                                                                                                                                                                │
│                                             Buffers: shared hit=7641                                                                                                                                                                                                                                                                                                                                                                                                                 │
│                                 ->  Index Scan using "IX_course_site_course_id" on course_site site_statuses_course_join  (cost=0.29..0.40 rows=3 width=8) (actual time=0.001..0.003 rows=8 loops=2296)                                                                                                                                                                                                                                                                              │
│                                       Index Cond: (course_id = course_subject.course_id)                                                                                                                                                                                                                                                                                                                                                                                             │
│                                       Buffers: shared hit=9655                                                                                                                                                                                                                                                                                                                                                                                                                       │
│                           ->  Index Scan using "PK_ucas_campus" on site  (cost=0.29..0.39 rows=1 width=4) (actual time=0.002..0.002 rows=0 loops=18388)                                                                                                                                                                                                                                                                                                                              │
│                                 Index Cond: (id = site_statuses_course_join.site_id)                                                                                                                                                                                                                                                                                                                                                                                                 │
│                                 Filter: ((latitude IS NOT NULL) AND (longitude IS NOT NULL) AND ((acos(LEAST('1'::double precision, (((('0.6211074934385727'::double precision * cos(radians(latitude))) * cos(radians(longitude))) + (('-0.015466475043944938'::double precision * cos(radians(latitude))) * sin(radians(longitude)))) + ('0.7835727597001878'::double precision * sin(radians(latitude)))))) * '3963.1899999999996'::double precision) <= '50'::double precision)) │
│                                 Rows Removed by Filter: 1                                                                                                                                                                                                                                                                                                                                                                                                                            │
│                                 Buffers: shared hit=55164                                                                                                                                                                                                                                                                                                                                                                                                                            │
│ Planning:                                                                                                                                                                                                                                                                                                                                                                                                                                                                            │
│   Buffers: shared hit=232                                                                                                                                                                                                                                                                                                                                                                                                                                                            │
│ Planning Time: 29.407 ms                                                                                                                                                                                                                                                                                                                                                                                                                                                             │
│ Execution Time: 210.312 ms                                                                                                                                                                                                                                                                                                                                                                                                                                                           │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
(105 rows)

Time: 241.081 ms
```
It's worth noting here that we join from `course` to `course_site` twice which would appear to be necessary given that both are `INNER JOIN`s. 

### Changes proposed in this pull request

1. Attempt to avoid the double join to `site_status`. These are the most expensive parts of the query. I've changed the `within` and `by_distance` scopes to join to `site` via `site_status` so that they can use the existing join.
2. Attempt to remove the sub-query that was introduced to avoid duplicates when filtering by provider name.

### Potential changes in future

There are some other things that we should look at that could give short-term gains:

1. Investigate whether the autosuggest for locations can be tuned.
2. Look at 1+n queries. Looking at the SQL logs there do seem to be a couple of 1+n queries though they don't appear to be adding a significant performance overhead (perhaps because we are paginating just 10 results at a time).
3. It looks like there is significant delay when there are no matches for a given location/filter set. Needs investigation.

In the longer term there may be bigger improvements that we can make as part of a more general rearchitecting of TTAPI, Find and other services. For example:

1. Find could maintain its own Postgresql database, synched from TTAPI. This database could be highly customised to its specific needs so it might represent a highly denormalised version of the course data.
2. We could potentially use a different kind of data store for course data in Find like Elasticsearch or similar. Again the data would be structured specifically to service course searches.

### Guidance to review

Removing the extra join to the `course_site` table gives different results to the original query. It took me a while to work out why this happens. However I think the original query was returning some courses that it should not have (but I may be misunderstanding the requirement).

The relevant parts of the original query are (some details omitted):

```
SELECT
  course.*
FROM
  "course"
  INNER JOIN "course_site" ON "course_site"."course_id" = "course"."id"
  INNER JOIN "course_site" "site_statuses_course_join" ON "site_statuses_course_join"."course_id" = "course"."id"
  INNER JOIN "site" ON "site"."id" = "site_statuses_course_join"."site_id"
WHERE "course_site"."status" IN ('N', 'R')
  AND some-trigonometry-function-that-works-out-distance("site.lat", "site.lng") < 50;
```

Here you can see there are two joins to `course_site` the second of which also joins to `site` (so that the closest location can be retrieved - not shown). The first join has a condition on `course_site.status` that is meant to filter out inactive sites (I believe). The second join has a condition on `site` lat/lng (within 50 miles of the search location). It's possible a course to have one site that matches the first condition and another that matches the second. If we combine these two joins and their associated conditions then that course no longer matches because neither of its sites satisfies both conditions. So I think that combining the joins has accidentally fixed a bug in the search logic. Does this make sense?

In terms of performance I'm seeing measurable benefits performance when doing a location based search. Not when doing an _across England_ search. e.g. the location query above has a top speed (on my machine) of about 210ms. The optimised one is about 125ms. Because the same query is again run to count the total the gains are doubled.

My main concern is whether the results are correct. What is the best way to test this?

My changes broke pretty much all of the tests for `CourseSearchService` (they rely on stubs/mocks so are fairly tied to the implementation). I've tried to fix them 'as there are' rather than make any radical changes here.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
