### PR TITLE
Optimisation for /v3/courses SQL - remove double join to `course_site`

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -147,10 +147,6 @@ class Course < ApplicationRecord
     joins(site_statuses: :site).merge(SiteStatus.where(status: :running)).merge(Site.within(range, origin: origin))
   end
 
-  scope :by_distance, ->(origin:) do
-    joins(site_statuses: :site).merge(SiteStatus.where(status: :running)).merge(Site.by_distance(origin: origin))
-  end
-
   scope :by_name_ascending, -> do
     order(name: :asc)
   end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -144,11 +144,11 @@ class Course < ApplicationRecord
           class_name: "CourseEnrichment"
 
   scope :within, ->(range, origin:) do
-    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.within(range, origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: :running)).merge(Site.within(range, origin: origin))
   end
 
   scope :by_distance, ->(origin:) do
-    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.by_distance(origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: :running)).merge(Site.by_distance(origin: origin))
   end
 
   scope :by_name_ascending, -> do

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -144,11 +144,11 @@ class Course < ApplicationRecord
           class_name: "CourseEnrichment"
 
   scope :within, ->(range, origin:) do
-    joins(:sites).merge(Site.within(range, origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.within(range, origin: origin))
   end
 
   scope :by_distance, ->(origin:) do
-    joins(:sites).merge(Site.by_distance(origin: origin))
+    joins(site_statuses: :site).merge(SiteStatus.where(status: %i[new_status running])).merge(Site.by_distance(origin: origin))
   end
 
   scope :by_name_ascending, -> do

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -56,11 +56,12 @@ class CourseSearchService
       outer_scope = outer_scope.joins(:provider)
       outer_scope = outer_scope.select("course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
 
-      outer_scope = if expand_university?
-                      outer_scope.order(:boosted_distance)
-                    else
-                      outer_scope.order(:distance)
-                    end
+      outer_scope =
+        if expand_university?
+          outer_scope.order(:boosted_distance)
+        else
+          outer_scope.order(:distance)
+        end
     end
 
     outer_scope


### PR DESCRIPTION
### Context

The endpoint that Find uses for course searches is high traffic and can be slow for certain queries. Therefore we have attempted to analyse the database queries to get a handle on what they are doing, how slow or fast they are and come up with any optimisations that are possible.

This is an optimisation extracted from https://github.com/DFE-Digital/teacher-training-api/pull/2188. It simply eliminates a double join from the `course` table to the `course_site` table resulting in a measurable performance gain and an (accidental) bug fix (I think).

### Changes proposed in this pull request

https://github.com/DFE-Digital/teacher-training-api/pull/2188 contains a fair amount of context for this change and some analysis of the underlying queries.

The code change is very small here and just attempts to ensure that there is a single join from `course` to `course_site`. It's best illustrated by the effect on an example query. This is the original SQL query for a location based search with some simple filters:

```
SELECT course.*, distance, (CASE WHEN provider.provider_type = 'O' THEN (distance - 10) ELSE distance END) as boosted_distance
FROM "course"
INNER JOIN (
  SELECT course_id,
    MIN(ACOS(least(1,COS(0.900577531861982)*COS(-0.022941230770756427)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+COS(0.900577531861982)*SIN(-0.022941230770756427)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+SIN(0.900577531861982)*SIN(RADIANS(site.latitude))))*3963.1899999999996) as distance
  FROM "course_site"
  INNER JOIN "site" ON "course_site"."site_id" = "site"."id"
  WHERE (
      "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'F'
      OR "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'P'
      OR "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'B'
    ) AND "site"."latitude" IS NOT NULL
    AND "site"."longitude" IS NOT NULL
    AND (
      "site"."address1" != ''
      OR "site"."postcode" != ''
    )
    GROUP BY course_id
  ) "distances" ON "course"."id" = "distances"."course_id"
  INNER JOIN "provider" ON "provider"."id" = "course"."provider_id"
  WHERE "course"."id" IN (
    SELECT "course"."id"
    FROM "course"
    INNER JOIN "provider" ON "course"."provider_id" = "provider"."id"
    INNER JOIN "course_site" ON "course_site"."course_id" = "course"."id"
    INNER JOIN "course_subject" ON "course_subject"."course_id" = "course"."id"
    INNER JOIN "subject" ON "subject"."id" = "course_subject"."subject_id"
    INNER JOIN "course_site" "site_statuses_course_join" ON "site_statuses_course_join"."course_id" = "course"."id"
    INNER JOIN "site" ON "site"."id" = "site_statuses_course_join"."site_id" AND "course_site"."status" IN ('N', 'R')
    WHERE "provider"."recruitment_cycle_id" = 3
      AND "provider"."discarded_at" IS NULL
      AND "course"."discarded_at" IS NULL
      AND "course_site"."vac_status" != ''
      AND "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "subject"."subject_code" = '00'
      AND (site.latitude IS NOT NULL
      AND site.longitude IS NOT NULL)
      AND (ACOS(least(1,COS(0.900577531861982)*COS(-0.022941230770756427)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+
      COS(0.900577531861982)*SIN(-0.022941230770756427)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+
      SIN(0.900577531861982)*SIN(RADIANS(site.latitude))))*3963.1899999999996)
      <= '50')
    ORDER BY "distance" ASC;
```


This is the SQL after the optimisation:

```
SELECT course.*, distance, (CASE WHEN provider.provider_type = 'O' THEN (distance - 10) ELSE distance END) as boosted_distance
FROM "course" INNER JOIN (
  SELECT course_id, MIN(ACOS(least(1,COS(0.900577531861982)*COS(-0.022941230770756427)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+COS(0.900577531861982)*SIN(-0.022941230770756427)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+SIN(0.900577531861982)*SIN(RADIANS(site.latitude))))*3963.1899999999996) as distance
  FROM "course_site"
  INNER JOIN "site" ON "course_site"."site_id" = "site"."id"
  WHERE (
      "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'F'
      OR "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'P'
      OR "course_site"."status" = 'R'
      AND "course_site"."publish" = 'Y'
      AND "course_site"."vac_status" = 'B'
    )
    AND "site"."latitude" IS NOT NULL
    AND "site"."longitude" IS NOT NULL
    AND (
      "site"."address1" != ''
      OR "site"."postcode" != ''
    ) GROUP BY course_id
  ) "distances" ON "course"."id" = "distances"."course_id"
  INNER JOIN "provider" ON "provider"."id" = "course"."provider_id"
  WHERE "course"."id" IN (
    SELECT "course"."id"
    FROM "course"
    INNER JOIN "provider" ON "course"."provider_id" = "provider"."id"
    INNER JOIN "course_site" ON "course_site"."course_id" = "course"."id"
    INNER JOIN "site" ON "site"."id" = "course_site"."site_id"
    INNER JOIN "course_subject" ON "course_subject"."course_id" = "course"."id"
    INNER JOIN "subject" ON "subject"."id" = "course_subject"."subject_id"
    WHERE "provider"."recruitment_cycle_id" = 3 AND "provider"."discarded_at" IS NULL
      AND "course"."discarded_at" IS NULL
      AND "course_site"."vac_status" != ''
      AND "course_site"."publish" = 'Y'
      AND "subject"."subject_code" = '00'
      AND "course_site"."status" = 'R'
      AND (site.latitude IS NOT NULL AND site.longitude IS NOT NULL)
      AND (ACOS(least(1,COS(0.900577531861982)*COS(-0.022941230770756427)*COS(RADIANS(site.latitude))*COS(RADIANS(site.longitude))+COS(0.900577531861982)*SIN(-0.022941230770756427)*COS(RADIANS(site.latitude))*SIN(RADIANS(site.longitude))+SIN(0.900577531861982)*SIN(RADIANS(site.latitude))))*3963.1899999999996) <= '50'
  )
ORDER BY "distance" ASC;
```

You can see that there are two joins to `course_site` in the first query and only one in the second. 

In this example in my dev environment (YMMV) the top-speed for this query run in psql changes from **175ms to 122ms**. 3 variations on this query are run to service a single API request so the gains are reasonably significant. I was seeing response times in Find for this query reduce from about **1.2s to 1.0s**.

The other optimisation not included here but in https://github.com/DFE-Digital/teacher-training-api/pull/2188 (the one that replaces the inner/outer query pattern with a single query) provides a further improvement, reducing the query time down to ~75ms.

### Guidance to review

Removing the extra join to the course_site table gives different results to the original query. I _think_ the new behaviour is correct.

If you look at the original query the first join has a condition on course_site.status that is meant to filter out inactive sites (I believe). The second join has a condition on site lat/lng (within 50 miles of the search location). It's possible a course to have one site that matches the first condition and another that matches the second. If we combine these two joins and their associated conditions then that course no longer matches because neither of its sites satisfies both conditions. So I think that combining the joins has accidentally fixed a bug in the search logic. Does this make sense?

Does this change make sense?
How can we mitigate the risk?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
