### PR TITLE
[xxx] Increase BigQuery timestamp precision

### DIFF
--- a/app/lib/big_query/entity_event.rb
+++ b/app/lib/big_query/entity_event.rb
@@ -8,7 +8,7 @@ module BigQuery
     def initialize
       @event_hash = {
         environment: Rails.env,
-        occurred_at: Time.zone.now.iso8601,
+        occurred_at: Time.zone.now.iso8601(6),
       }
       yield self if block_given?
     end


### PR DESCRIPTION
We need more precision to differentiate between events happening in the same second.

### Context

We timestamp events sent to Big Query. Those events often happen almost simultaneously so we need to be more precise to determine the order in Big Query.

### Changes proposed in this pull request

Two brackets and the number 6.

### Guidance to review

I copied this so it must be fine -> https://github.com/DFE-Digital/apply-for-teacher-training/pull/5678

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
