### PR TITLE
[0377] Added DSI prod for sandbox configs

### DIFF
--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -4,3 +4,12 @@ publish_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
 find_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
 environment:
   name: "sandbox"
+
+base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
+
+dfe_signin:
+  issuer: https://oidc.signin.education.gov.uk
+  secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
+  profile: https://profile.signin.education.gov.uk
+  base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
+  user_search_url: https://support.signin.education.gov.uk/users

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -11,5 +11,5 @@ dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
-  base_url: https://sandbox.publish-teacher-training-courses.service.gov.uk
+  base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users


### PR DESCRIPTION
### Context
The sandbox config was misaligned 

### Changes proposed in this pull request
Sandbox are aligned with DSI `prod` settings


### Guidance to review
They are aligned with DSI `prod` settings

https://github.com/DFE-Digital/publish-teacher-training/blob/master/config/settings/sandbox.yml

> Cannot really test locally as it's DSI is 3rd party

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [ ] Tested by running locally
