### PR TITLE
[203] Use size instead of count

### DIFF
--- a/app/controllers/api/v3/courses_controller.rb
+++ b/app/controllers/api/v3/courses_controller.rb
@@ -11,7 +11,7 @@ module API
         render jsonapi: paginate(course_search),
                fields: fields_param,
                include: params[:include],
-               meta: { count: course_search.count("course.id") },
+               meta: { count: course_search.size },
                class: CourseSerializersServiceV3.new.execute,
                cache: Rails.cache
       end


### PR DESCRIPTION
### Context

- To reduce latency on the v3 `/courses` endpoint

### Changes proposed in this pull request

- use `course_search.size` instead of `course_search.count("course.id")`

### Guidance to review

- run `ab -n 10 http://localhost:3001/api/v3/courses` from your command line with and without the changes above to see the latency difference

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
