### PR TITLE
Fix bug with updating pending GCSEs

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -186,7 +186,7 @@ module API
       end
 
       def update_course
-        return unless course_params.values.any? || funding_type_params.present? || qualification_params.present?
+        return unless course_params.values.present? || funding_type_params.present? || qualification_params.present?
         return unless @course.course_params_assignable(course_params)
 
         @course.assign_attributes(course_params)


### PR DESCRIPTION
### Context

There's a sneaky little bug here

The value passed through in the controller is a boolean, but in the test a string is passed through.

This means when any? is called on [false] if returns false. If we use present it returns true.

This only is an issue on update when you don't update equivalency values.

### Changes proposed in this pull request

- use `.present?` instead of  `.any?` in the course controller

### Guidance to review

This seems to be a quirk of the way the tests are setup. Is there a good way to tweak the test so it returns a boolean rather than a string.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
