### PR TITLE
[369] allow support users to edit confirmed allocation numbers

### DIFF
--- a/app/controllers/support/allocation_uplifts_controller.rb
+++ b/app/controllers/support/allocation_uplifts_controller.rb
@@ -19,7 +19,7 @@ module Support
 
     def update
       if allocation_uplift.update(update_allocation_uplift_params)
-        redirect_to support_allocation_path(allocation_uplift.allocation)
+        redirect_to support_allocation_path(allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully updated" }
       else
         render :edit
       end

--- a/app/controllers/support/allocation_uplifts_controller.rb
+++ b/app/controllers/support/allocation_uplifts_controller.rb
@@ -10,6 +10,7 @@ module Support
 
     def create
       @allocation_uplift = AllocationUplift.new(create_allocation_uplift_params)
+      @allocation_uplift.allocation = allocation
       if @allocation_uplift.save
         redirect_to support_allocation_path(@allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully created" }
       else
@@ -28,7 +29,7 @@ module Support
   private
 
     def allocation_uplift
-      @allocation_uplift ||= AllocationUplift.find(params[:id])
+      @allocation_uplift ||= allocation.allocation_uplift
     end
 
     def allocation

--- a/app/controllers/support/allocation_uplifts_controller.rb
+++ b/app/controllers/support/allocation_uplifts_controller.rb
@@ -1,0 +1,47 @@
+module Support
+  class AllocationUpliftsController < ApplicationController
+    def edit
+      allocation_uplift
+    end
+
+    def update
+      if allocation_uplift.update(update_allocation_uplift_params)
+        redirect_to support_allocation_path(allocation_uplift.allocation)
+      else
+        render :edit
+      end
+    end
+
+    def new
+      @allocation_uplift = AllocationUplift.new(allocation: allocation)
+    end
+
+    def create
+      @allocation = Allocation.find(create_allocation_uplift_params[:allocation_id].to_i)
+      @allocation_uplift = AllocationUplift.new(allocation: @allocation, uplifts: create_allocation_uplift_params[:uplifts])
+      if @allocation_uplift.save
+        redirect_to support_allocation_path(allocation), flash: { success: "Allocation Uplift was successfully created" }
+      else
+        render :new
+      end
+    end
+
+  private
+
+    def allocation_uplift
+      @allocation_uplift ||= AllocationUplift.find(params[:id])
+    end
+
+    def allocation
+      @allocation ||= Allocation.find(params[:allocation_id])
+    end
+
+    def create_allocation_uplift_params
+      params.require(:allocation_uplift).permit(:allocation_id, :uplifts)
+    end
+
+    def update_allocation_uplift_params
+      params.require(:allocation_uplift).permit(:uplifts)
+    end
+  end
+end

--- a/app/controllers/support/allocation_uplifts_controller.rb
+++ b/app/controllers/support/allocation_uplifts_controller.rb
@@ -4,25 +4,24 @@ module Support
       allocation_uplift
     end
 
-    def update
-      if allocation_uplift.update(update_allocation_uplift_params)
-        redirect_to support_allocation_path(allocation_uplift.allocation)
-      else
-        render :edit
-      end
-    end
-
     def new
       @allocation_uplift = AllocationUplift.new(allocation: allocation)
     end
 
     def create
-      @allocation = Allocation.find(create_allocation_uplift_params[:allocation_id].to_i)
-      @allocation_uplift = AllocationUplift.new(allocation: @allocation, uplifts: create_allocation_uplift_params[:uplifts])
+      @allocation_uplift = AllocationUplift.new(create_allocation_uplift_params)
       if @allocation_uplift.save
-        redirect_to support_allocation_path(allocation), flash: { success: "Allocation Uplift was successfully created" }
+        redirect_to support_allocation_path(@allocation_uplift.allocation), flash: { success: "Allocation Uplift was successfully created" }
       else
         render :new
+      end
+    end
+
+    def update
+      if allocation_uplift.update(update_allocation_uplift_params)
+        redirect_to support_allocation_path(allocation_uplift.allocation)
+      else
+        render :edit
       end
     end
 

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -4,6 +4,14 @@ module Support
       @providers_with_allocations = filtered_providers_with_allocations.page(params[:page] || 1)
     end
 
+    def edit
+      @allocation = Allocation.find(params[:id])
+    end
+
+    def show
+      @allocation = Allocation.find(params[:id])
+    end
+
   private
 
     def filtered_providers_with_allocations

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -11,7 +11,7 @@ module Support
     end
 
     def find_providers_with_allocations
-      Provider.where(id: Allocation.current_allocations.select(:provider_id))
+      Provider.where(id: Allocation.current_allocations.select(:provider_id)).order(:provider_name)
     end
 
     def filters

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -7,11 +7,19 @@ module Support
   private
 
     def filtered_providers_with_allocations
-      Support::Providers::Filter.call(providers: find_providers_with_allocations, filters: nil)
+      Support::Providers::Filter.call(providers: find_providers_with_allocations, filters: filters)
     end
 
     def find_providers_with_allocations
       Provider.where(id: Allocation.current_allocations.select(:provider_id))
+    end
+
+    def filters
+      @filters ||= ProviderFilter.new(params: filter_params).filters
+    end
+
+    def filter_params
+      params.permit(:text_search, :page, :commit)
     end
   end
 end

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -1,0 +1,17 @@
+module Support
+  class AllocationsController < ApplicationController
+    def index
+      @providers_with_allocations = filtered_providers_with_allocations.page(params[:page] || 1)
+    end
+
+  private
+
+    def filtered_providers_with_allocations
+      Support::Providers::Filter.call(providers: find_providers_with_allocations, filters: nil)
+    end
+
+    def find_providers_with_allocations
+      Provider.where(id: Allocation.current_allocations.select(:provider_id))
+    end
+  end
+end

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -1,11 +1,20 @@
 module Support
   class AllocationsController < ApplicationController
+    before_action :set_allocation, only: %i[show edit]
     def index
       @providers_with_allocations = filtered_providers_with_allocations.page(params[:page] || 1)
     end
 
-    def show
-      allocation
+    def show; end
+
+    def edit; end
+
+    def update
+      if allocation.update(update_params)
+        redirect_to support_allocation_path(allocation), flash: { success: "Allocation was successfully updated" }
+      else
+        render :edit
+      end
     end
 
   private
@@ -24,6 +33,14 @@ module Support
 
     def filter_params
       params.permit(:text_search, :page, :commit)
+    end
+
+    def update_params
+      params.require(:allocation).permit(:confirmed_number_of_places)
+    end
+
+    def set_allocation
+      allocation
     end
   end
 end

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -4,15 +4,15 @@ module Support
       @providers_with_allocations = filtered_providers_with_allocations.page(params[:page] || 1)
     end
 
-    def edit
-      @allocation = Allocation.find(params[:id])
-    end
-
     def show
-      @allocation = Allocation.find(params[:id])
+      allocation
     end
 
   private
+
+    def allocation
+      @allocation ||= Allocation.find(params[:id])
+    end
 
     def filtered_providers_with_allocations
       Support::Providers::Filter.call(providers: find_providers_with_allocations, filters: filters)

--- a/app/controllers/support/allocations_controller.rb
+++ b/app/controllers/support/allocations_controller.rb
@@ -15,11 +15,7 @@ module Support
     end
 
     def filtered_providers_with_allocations
-      Support::Providers::Filter.call(providers: find_providers_with_allocations, filters: filters)
-    end
-
-    def find_providers_with_allocations
-      Provider.where(id: Allocation.current_allocations.select(:provider_id)).order(:provider_name)
+      Support::Providers::Filter.call(providers: Provider.with_allocations_for_current_cycle_year, filters: filters)
     end
 
     def filters

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -16,7 +16,7 @@ class Allocation < ApplicationRecord
 
   enum request_type: { initial: 0, repeat: 1, declined: 2 }
 
-  scope :current_allocations, -> { RecruitmentCycle.find_by(year: Settings.allocation_cycle_year).allocations }
+  scope :current_allocations, -> { where(recruitment_cycle: RecruitmentCycle.find_by(year: Settings.allocation_cycle_year)) }
 
   def previous
     Allocation.find_by(

--- a/app/models/allocation.rb
+++ b/app/models/allocation.rb
@@ -16,6 +16,8 @@ class Allocation < ApplicationRecord
 
   enum request_type: { initial: 0, repeat: 1, declined: 2 }
 
+  scope :current_allocations, -> { RecruitmentCycle.find_by(year: Settings.allocation_cycle_year).allocations }
+
   def previous
     Allocation.find_by(
       provider_code: provider_code,

--- a/app/models/allocation_uplift.rb
+++ b/app/models/allocation_uplift.rb
@@ -2,4 +2,6 @@ class AllocationUplift < ApplicationRecord
   belongs_to :allocation
 
   delegate :provider, :recruitment_cycle, to: :allocation
+
+  validates :uplifts, numericality: true
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,6 +51,10 @@ class Provider < ApplicationRecord
            foreign_key: :accredited_body_code,
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
+
+  # We have a has_many relationship rather than has_one as
+  # there are lead_schools that have PE courses ratified by more than
+  # one Accredited Body
   has_many :allocations
 
   # the accredited_providers that this provider is a training_provider for

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -107,6 +107,8 @@ class Provider < ApplicationRecord
 
   scope :in_current_cycle, -> { where(recruitment_cycle: RecruitmentCycle.current_recruitment_cycle) }
 
+  scope :with_allocations_for_current_cycle_year, -> { joins(:allocations).merge(Allocation.current_allocations).order(:provider_name) }
+
   scope :not_geocoded, -> { where(latitude: nil, longitude: nil).or where(region_code: nil) }
 
   serialize :accrediting_provider_enrichments, AccreditingProviderEnrichment::ArraySerializer

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -51,6 +51,7 @@ class Provider < ApplicationRecord
            foreign_key: :accredited_body_code,
            primary_key: :provider_code,
            inverse_of: :accrediting_provider
+  has_many :allocations
 
   # the accredited_providers that this provider is a training_provider for
   has_many :accrediting_providers, -> { distinct }, through: :courses

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -15,11 +15,6 @@ class RecruitmentCycle < ApplicationRecord
     end
     alias_method :current, :current_recruitment_cycle
 
-    def current_allocation_recruitment_cycle
-      find_by(year: Settings.allocation_cycle_year)
-    end
-    alias_method :current_allocation, :current_allocation_recruitment_cycle
-
     def next_recruitment_cycle
       current_recruitment_cycle.next
     end

--- a/app/models/recruitment_cycle.rb
+++ b/app/models/recruitment_cycle.rb
@@ -15,6 +15,11 @@ class RecruitmentCycle < ApplicationRecord
     end
     alias_method :current, :current_recruitment_cycle
 
+    def current_allocation_recruitment_cycle
+      find_by(year: Settings.allocation_cycle_year)
+    end
+    alias_method :current_allocation, :current_allocation_recruitment_cycle
+
     def next_recruitment_cycle
       current_recruitment_cycle.next
     end

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,5 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: support_providers_path },
   { name: "Users", url: support_users_path },
-  { name: "Allocations", url: support_allocations_path },
+  { name: "PE Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/_menu.html.erb
+++ b/app/views/support/_menu.html.erb
@@ -1,4 +1,5 @@
 <%= render TabNavigation::View.new(items: [
   { name: "Providers", url: support_providers_path },
   { name: "Users", url: support_users_path },
+  { name: "Allocations", url: support_allocations_path },
 ]) %>

--- a/app/views/support/allocation_uplifts/edit.html.erb
+++ b/app/views/support/allocation_uplifts/edit.html.erb
@@ -2,6 +2,13 @@
 
 <h1 class="govuk-heading-l">Allocation Uplift for <%= @allocation_uplift.provider.provider_name %></h1>
 
+<%= content_for(:breadcrumbs) do %>
+    <%= render GovukComponent::BackLinkComponent.new(
+      text: "Allocation record for #{@allocation_uplift.provider.provider_name}",
+      href: support_allocation_path(@allocation_uplift.allocation.id),
+    ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>

--- a/app/views/support/allocation_uplifts/edit.html.erb
+++ b/app/views/support/allocation_uplifts/edit.html.erb
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
-    <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>
+    <%= form_with model: [@allocation, @allocation_uplift], url: support_allocation_uplift_path, local: true, method: :patch do |f| %>
         
     <%= f.govuk_error_summary %>
 

--- a/app/views/support/allocation_uplifts/edit.html.erb
+++ b/app/views/support/allocation_uplifts/edit.html.erb
@@ -1,0 +1,17 @@
+<%= render PageTitle::View.new(title: "support.allocation_uplifts.edit") %>
+
+<h1 class="govuk-heading-l">Allocation Uplift for <%= @allocation_uplift.provider.provider_name %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>
+        
+    <%= f.govuk_error_summary %>
+
+    <%= f.govuk_text_field :uplifts, label: { text: "Allocation Uplift", size: "s" }, width: 20 %>
+    <%= f.govuk_submit %>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), support_allocation_path(@allocation_uplift)) %>
+  </div>
+</div>

--- a/app/views/support/allocation_uplifts/new.html.erb
+++ b/app/views/support/allocation_uplifts/new.html.erb
@@ -2,6 +2,13 @@
 
 <h1 class="govuk-heading-l">Create an Allocation Uplift for <%= @allocation_uplift.provider.provider_name %></h1>
 
+<%= content_for(:breadcrumbs) do %>
+    <%= render GovukComponent::BackLinkComponent.new(
+      text: "Allocation record for #{@allocation_uplift.provider.provider_name}",
+      href: support_allocation_path(@allocation_uplift.allocation.id),
+    ) %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>

--- a/app/views/support/allocation_uplifts/new.html.erb
+++ b/app/views/support/allocation_uplifts/new.html.erb
@@ -1,0 +1,18 @@
+<%= render PageTitle::View.new(title: "support.allocation_uplifts.edit") %>
+
+<h1 class="govuk-heading-l">Create an Allocation Uplift for <%= @allocation_uplift.provider.provider_name %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: [:support, @allocation_uplift], local: true do |f| %>
+        
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_text_field :uplifts, label: { text: "Allocation Uplift", size: "s" }, width: 20 %>
+      <%= f.hidden_field(:allocation_id, value: @allocation_uplift.allocation.id) %>
+      <%= f.govuk_submit %>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), support_allocation_path(@allocation)) %>
+  </div>
+</div>

--- a/app/views/support/allocation_uplifts/new.html.erb
+++ b/app/views/support/allocation_uplifts/new.html.erb
@@ -16,7 +16,6 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field :uplifts, label: { text: "Allocation Uplift", size: "s" }, width: 20 %>
-      <%= f.hidden_field(:allocation_id, value: @allocation_uplift.allocation.id) %>
       <%= f.govuk_submit %>
     <% end %>
 

--- a/app/views/support/allocations/_list.html.erb
+++ b/app/views/support/allocations/_list.html.erb
@@ -2,9 +2,9 @@
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
       <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Number of Allocations</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Number of Uplifts</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Provider code</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Number of allocations</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Number of Uplifts</th>
     </tr>
   </thead>
 

--- a/app/views/support/allocations/_list.html.erb
+++ b/app/views/support/allocations/_list.html.erb
@@ -13,7 +13,7 @@
       <tr class="govuk-table__row qa-provider_row">
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+            <%= govuk_link_to provider.provider_name, support_allocation_path(provider.allocations.last.id) %>
           </span>
         </td>
 
@@ -31,7 +31,7 @@
 
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
-            <%= provider.allocations.last.allocation_uplift&.uplfits.to_i %>
+            <%= provider.allocations.last.allocation_uplift&.uplifts.to_i %>
           </span>
         </td>
       </tr>

--- a/app/views/support/allocations/_list.html.erb
+++ b/app/views/support/allocations/_list.html.erb
@@ -1,0 +1,40 @@
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider code</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Number of Allocations</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Number of Uplifts</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% @providers_with_allocations.each do |provider| %>
+      <tr class="govuk-table__row qa-provider_row">
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= govuk_link_to provider.provider_name, support_provider_path(provider) %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.provider_code %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.allocations.last.confirmed_number_of_places %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.allocations.last.allocation_uplift&.uplfits.to_i %>
+          </span>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/support/allocations/edit.html.erb
+++ b/app/views/support/allocations/edit.html.erb
@@ -1,0 +1,19 @@
+<%= render PageTitle::View.new(title: "support.allocations.edit") %>
+
+<h1 class="govuk-heading-l">Edit Allocation</h1>
+
+<%= render "support/menu" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <%= form_with model: [:support, @allocation], local: true do |f| %>
+        
+    <%= f.govuk_error_summary %>
+
+    <%= f.govuk_text_field :confirmed_number_of_places, label: { text: "What are the confirmed number of places", size: "s" }, width: 20 %>
+    <%= f.govuk_submit %>
+    <% end %>
+
+    <%= govuk_link_to(t("cancel"), support_provider_path) %>
+  </div>
+</div>

--- a/app/views/support/allocations/index.html.erb
+++ b/app/views/support/allocations/index.html.erb
@@ -1,0 +1,9 @@
+<%= render PageTitle::View.new(title: "support.allocations.index") %>
+
+<h1 class="govuk-heading-l">Allocations</h1>
+
+<%= render "support/menu" %>
+
+<%= render PaginatedFilter::View.new(filters: nil, collection: @providers_with_allocations) do %>
+  <%= render "list", providers_with_allocations: @providers_with_allocations %>
+<% end %>

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -1,7 +1,21 @@
+<%= content_for(:breadcrumbs) do %>
+    <%= render GovukComponent::BackLinkComponent.new(
+      text: "All Allocation records",
+      href: support_allocations_path,
+    ) %>
+<% end %>
+
+<h1 class="govuk-heading-l">Allocations for <%= @allocation.provider.provider_name %></h1>
+
 <%= render GovukComponent::SummaryListComponent.new do |component|
   component.row do |row|
     row.key { "Provider Name" }
     row.value { @allocation.provider.provider_name }
+  end
+
+  component.row do |row|
+    row.key { "Accredited Body Name" }
+    row.value { @allocation.accredited_body.provider_name }
   end
 
   component.row do |row|

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -23,7 +23,7 @@
   component.row do |row|
     row.key { "Allocations" }
     row.value { @allocation.confirmed_number_of_places.to_s }
-    row.action(href: nil)
+    row.action(text: "Change", href: edit_support_allocation_path(id: @allocation.id))
   end
 
   component.row do |row|

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -1,0 +1,21 @@
+<%= render GovukComponent::SummaryListComponent.new do |component|
+  component.row do |row|
+    row.key { "Provider Name" }
+    row.value { @allocation.provider.provider_name }
+  end
+
+  component.row do |row|
+    row.key { "Allocations" }
+    row.value { @allocation.confirmed_number_of_places.to_s }
+  end
+
+  component.row do |row|
+    row.key { "Allocation Uplifts" }
+    row.value { @allocation.allocation_uplift&.uplifts.to_i.to_s }
+    if @allocation.allocation_uplift.nil?
+      row.action(text: "Change", href: new_support_allocation_uplift_path(allocation_id: @allocation.id))
+    else
+      row.action(text: "Change", href: edit_support_allocation_uplift_path(allocation_id: @allocation.id, id: @allocation.allocation_uplift&.id))
+    end
+  end
+end %>

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -11,16 +11,19 @@
   component.row do |row|
     row.key { "Provider Name" }
     row.value { @allocation.provider.provider_name }
+    row.action(href: nil)
   end
 
   component.row do |row|
     row.key { "Accredited Body Name" }
     row.value { @allocation.accredited_body.provider_name }
+    row.action(href: nil)
   end
 
   component.row do |row|
     row.key { "Allocations" }
     row.value { @allocation.confirmed_number_of_places.to_s }
+    row.action(href: nil)
   end
 
   component.row do |row|

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,8 @@ en:
         users:
           index: "Users"
           show: "User overview"
+        allocations:
+          index: "Allocations"
         data_exports:
           index: "Data exports"
     filter:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,7 @@ en:
           show: "User overview"
         allocations:
           index: "Allocations"
+          edit: "Edit Allocation"
         allocation_uplifts:
           edit: "Edit Allocation Uplift"
         data_exports:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,8 @@ en:
           show: "User overview"
         allocations:
           index: "Allocations"
+        allocation_uplifts:
+          edit: "Edit Allocation Uplift"
         data_exports:
           index: "Data exports"
     filter:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     end
     resources :users, only: %i[index show new create]
 
-    resources :allocations, only: %i[index show] do
+    resources :allocations, only: %i[index show edit update] do
       resources :uplifts, only: %i[edit update create new], controller: :allocation_uplifts
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,9 @@ Rails.application.routes.draw do
     end
     resources :users, only: %i[index show new create]
 
-    resources :allocations, only: %i[index]
+    resources :allocations, only: %i[index show]
+
+    resources :allocation_uplifts, only: %i[edit update create new]
 
     resources :data_exports, path: "data-exports", only: [:index] do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,9 +29,9 @@ Rails.application.routes.draw do
     end
     resources :users, only: %i[index show new create]
 
-    resources :allocations, only: %i[index show]
-
-    resources :allocation_uplifts, only: %i[edit update create new]
+    resources :allocations, only: %i[index show] do
+      resources :uplifts, only: %i[edit update create new], controller: :allocation_uplifts
+    end
 
     resources :data_exports, path: "data-exports", only: [:index] do
       member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
     end
     resources :users, only: %i[index show new create]
 
+    resources :allocations, only: %i[index]
+
     resources :data_exports, path: "data-exports", only: [:index] do
       member do
         post :download

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -4,3 +4,6 @@ environment:
   name: "review"
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+authentication:
+  secret: secret
+  mode: persona

--- a/spec/factories/allocations.rb
+++ b/spec/factories/allocations.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     association :accredited_body, factory: %i(provider accredited_body)
     association :provider
     number_of_places { 0 }
-    recruitment_cycle { RecruitmentCycle.current }
+    association :recruitment_cycle, :current_allocation, strategy: :find_or_create
 
     provider_code { provider.provider_code }
     accredited_body_code { accredited_body.provider_code }

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -11,5 +11,9 @@ FactoryBot.define do
     trait :next do
       year { (Settings.current_recruitment_cycle_year.to_i + 1).to_s }
     end
+
+    trait :current_allocation do
+      year { Settings.allocation_cycle_year }
+    end
   end
 end

--- a/spec/features/support/allocations/allocation_edit_spec.rb
+++ b/spec/features/support/allocations/allocation_edit_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Edit an Allocation Uplift" do
+  before do
+    given_i_am_authenticated(user: create(:user, :admin))
+    and_there_are_providers_with_allocations
+    when_i_visit_the_allocation_edit_page
+  end
+
+  scenario "i can edit the allocation amount" do
+    then_i_can_edit_their_allocation_amount
+    and_i_click_continue
+    and_i_get_redirected_to_allocation_show_page
+    with_a_success_message
+    and_the_allocation_has_updated
+  end
+
+private
+
+  def and_there_are_providers_with_allocations
+    @provider = create(:provider)
+    @allocation = create(:allocation, provider: @provider, number_of_places: 5, confirmed_number_of_places: 5)
+  end
+
+  def when_i_visit_the_allocation_edit_page
+    allocation_edit_page.load(id: @allocation.id)
+  end
+
+  def then_i_can_edit_their_allocation_amount
+    @confirmed_number_of_places = 500
+    allocation_edit_page.confirmed_number_of_places.set(@confirmed_number_of_places)
+  end
+
+  def and_i_click_continue
+    allocation_edit_page.submit.click
+  end
+
+  def and_i_get_redirected_to_allocation_show_page
+    expect(allocations_show_page).to be_displayed(id: @allocation.id)
+  end
+
+  def with_a_success_message
+    expect(allocations_show_page).to have_content "Allocation was successfully updated"
+  end
+
+  def and_the_allocation_has_updated
+    @allocation.reload
+    expect(@allocation.confirmed_number_of_places).to eq @confirmed_number_of_places
+  end
+end

--- a/spec/features/support/allocations/allocation_uplift_edit_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_edit_spec.rb
@@ -18,6 +18,7 @@ feature "Edit an Allocation Uplift" do
     then_i_can_edit_their_allocation_uplift_amount
     and_i_click_continue
     and_i_get_redirected_to_allocation_show_page
+    with_a_success_message
     and_the_allocation_has_updated
   end
 
@@ -41,6 +42,10 @@ private
 
   def and_i_get_redirected_to_allocation_show_page
     expect(allocations_show_page).to be_displayed(id: allocation.id)
+  end
+
+  def with_a_success_message
+    expect(allocations_show_page).to have_content "Allocation Uplift was successfully updated"
   end
 
   def and_the_allocation_has_updated

--- a/spec/features/support/allocations/allocation_uplift_edit_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_edit_spec.rb
@@ -3,13 +3,8 @@
 require "rails_helper"
 
 feature "Edit an Allocation Uplift" do
-  let(:user) { create(:user, :admin) }
-  let(:provider) { create(:provider) }
-  let(:allocation) { create(:allocation, :with_allocation_uplift, provider: provider, number_of_places: 5) }
-  let(:new_allocation_uplift) { 500 }
-
   before do
-    given_i_am_authenticated(user: user)
+    given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_providers_with_allocations_and_uplifts
     when_i_visit_the_allocation_uplift_edit_page
   end
@@ -25,15 +20,17 @@ feature "Edit an Allocation Uplift" do
 private
 
   def and_there_are_providers_with_allocations_and_uplifts
-    allocation
+    @provider = create(:provider)
+    @allocation = create(:allocation, :with_allocation_uplift, provider: @provider, number_of_places: 5)
   end
 
   def when_i_visit_the_allocation_uplift_edit_page
-    allocation_uplift_edit_page.load(uplift_id: allocation.allocation_uplift.id, allocation_id: allocation.id)
+    allocation_uplift_edit_page.load(uplift_id: @allocation.allocation_uplift.id, allocation_id: @allocation.id)
   end
 
   def then_i_can_edit_their_allocation_uplift_amount
-    allocation_uplift_edit_page.allocation_uplift_amount.set(new_allocation_uplift)
+    @new_allocation_uplift = 500
+    allocation_uplift_edit_page.allocation_uplift_amount.set(@new_allocation_uplift)
   end
 
   def and_i_click_continue
@@ -41,7 +38,7 @@ private
   end
 
   def and_i_get_redirected_to_allocation_show_page
-    expect(allocations_show_page).to be_displayed(id: allocation.id)
+    expect(allocations_show_page).to be_displayed(id: @allocation.id)
   end
 
   def with_a_success_message
@@ -49,7 +46,7 @@ private
   end
 
   def and_the_allocation_has_updated
-    allocation.reload
-    expect(allocation.allocation_uplift.uplifts).to eq new_allocation_uplift
+    @allocation.reload
+    expect(@allocation.allocation_uplift.uplifts).to eq @new_allocation_uplift
   end
 end

--- a/spec/features/support/allocations/allocation_uplift_edit_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_edit_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Edit an Allocation Uplift" do
+  let(:user) { create(:user, :admin) }
+  let(:provider) { create(:provider) }
+  let(:allocation) { create(:allocation, :with_allocation_uplift, provider: provider, number_of_places: 5) }
+  let(:new_allocation_uplift) { 500 }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_there_are_providers_with_allocations_and_uplifts
+    when_i_visit_the_allocation_uplift_edit_page
+  end
+
+  scenario "i can edit the allocation uplift amount" do
+    then_i_can_edit_their_allocation_uplift_amount
+    and_i_click_continue
+    and_i_get_redirected_to_allocation_show_page
+    and_the_allocation_has_updated
+  end
+
+private
+
+  def and_there_are_providers_with_allocations_and_uplifts
+    allocation
+  end
+
+  def when_i_visit_the_allocation_uplift_edit_page
+    allocation_uplift_edit_page.load(uplift_id: allocation.allocation_uplift.id, allocation_id: allocation.id)
+  end
+
+  def then_i_can_edit_their_allocation_uplift_amount
+    allocation_uplift_edit_page.allocation_uplift_amount.set(new_allocation_uplift)
+  end
+
+  def and_i_click_continue
+    allocation_uplift_edit_page.submit.click
+  end
+
+  def and_i_get_redirected_to_allocation_show_page
+    expect(allocations_show_page).to be_displayed(id: allocation.id)
+  end
+
+  def and_the_allocation_has_updated
+    allocation.reload
+    expect(allocation.allocation_uplift.uplifts).to eq new_allocation_uplift
+  end
+end

--- a/spec/features/support/allocations/allocation_uplift_new_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_new_spec.rb
@@ -6,6 +6,7 @@ feature "Edit an Allocation Uplift" do
   let(:user) { create(:user, :admin) }
   let(:provider) { create(:provider) }
   let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
+  let(:allocation_uplift_amount) { 5 }
 
   before do
     given_i_am_authenticated(user: user)
@@ -17,6 +18,7 @@ feature "Edit an Allocation Uplift" do
     then_i_can_create_an_uplift
     and_i_click_continue
     and_i_get_redirected_to_allocation_show_page
+    with_a_success_message
     and_the_allocation_has_an_uplift
   end
 
@@ -32,7 +34,7 @@ private
 
   def then_i_can_create_an_uplift
     expect(allocation_uplift_new_page).to have_content "Create an Allocation Uplift for #{provider.provider_name}"
-    allocation_uplift_new_page.allocation_uplift_amount.set(5)
+    allocation_uplift_new_page.allocation_uplift_amount.set(allocation_uplift_amount)
   end
 
   def and_i_click_continue
@@ -43,8 +45,12 @@ private
     expect(allocations_show_page).to be_displayed(id: allocation.id)
   end
 
+  def with_a_success_message
+    expect(allocations_show_page).to have_content "Allocation Uplift was successfully created"
+  end
+
   def and_the_allocation_has_an_uplift
-    allocation.reload
     expect(allocation.allocation_uplift).to be_present
+    expect(allocation.allocation_uplift.uplifts).to eq allocation_uplift_amount
   end
 end

--- a/spec/features/support/allocations/allocation_uplift_new_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_new_spec.rb
@@ -3,13 +3,8 @@
 require "rails_helper"
 
 feature "Edit an Allocation Uplift" do
-  let(:user) { create(:user, :admin) }
-  let(:provider) { create(:provider) }
-  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
-  let(:allocation_uplift_amount) { 5 }
-
   before do
-    given_i_am_authenticated(user: user)
+    given_i_am_authenticated(user: create(:user, :admin))
     and_theres_a_provider_with_an_allocation_and_no_uplift
     when_i_visit_the_allocation_uplift_new_page
   end
@@ -25,16 +20,18 @@ feature "Edit an Allocation Uplift" do
 private
 
   def and_theres_a_provider_with_an_allocation_and_no_uplift
-    allocation
+    @provider = create(:provider)
+    @allocation = create(:allocation, provider: @provider, number_of_places: 5)
   end
 
   def when_i_visit_the_allocation_uplift_new_page
-    allocation_uplift_new_page.load(allocation_id: allocation.id)
+    allocation_uplift_new_page.load(allocation_id: @allocation.id)
   end
 
   def then_i_can_create_an_uplift
-    expect(allocation_uplift_new_page).to have_content "Create an Allocation Uplift for #{provider.provider_name}"
-    allocation_uplift_new_page.allocation_uplift_amount.set(allocation_uplift_amount)
+    @allocation_uplift_amount = 5
+    expect(allocation_uplift_new_page).to have_content "Create an Allocation Uplift for #{@provider.provider_name}"
+    allocation_uplift_new_page.allocation_uplift_amount.set(@allocation_uplift_amount)
   end
 
   def and_i_click_continue
@@ -42,7 +39,7 @@ private
   end
 
   def and_i_get_redirected_to_allocation_show_page
-    expect(allocations_show_page).to be_displayed(id: allocation.id)
+    expect(allocations_show_page).to be_displayed(id: @allocation.id)
   end
 
   def with_a_success_message
@@ -50,7 +47,7 @@ private
   end
 
   def and_the_allocation_has_an_uplift
-    expect(allocation.allocation_uplift).to be_present
-    expect(allocation.allocation_uplift.uplifts).to eq allocation_uplift_amount
+    expect(@allocation.allocation_uplift).to be_present
+    expect(@allocation.allocation_uplift.uplifts).to eq @allocation_uplift_amount
   end
 end

--- a/spec/features/support/allocations/allocation_uplift_new_spec.rb
+++ b/spec/features/support/allocations/allocation_uplift_new_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Edit an Allocation Uplift" do
+  let(:user) { create(:user, :admin) }
+  let(:provider) { create(:provider) }
+  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_theres_a_provider_with_an_allocation_and_no_uplift
+    when_i_visit_the_allocation_uplift_new_page
+  end
+
+  scenario "i can create a new uplift amount" do
+    then_i_can_create_an_uplift
+    and_i_click_continue
+    and_i_get_redirected_to_allocation_show_page
+    and_the_allocation_has_an_uplift
+  end
+
+private
+
+  def and_theres_a_provider_with_an_allocation_and_no_uplift
+    allocation
+  end
+
+  def when_i_visit_the_allocation_uplift_new_page
+    allocation_uplift_new_page.load(allocation_id: allocation.id)
+  end
+
+  def then_i_can_create_an_uplift
+    expect(allocation_uplift_new_page).to have_content "Create an Allocation Uplift for #{provider.provider_name}"
+    allocation_uplift_new_page.allocation_uplift_amount.set(5)
+  end
+
+  def and_i_click_continue
+    allocation_uplift_new_page.submit.click
+  end
+
+  def and_i_get_redirected_to_allocation_show_page
+    expect(allocations_show_page).to be_displayed(id: allocation.id)
+  end
+
+  def and_the_allocation_has_an_uplift
+    allocation.reload
+    expect(allocation.allocation_uplift).to be_present
+  end
+end

--- a/spec/features/support/allocations/allocations_list_spec.rb
+++ b/spec/features/support/allocations/allocations_list_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View providers" do
+  let(:user) { create(:user, :admin) }
+  let(:provider) { create(:provider) }
+  let(:provider2) { create(:provider) }
+  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
+  let(:allocation2) { create(:allocation, provider: provider2, number_of_places: 3) }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_there_are_providers_with_allocations_and_uplifts
+    when_i_visit_the_allocations_index_page
+  end
+
+  scenario "i can view the providers" do
+    then_i_see_the_providers_and_their_allocations
+  end
+
+  def and_there_are_providers_with_allocations_and_uplifts
+    allocation
+    allocation2
+  end
+
+  def when_i_visit_the_allocations_index_page
+    allocations_index_page.load
+  end
+
+  def then_i_see_the_providers_and_their_allocations
+    expect(allocations_index_page.providers.size).to eq(2)
+    expect(allocations_index_page).to have_content provider.provider_name
+  end
+end

--- a/spec/features/support/allocations/allocations_list_spec.rb
+++ b/spec/features/support/allocations/allocations_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "View providers" do
+feature "View allocations" do
   let(:user) { create(:user, :admin) }
   let(:provider) { create(:provider) }
   let(:provider2) { create(:provider) }
@@ -15,7 +15,7 @@ feature "View providers" do
     when_i_visit_the_allocations_index_page
   end
 
-  scenario "i can view the providers" do
+  scenario "i can view all providers and their allocations" do
     then_i_see_the_providers_and_their_allocations
   end
 

--- a/spec/features/support/allocations/allocations_list_spec.rb
+++ b/spec/features/support/allocations/allocations_list_spec.rb
@@ -3,14 +3,8 @@
 require "rails_helper"
 
 feature "View allocations" do
-  let(:user) { create(:user, :admin) }
-  let(:provider) { create(:provider) }
-  let(:provider2) { create(:provider) }
-  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
-  let(:allocation2) { create(:allocation, provider: provider2, number_of_places: 3) }
-
   before do
-    given_i_am_authenticated(user: user)
+    given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_providers_with_allocations_and_uplifts
     when_i_visit_the_allocations_index_page
   end
@@ -20,8 +14,10 @@ feature "View allocations" do
   end
 
   def and_there_are_providers_with_allocations_and_uplifts
-    allocation
-    allocation2
+    @provider = create(:provider)
+    @provider2 = create(:provider)
+    @allocation = create(:allocation, provider: @provider, number_of_places: 5)
+    @allocation2 = create(:allocation, provider: @provider2, number_of_places: 3)
   end
 
   def when_i_visit_the_allocations_index_page
@@ -30,6 +26,6 @@ feature "View allocations" do
 
   def then_i_see_the_providers_and_their_allocations
     expect(allocations_index_page.providers.size).to eq(2)
-    expect(allocations_index_page).to have_content provider.provider_name
+    expect(allocations_index_page).to have_content @provider.provider_name
   end
 end

--- a/spec/features/support/allocations/allocations_show_spec.rb
+++ b/spec/features/support/allocations/allocations_show_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View providers" do
+  let(:user) { create(:user, :admin) }
+  let(:provider) { create(:provider) }
+  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_there_are_providers_with_allocations_and_uplifts
+    when_i_visit_the_allocations_show_page
+  end
+
+  scenario "i can view the providers" do
+    then_i_see_the_provider_and_their_allocations
+  end
+
+private
+
+  def and_there_are_providers_with_allocations_and_uplifts
+    allocation
+  end
+
+  def when_i_visit_the_allocations_show_page
+    allocations_show_page.load(id: allocation.id)
+  end
+
+  def then_i_see_the_provider_and_their_allocations
+    expect(allocations_show_page).to have_content provider.provider_name
+    expect(allocations_show_page).to have_content "Allocations"
+    expect(allocations_show_page).to have_link "Change"
+  end
+end

--- a/spec/features/support/allocations/allocations_show_spec.rb
+++ b/spec/features/support/allocations/allocations_show_spec.rb
@@ -3,12 +3,8 @@
 require "rails_helper"
 
 feature "View an allocation" do
-  let(:user) { create(:user, :admin) }
-  let(:provider) { create(:provider) }
-  let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
-
   before do
-    given_i_am_authenticated(user: user)
+    given_i_am_authenticated(user: create(:user, :admin))
     and_there_are_providers_with_allocations_and_uplifts
     when_i_visit_the_allocations_show_page
   end
@@ -20,15 +16,16 @@ feature "View an allocation" do
 private
 
   def and_there_are_providers_with_allocations_and_uplifts
-    allocation
+    @provider = create(:provider)
+    @allocation = create(:allocation, provider: @provider, number_of_places: 5)
   end
 
   def when_i_visit_the_allocations_show_page
-    allocations_show_page.load(id: allocation.id)
+    allocations_show_page.load(id: @allocation.id)
   end
 
   def then_i_see_the_provider_and_their_allocations
-    expect(allocations_show_page).to have_content provider.provider_name
+    expect(allocations_show_page).to have_content @provider.provider_name
     expect(allocations_show_page).to have_content "Allocations"
     expect(allocations_show_page).to have_link "Change"
   end

--- a/spec/features/support/allocations/allocations_show_spec.rb
+++ b/spec/features/support/allocations/allocations_show_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "View providers" do
+feature "View an allocation" do
   let(:user) { create(:user, :admin) }
   let(:provider) { create(:provider) }
   let(:allocation) { create(:allocation, provider: provider, number_of_places: 5) }
@@ -13,7 +13,7 @@ feature "View providers" do
     when_i_visit_the_allocations_show_page
   end
 
-  scenario "i can view the providers" do
+  scenario "i can view the providers' allocations" do
     then_i_see_the_provider_and_their_allocations
   end
 

--- a/spec/services/allocations/update_spec.rb
+++ b/spec/services/allocations/update_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Allocations::Update do
         let(:provider) { create(:provider) }
         let(:accredited_body) { create(:provider, :accredited_body) }
         let(:previous_recruitment_cycle) do
-          create(:recruitment_cycle, year: RecruitmentCycle.current.year.to_i - 1)
+          create(:recruitment_cycle, year: Settings.allocation_cycle_year.to_i - 1)
         end
 
         let(:previous_number_of_places) { rand(1..99) }

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -46,6 +46,14 @@ module FeatureHelpers
       @allocations_show_page ||= PageObjects::Support::AllocationsShow.new
     end
 
+    def allocation_uplift_edit_page
+      @allocation_uplift_edit_page ||= PageObjects::Support::AllocationUpliftEdit.new
+    end
+
+    def allocation_uplift_new_page
+      @allocation_uplift_new_page ||= PageObjects::Support::AllocationUpliftNew.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -42,6 +42,10 @@ module FeatureHelpers
       @allocations_index_page ||= PageObjects::Support::AllocationsIndex.new
     end
 
+    def allocations_show_page
+      @allocations_show_page ||= PageObjects::Support::AllocationsShow.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -50,6 +50,10 @@ module FeatureHelpers
       @allocation_uplift_edit_page ||= PageObjects::Support::AllocationUpliftEdit.new
     end
 
+    def allocation_edit_page
+      @allocation_edit_page ||= PageObjects::Support::AllocationEdit.new
+    end
+
     def allocation_uplift_new_page
       @allocation_uplift_new_page ||= PageObjects::Support::AllocationUpliftNew.new
     end

--- a/spec/support/feature_helpers/pages.rb
+++ b/spec/support/feature_helpers/pages.rb
@@ -38,6 +38,10 @@ module FeatureHelpers
       @user_new_page ||= PageObjects::Support::UserNew.new
     end
 
+    def allocations_index_page
+      @allocations_index_page ||= PageObjects::Support::AllocationsIndex.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/page_objects/support/allocation_edit.rb
+++ b/spec/support/page_objects/support/allocation_edit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class AllocationEdit < PageObjects::Base
+      set_url "/support/allocations/{id}/edit"
+
+      element :confirmed_number_of_places, "#allocation-confirmed-number-of-places-field"
+      element :submit, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/support/allocation_uplift_edit.rb
+++ b/spec/support/page_objects/support/allocation_uplift_edit.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationUpliftEdit < PageObjects::Base
-      set_url "/support/allocation_uplifts/{uplift_id}/edit?allocation_id={allocation_id}"
+      set_url "/support/allocations/{allocation_id}/uplifts/{uplift_id}/edit"
 
       element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
       element :submit, ".govuk-button"

--- a/spec/support/page_objects/support/allocation_uplift_edit.rb
+++ b/spec/support/page_objects/support/allocation_uplift_edit.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class AllocationUpliftEdit < PageObjects::Base
+      set_url "/support/allocation_uplifts/{uplift_id}/edit?allocation_id={allocation_id}"
+
+      element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
+      element :submit, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/support/allocation_uplift_new.rb
+++ b/spec/support/page_objects/support/allocation_uplift_new.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class AllocationUpliftNew < PageObjects::Base
+      set_url "/support/allocation_uplifts/new?allocation_id={allocation_id}"
+
+      element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
+      element :submit, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/support/allocation_uplift_new.rb
+++ b/spec/support/page_objects/support/allocation_uplift_new.rb
@@ -3,7 +3,7 @@
 module PageObjects
   module Support
     class AllocationUpliftNew < PageObjects::Base
-      set_url "/support/allocation_uplifts/new?allocation_id={allocation_id}"
+      set_url "/support/allocations/{allocation_id}/uplifts/new"
 
       element :allocation_uplift_amount, "#allocation-uplift-uplifts-field"
       element :submit, ".govuk-button"

--- a/spec/support/page_objects/support/allocations_index.rb
+++ b/spec/support/page_objects/support/allocations_index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class AllocationsIndex < PageObjects::Base
+      set_url "/support/allocations"
+
+      def providers
+        page.find_all(".qa-provider_row")
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/allocations_show.rb
+++ b/spec/support/page_objects/support/allocations_show.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    class AllocationsShow < PageObjects::Base
+      set_url "/support/allocations/{id}"
+
+      element :change_link, ".govuk-link"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/GzEv6eFo/369-allow-support-users-to-edit-confirmed-allocation-numbers)

### Changes proposed in this pull request

- Add edit/update functionality to change allocation numbers on the Support console

### Guidance to review

- Go to the support console
- Click on the PE Allocations tab
- Choose a provider
- Click the Change link on the allocation number

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
