### PR TITLE
Add loadtest database config

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -37,3 +37,6 @@ production:
 
 sandbox:
   <<: *default
+
+loadtest:
+  <<: *default


### PR DESCRIPTION
### Context

loadtest is picking a default db settings from DATABASE_URL instead of the one specified in the file.

### Changes proposed in this pull request

Add db config section for loadtest env

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
