### PR TITLE
[xxx] Send arrays to BigQuery as json

### DIFF
--- a/app/lib/big_query/entity_event.rb
+++ b/app/lib/big_query/entity_event.rb
@@ -41,13 +41,8 @@ module BigQuery
 
     def hash_to_kv_pairs(hash)
       hash.map do |(key, value)|
-        if value.in? [true, false]
-          value = value.to_s
-        end
-
-        if value.is_a?(Hash)
-          value = value.to_json
-        end
+        value = value.to_s if value.in? [true, false]
+        value = value.to_json if value.is_a?(Hash) || value.is_a?(Array)
 
         { "key" => key, "value" => Array.wrap(value) }
       end

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -166,7 +166,6 @@ shared:
     - subject_code
     - subject_name
   subject_area:
-    - id
     - typename
     - name
     - created_at

--- a/spec/lib/big_query/entity_event_spec.rb
+++ b/spec/lib/big_query/entity_event_spec.rb
@@ -64,7 +64,7 @@ module BigQuery
           [
             { "key" => "one", "value" => ["one"] },
             { "key" => "two", "value" => ["true"] },
-            { "key" => "three", "value" => [1, 2, 3] },
+            { "key" => "three", "value" => ["[1,2,3]"] },
             { "key" => "four", "value" => ["{\"first\":\"test-one\",\"second\":\"test-two\"}"] },
           ]
         end


### PR DESCRIPTION
### Context

`Provider.accrediting_provider_enrichments` is an array in a jsonb field. Sending this to BigQuery is currently failing.

### Changes proposed in this pull request

Update `BigQuery::EntityEvent` to handle array attributes and send as JSON.

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
