### PR TITLE
Optimisation for /v3/courses SQL - merge inner/outer query

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -11,7 +11,7 @@ module API
         render jsonapi: paginate(course_search),
                fields: fields_param,
                include: params[:include],
-               meta: { count: course_search.count("course.id") },
+               meta: { count: course_search.count("DISTINCT course.id") },
                class: CourseSerializersServiceV3.new.execute,
                cache: Rails.cache
       end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -164,7 +164,7 @@ class Course < ApplicationRecord
   end
 
   scope :accredited_body_order, ->(provider_name) do
-    joins(:provider).merge(Provider.by_provider_name(provider_name))
+    joins(:provider).order('by_provider_name')
   end
 
   scope :changed_since, ->(timestamp) do

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -43,8 +43,8 @@ class CourseSearchService
 
     if provider_name.present?
       scope = scope
-                      .accredited_body_order(provider_name)
-                      .ascending_canonical_order
+        .accredited_body_order(provider_name)
+        .ascending_canonical_order
     elsif sort_by_provider_ascending?
       scope = scope.ascending_canonical_order
       scope = scope.select("provider.provider_name", "course.*")

--- a/app/services/course_search_service.rb
+++ b/app/services/course_search_service.rb
@@ -34,37 +34,37 @@ class CourseSearchService
     # The 'where' scope will remove duplicates
     # An outer query is required in the event the provider name is present.
     # This prevents 'PG::InvalidColumnReference: ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list'
-    outer_scope = Course.includes(
+    scope = scope.includes(
       :enrichments,
       subjects: [:financial_incentive],
       site_statuses: [:site],
       provider: %i[recruitment_cycle ucas_preferences],
-    ).where(id: scope.select(:id))
+    )
 
     if provider_name.present?
-      outer_scope = outer_scope
+      scope = scope
                       .accredited_body_order(provider_name)
                       .ascending_canonical_order
     elsif sort_by_provider_ascending?
-      outer_scope = outer_scope.ascending_canonical_order
-      outer_scope = outer_scope.select("provider.provider_name", "course.*")
+      scope = scope.ascending_canonical_order
+      scope = scope.select("provider.provider_name", "course.*")
     elsif sort_by_provider_descending?
-      outer_scope = outer_scope.descending_canonical_order
-      outer_scope = outer_scope.select("provider.provider_name", "course.*")
+      scope = scope.descending_canonical_order
+      scope = scope.select("provider.provider_name", "course.*")
     elsif sort_by_distance?
-      outer_scope = outer_scope.joins(courses_with_distance_from_origin)
-      outer_scope = outer_scope.joins(:provider)
-      outer_scope = outer_scope.select("course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
+      scope = scope.joins(courses_with_distance_from_origin)
+      scope = scope.joins(:provider)
+      scope = scope.select("DISTINCT(course.id), course.*, distance, #{Course.sanitize_sql(distance_with_university_area_adjustment)}")
 
-      outer_scope =
+      scope =
         if expand_university?
-          outer_scope.order(:boosted_distance)
+          scope.order(:boosted_distance)
         else
-          outer_scope.order(:distance)
+          scope.order(:distance)
         end
     end
 
-    outer_scope
+    scope
   end
 
   private_class_method :new


### PR DESCRIPTION
### Context

The endpoint that Find uses for course searches is high traffic and can be slow for certain queries. Therefore we have attempted to analyse the database queries to get a handle on what they are doing, how slow or fast they are and come up with any optimisations that are possible.

This is an optimisation extracted from https://github.com/DFE-Digital/teacher-training-api/pull/2188. In the `CourseSearchService` the main query is made up of an 'inner' sub-query that applies filters and fetches a list of matching course `id`s. These `id`s are fed into another 'outer' query that fetches the data needed and deals with sorting and pagination.

See the above PR for additional context.

### Changes proposed in this pull request

This PR attempts to merge the inner and outer queries described above. Merging the queries causes some duplicate courses to be returned by the query. I've attempted to fix this with a `DISTINCT(course.id)`.

### Guidance to review

I'm leaving this in DRAFT for now while we work on improving tests that exercise `CourseSearchService`.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
