### PR TITLE
[2261] Stop logging bigquery

### DIFF
--- a/app/jobs/send_event_to_big_query_job.rb
+++ b/app/jobs/send_event_to_big_query_job.rb
@@ -1,5 +1,6 @@
 class SendEventToBigQueryJob < ApplicationJob
   queue_as :low_priority
+  self.logger = ActiveSupport::TaggedLogging.new(Logger.new(IO::NULL))
 
   def perform(event_json, dataset = Settings.google.bigquery.dataset, table = Settings.google.bigquery.table_name)
     return unless FeatureService.enabled?(:send_request_data_to_bigquery)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,6 +3,7 @@ if ENV.key?("VCAP_SERVICES")
     config.redis = {
       url: ENV.fetch("REDIS_WORKER_URL"),
     }
+    config.logger.level = Logger::WARN
 
     if Settings.bg_jobs
       Sidekiq::Cron::Job.load_from_hash Settings.bg_jobs


### PR DESCRIPTION
### Context
Filling up Logit with bigquery job log

### Changes proposed in this pull request
Stop filling up Logit with bigquery job log by setting sidekig log level to WARN and bigquery job activejob log to null logger

### Guidance to review
Same implementation as find

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
