### PR TITLE
Run 10 web app instances and 50 RAILS_MAX_THREADS

### DIFF
--- a/terraform/workspace_variables/app_config.yml
+++ b/terraform/workspace_variables/app_config.yml
@@ -1,6 +1,7 @@
 default: &default
   ASSETS_PRECOMPILE: true
   RAILS_SERVE_STATIC_FILES: true
+  RAILS_MAX_THREADS: 50
 
 qa:
   <<: *default

--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -2,9 +2,9 @@
 cf_space                   = "bat-prod"
 paas_app_environment       = "prod"
 paas_web_app_host_name     = null
-paas_web_app_instances     = 8
-paas_web_app_memory        = 1536
-paas_worker_app_instances  = 2
+paas_web_app_instances     = 10
+paas_web_app_memory        = 2048
+paas_worker_app_instances  = 4
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "medium-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"


### PR DESCRIPTION
### Context

In preparation for the cycle opening, we tested this combination with Find.
A combined capacity of 500 request threads gives us an optimal setup against the DB plan.
This combination has been tested against find and with caching enabled gives us an ideal setup.

### Changes proposed in this pull request

Run 10 web app instances and 4 worker app instances in prod.
Set RAILS_MAX_THREADS to 50

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
