### PR TITLE
Only use SemanticLogger when running with the :production bundle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -94,9 +94,6 @@ gem "govuk_notify_rails"
 gem "sidekiq"
 gem "sidekiq-cron"
 
-# Semantic Logger makes logs pretty
-gem "rails_semantic_logger"
-
 # Thread-safe global state
 gem "request_store"
 
@@ -128,6 +125,11 @@ gem "google-cloud-bigquery"
 
 # Faster JSON serialization
 gem "oj"
+
+# Semantic Logger makes production logs consumable by Logit
+group :production do
+  gem "rails_semantic_logger"
+end
 
 group :development, :test do
   # Prettyprint in console

--- a/config/application.rb
+++ b/config/application.rb
@@ -50,7 +50,7 @@ module ManageCoursesBackend
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
-    config.skylight.logger = SemanticLogger[Skylight]
+    config.skylight.logger = SemanticLogger[Skylight] if defined?(SemanticLogger)
     config.skylight.log_level = :fatal
     config.skylight.native_log_level = :fatal
 

--- a/config/initializers/semantic_logger.rb
+++ b/config/initializers/semantic_logger.rb
@@ -1,4 +1,6 @@
-Rails.application.config.semantic_logger.application = Settings.application_name
-Rails.application.config.rails_semantic_logger.format = :json
-SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
-Rails.application.config.logger.info("Application logging to STDOUT")
+if defined?(SemanticLogger)
+  Rails.application.config.semantic_logger.application = Settings.application_name
+  Rails.application.config.rails_semantic_logger.format = :json
+  SemanticLogger.add_appender(io: STDOUT, level: Rails.application.config.log_level, formatter: Rails.application.config.rails_semantic_logger.format)
+  Rails.application.config.logger.info("Application logging to STDOUT")
+end


### PR DESCRIPTION
This will only be true in deployed environments — JSON logs are not user-friendly in development.

Following https://github.com/DFE-Digital/find-teacher-training/pull/997