### PR TITLE
Use jsonapi-rails fork and add caching to V3 courses endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem "kaminari"
 gem "pagy", "~> 3.13"
 
 # JSON:API Ruby Client
-gem "jsonapi-rails"
+gem "jsonapi-rails", github: "DFE-Digital/jsonapi-rails"
 gem "jsonapi-rb"
 
 # Access jsonb attributes like normal ActiveRecord model attributes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
   specs:
     custom_error_message (1.2.1)
 
+GIT
+  remote: https://github.com/DFE-Digital/jsonapi-rails.git
+  revision: 359d794d916caebc2ea2cf907477227279b4fac3
+  specs:
+    jsonapi-rails (0.4.1)
+      jsonapi-parser (~> 0.1.0)
+      jsonapi-rb (~> 0.5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -285,9 +293,6 @@ GEM
       addressable (>= 2.4)
     jsonapi-deserializable (0.2.0)
     jsonapi-parser (0.1.1)
-    jsonapi-rails (0.4.0)
-      jsonapi-parser (~> 0.1.0)
-      jsonapi-rb (~> 0.5.0)
     jsonapi-rb (0.5.0)
       jsonapi-deserializable (~> 0.2.0)
       jsonapi-serializable (~> 0.3.0)
@@ -667,7 +672,7 @@ DEPENDENCIES
   guard-rubocop
   highline
   httparty
-  jsonapi-rails
+  jsonapi-rails!
   jsonapi-rb
   jsonapi-rspec
   jsonb_accessor

--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -12,7 +12,8 @@ module API
                fields: fields_param,
                include: params[:include],
                meta: { count: course_search.count("course.id") },
-               class: CourseSerializersServiceV3.new.execute
+               class: CourseSerializersServiceV3.new.execute,
+               cache: Rails.cache
       end
 
       def show

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -3,6 +3,10 @@ module API
     class SerializableCourse < JSONAPI::Serializable::Resource
       include TimeFormat
 
+      def jsonapi_cache_key(options)
+        "V3/#{@object.cache_key_with_version} " + super(options)
+      end
+
       class << self
         def enrichment_attribute(name, enrichment_name = name)
           attribute name do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -152,4 +152,7 @@ RSpec.configure do |config|
   Kernel.srand config.seed
 =end
   config.include JSONAPI::RSpec
+
+  # Ensure we're clearing the cache before each spec
+  config.before { Rails.cache.clear }
 end


### PR DESCRIPTION
### Context

We forked jsonapi-rails because:

- its caching mechanism is broken
- the project appears to be abandoned, with the current maintainer unresponsive to open issues and PRs

Commit 359d794 of the fork provides a fix for the cache.

With the code change in place, we're able to add caching to V3 courses.

### Changes proposed in this pull request
- Use the DfE fork of jsonapi/rails
- Do sub-object caching of courses in the index action of the V3 courses controller, keeping serialised JSON
course payloads in the cache and using them when rendering responses at
this endpoint.

### Guidance to review
- Is the spec sufficient?


### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
