### PR TITLE
Fix jsonapi caching for included resources in V3 courses endpoint

### DIFF
--- a/app/serializers/api/v2/serializable_provider.rb
+++ b/app/serializers/api/v2/serializable_provider.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SerializableProvider < JSONAPI::Serializable::Resource
+      include JsonapiCacheKeyHelper
+
       type "providers"
 
       attributes :provider_code, :provider_name, :provider_type, :accredited_body?,

--- a/app/serializers/api/v2/serializable_provider_enrichment.rb
+++ b/app/serializers/api/v2/serializable_provider_enrichment.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SerializableProviderEnrichment < JSONAPI::Serializable::Resource
+      include JsonapiCacheKeyHelper
+
       type "provider_enrichment"
 
       has_one :provider

--- a/app/serializers/api/v2/serializable_site.rb
+++ b/app/serializers/api/v2/serializable_site.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SerializableSite < JSONAPI::Serializable::Resource
+      include JsonapiCacheKeyHelper
+
       type "sites"
 
       attributes :code, :location_name, :address1, :address2,

--- a/app/serializers/api/v2/serializable_site_status.rb
+++ b/app/serializers/api/v2/serializable_site_status.rb
@@ -1,8 +1,9 @@
 module API
   module V2
     class SerializableSiteStatus < JSONAPI::Serializable::Resource
-      type "site_statuses"
+      include JsonapiCacheKeyHelper
 
+      type "site_statuses"
       attributes :vac_status, :publish, :status, :has_vacancies?
 
       has_one :site

--- a/app/serializers/api/v2/serializable_subject.rb
+++ b/app/serializers/api/v2/serializable_subject.rb
@@ -1,6 +1,8 @@
 module API
   module V2
     class SerializableSubject < JSONAPI::Serializable::Resource
+      include JsonapiCacheKeyHelper
+
       type "subjects"
 
       attributes :subject_name, :subject_code

--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -2,12 +2,7 @@ module API
   module V3
     class SerializableCourse < JSONAPI::Serializable::Resource
       include TimeFormat
-
-      def jsonapi_cache_key(options)
-        course_cache_key = @object.cache_key_with_version
-        provider_cache_key = @object.provider.cache_key_with_version
-        "V3/#{course_cache_key} #{provider_cache_key}" + super(options)
-      end
+      include JsonapiCacheKeyHelper
 
       class << self
         def enrichment_attribute(name, enrichment_name = name)

--- a/app/serializers/jsonapi_cache_key_helper.rb
+++ b/app/serializers/jsonapi_cache_key_helper.rb
@@ -1,0 +1,5 @@
+module JsonapiCacheKeyHelper
+  def jsonapi_cache_key(options)
+    "#{self.class}/#{@object.cache_key_with_version} " + super(options)
+  end
+end


### PR DESCRIPTION

### Context
The first version of this caching feature didn't correctly accommodate
cache busting for included resources. The keys created by the gem via
the default implementation of jsonapi_cache_key only contain an id, so
don't become stale. This meant that updates to those resources would
remain in the cache indefinitely.

### Changes proposed in this pull request

Fix this by including a custom cache key for every serializer used by the
V3 courses endpoint.

### Guidance to review
- Do the specs and the new cache key format look sensible?
### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
