### PR TITLE
Separate redis instance for cache

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   config.active_record.logger = nil # Don't log SQL in production
 
   # Use a different cache store in production.
-  # config.cache_store = :mem_cache_store
+  config.cache_store = :redis_cache_store, { url: ENV.fetch("REDIS_CACHE_URL") }
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -33,12 +33,16 @@ locals {
   web_app_name                 = "teacher-training-api-${local.app_name_suffix}"
   worker_app_name              = "teacher-training-api-worker-${local.app_name_suffix}"
   postgres_service_name        = "teacher-training-api-postgres-${local.app_name_suffix}"
-  redis_service_name           = "teacher-training-api-redis-${local.app_name_suffix}"
+  redis_worker_service_name    = "teacher-training-api-worker-redis-${local.app_name_suffix}"
+  redis_cache_service_name     = "teacher-training-api-cache-redis-${local.app_name_suffix}"
   logging_service_name         = "teacher-training-api-logit-${local.app_name_suffix}"
   deployment_strategy          = "blue-green-v2"
   qa_postgres_service_instance = "eef01a89-0659-4eae-8220-8a142fa4502e"
 
   worker_app_start_command = "bundle exec sidekiq -c 5 -C config/sidekiq.yml"
+
+  app_environment_variables = merge(var.app_environment_variables,
+  { REDIS_CACHE_URL = cloudfoundry_service_key.redis_cache_key.credentials.uri })
 
   postgres_extensions = {
     enable_extensions = ["pg_buffercache", "pg_stat_statements", "btree_gin", "btree_gist"]


### PR DESCRIPTION
### Context

Use separate redis instance for caching

### Changes proposed in this pull request

Create a redis instance for caching
Set memory policy for redis instances
Set rails cache store to redis_cache_store

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
