### PR TITLE
Query tuning for the public V1 provider/courses index endpoint

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -586,7 +586,7 @@ class Course < ApplicationRecord
     requirements = [I18n.t("course.values.bursary_requirements.second_degree")]
     mathematics_requirement = I18n.t("course.values.bursary_requirements.maths")
 
-    if subjects.include?(PrimarySubject.find_by(subject_name: "Primary with mathematics"))
+    if subjects.any? { |subject| subject.subject_name == "Primary with mathematics" }
       requirements.push(mathematics_requirement)
     end
 

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -36,7 +36,8 @@ class CourseSearchService
     # This prevents 'PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list'
     outer_scope = Course.includes(
       :enrichments,
-      subjects: [:financial_incentive],
+      :financial_incentives,
+      course_subjects: [:subject],
       site_statuses: [:site],
       provider: %i[recruitment_cycle ucas_preferences],
     ).where(id: scope.select(:id))

--- a/spec/services/course_search_service_spec.rb
+++ b/spec/services/course_search_service_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe CourseSearchService do
       allow(Course).to receive(:includes)
         .with(
           :enrichments,
-          subjects: [:financial_incentive],
+          :financial_incentives,
+          course_subjects: [:subject],
           site_statuses: [:site],
           provider: %i[recruitment_cycle ucas_preferences],
         ).and_return(course_with_includes)


### PR DESCRIPTION
### Context

This endpoint was flagged as problematic by Skylight:

https://www.skylight.io/app/applications/NXAwzyZjkp2m/recent/6h/endpoints/API::Public::V1::Providers::CoursesController%23index?responseType=jsonapi

### Changes proposed in this pull request

The logs show that there are a lot of 1+n type queries happening when we hit this endpoint. The tables being queried repeatedly include `provider`, `financial_incentive`, `subject`, `course_enrichment`.

Two very subtle changes result in measurable performance improvements by reducing these queries.

1. I've adjusted the `includes` in the query used by this endpoint to avoid the 1+n's on `financial_incentive` and `course_enrichment`
2. It turns out that there is a repeated lookup in the `Course#bursary_requirements` method. This eliminates a bunch of 1+n's on the `subject` table.

As a rough yardstick these changes reduce the log footprint for my sample request from 450 to 220 lines and improve the performance (measured by curling the API) by about 30%.

There is potential for further improvement. There are still 1+n queries loading `Course#accredited_body`. This association is a customised `belongs_to :provider` (it uses the `provider_code` and `recruitment_cycle_id` columns as a foreign key) and you can't add it to the `includes` list. So I'm not sure how to fix this one without changing the schema to use a more conventional foreign key.

### Guidance to review

- As we are again changing the `CourseSearchService` does this have any knock-on effects? It needs more testing I think.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
