### PR TITLE
[164] Switch cycle to 2022

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -25,5 +25,3 @@ render_json_errors: true
 
 features:
   send_request_data_to_bigquery: true
-
-current_recruitment_cycle_year: 2021


### PR DESCRIPTION
### Context

Make 2022 the current cycle in production.

### Changes proposed in this pull request

Remove the settings override in /settings/production.yml

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
