### PR TITLE
[xxx] Validate accredited body if course not self accredited

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -304,6 +304,7 @@ class Course < ApplicationRecord
   validate :validate_subject_count
   validate :validate_subject_consistency
   validate :validate_custom_age_range, on: %i[create new], if: -> { age_range_in_years.present? }
+  validate :accredited_body_exists_in_current_cycle, on: :publish, unless: -> { self_accredited? }
   validates_with UniqueCourseValidator, on: :new
 
   validates :name, :profpost_flag, :program_type, :qualification, :start_date, :study_mode, presence: true
@@ -868,5 +869,9 @@ private
 
   def self_accredited_cannot_be_salary_funded
     errors.add(:program_type, "Salary is not valid for a self accredited course") if self_accredited? && funding_type == "salary"
+  end
+
+  def accredited_body_exists_in_current_cycle
+    errors.add(:base, "The Accredited Body #{accredited_body_code} does not exist in this cycle") unless RecruitmentCycle.current.providers.find_by(provider_code: accredited_body_code)
   end
 end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -872,6 +872,8 @@ private
   end
 
   def accredited_body_exists_in_current_cycle
+    return unless accredited_body_code
+
     errors.add(:base, "The Accredited Body #{accredited_body_code} does not exist in this cycle") unless RecruitmentCycle.current.providers.find_by(provider_code: accredited_body_code)
   end
 end

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,3 +4,6 @@ environment:
   name: "review"
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+authentication:
+  secret: secret
+  mode: persona

--- a/spec/controllers/api/v2/courses_controller_spec.rb
+++ b/spec/controllers/api/v2/courses_controller_spec.rb
@@ -4,13 +4,15 @@ describe API::V2::CoursesController, type: :controller do
   let(:site_status) { build(:site_status, :new) }
   let(:dfe_subject) { find_or_create(:primary_subject, :primary) }
   let(:provider) { create(:provider) }
+  let(:accredited_body) { create(:provider, :accredited_body) }
   let(:course) do
     create(:course,
            :with_gcse_equivalency,
            site_statuses: [site_status],
            enrichments: [enrichment],
            subjects: [dfe_subject],
-           provider: provider)
+           provider: provider,
+           accredited_body_code: accredited_body.provider_code)
   end
   let(:email) { "manage_courses@digital.education.gov.uk" }
   let(:sign_in_user_id) { "manage_courses_api" }

--- a/spec/models/course/publishable_spec.rb
+++ b/spec/models/course/publishable_spec.rb
@@ -14,7 +14,7 @@ describe Course, type: :model do
       let(:enrichment) { build(:course_enrichment, :subsequent_draft, created_at: 1.day.ago) }
       let(:primary_with_mathematics) { find_or_create(:primary_subject, :primary_with_mathematics) }
       let(:course) {
-        create(:course, :with_gcse_equivalency, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status])
+        create(:course, :with_gcse_equivalency, :self_accredited, subjects: [primary_with_mathematics], enrichments: [enrichment], site_statuses: [site_status])
       }
 
       its(:publishable?) { is_expected.to be_truthy }

--- a/spec/requests/api/v2/providers/courses/publish_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publish_spec.rb
@@ -4,6 +4,7 @@ describe "Publish API v2", type: :request do
   let(:user)         { create(:user) }
   let(:organisation) { create(:organisation, users: [user]) }
   let(:provider)       { create :provider, organisations: [organisation] }
+  let(:accredited_body) { create :provider, :accredited_body }
   let(:payload) { { email: user.email } }
   let(:credentials) { encode_to_credentials(payload) }
 
@@ -21,6 +22,7 @@ describe "Publish API v2", type: :request do
       create(:course,
              :with_gcse_equivalency,
              provider: provider,
+             accredited_body_code: accredited_body.provider_code,
              site_statuses: [site_status],
              enrichments: [enrichment],
              subjects: [dfe_subject])
@@ -57,6 +59,7 @@ describe "Publish API v2", type: :request do
                :with_gcse_equivalency,
                level: "primary",
                provider: provider,
+               accredited_body_code: accredited_body.provider_code,
                site_statuses: [site_status],
                enrichments: [enrichment],
                subjects: dfe_subjects,
@@ -140,6 +143,7 @@ describe "Publish API v2", type: :request do
             "Enter a course length",
             "Enter details about the salary for this course",
             "Enter GCSE requirements",
+            "The Accredited Body  does not exist in this cycle",
           ])
         end
       end
@@ -164,6 +168,7 @@ describe "Publish API v2", type: :request do
               "Enter a course length",
               "Enter details about the fee for UK and EU students",
               "Enter GCSE requirements",
+              "The Accredited Body  does not exist in this cycle",
             ])
           end
 
@@ -173,6 +178,7 @@ describe "Publish API v2", type: :request do
               "/data/attributes/how_school_placements_work",
               "/data/attributes/course_length",
               "/data/attributes/fee_uk_eu",
+              nil,
               nil,
             ])
           end
@@ -199,6 +205,7 @@ describe "Publish API v2", type: :request do
               "Enter a course length",
               "Enter details about the salary for this course",
               "Enter GCSE requirements",
+              "The Accredited Body  does not exist in this cycle",
             ])
           end
         end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -64,7 +64,6 @@ describe "Publishable API v2", type: :request do
             "Enter details about the salary for this course",
             "Enter GCSE requirements",
             "Select at least one location for this course",
-            "The Accredited Body  does not exist in this cycle",
           ])
         end
       end
@@ -82,14 +81,13 @@ describe "Publishable API v2", type: :request do
           it { is_expected.to have_http_status(:unprocessable_entity) }
 
           it "has validation error details" do
-            expect(json_data.count).to eq 6
+            expect(json_data.count).to eq 5
             expect(json_data.map { |error| error["detail"] }).to match_array([
               "Enter details about this course",
               "Enter a course length",
               "Enter details about the fee for UK and EU students",
               "Enter GCSE requirements",
               "Enter details about school placements",
-              "The Accredited Body  does not exist in this cycle",
             ])
           end
 
@@ -99,7 +97,7 @@ describe "Publishable API v2", type: :request do
               /data/attributes/how_school_placements_work
               /data/attributes/course_length
               /data/attributes/fee_uk_eu
-            ).push(nil, nil))
+            ) << nil)
           end
         end
       end

--- a/spec/requests/api/v2/providers/courses/publishable_spec.rb
+++ b/spec/requests/api/v2/providers/courses/publishable_spec.rb
@@ -38,7 +38,7 @@ describe "Publishable API v2", type: :request do
 
     context "unpublished course with draft enrichment" do
       let(:course) do
-        create(:course, :primary, :unpublished, :draft_enrichment, :with_gcse_equivalency)
+        create(:course, :primary, :unpublished, :draft_enrichment, :with_gcse_equivalency, :self_accredited)
       end
 
       it "returns ok" do
@@ -64,6 +64,7 @@ describe "Publishable API v2", type: :request do
             "Enter details about the salary for this course",
             "Enter GCSE requirements",
             "Select at least one location for this course",
+            "The Accredited Body  does not exist in this cycle",
           ])
         end
       end
@@ -81,13 +82,14 @@ describe "Publishable API v2", type: :request do
           it { is_expected.to have_http_status(:unprocessable_entity) }
 
           it "has validation error details" do
-            expect(json_data.count).to eq 5
+            expect(json_data.count).to eq 6
             expect(json_data.map { |error| error["detail"] }).to match_array([
               "Enter details about this course",
               "Enter a course length",
               "Enter details about the fee for UK and EU students",
               "Enter GCSE requirements",
               "Enter details about school placements",
+              "The Accredited Body  does not exist in this cycle",
             ])
           end
 
@@ -97,7 +99,7 @@ describe "Publishable API v2", type: :request do
               /data/attributes/how_school_placements_work
               /data/attributes/course_length
               /data/attributes/fee_uk_eu
-            ) << nil)
+            ).push(nil, nil))
           end
         end
       end


### PR DESCRIPTION
### Context

- We are getting situations where an accredited body is discarded, but courses that are accredited by them are still able to be published. 

### Changes proposed in this pull request

 - Add a validation that prevents courses from being published, if their AB does not exist in the current cycle

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
