### PR TITLE
[368] Add delete user to support

### DIFF
--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -21,6 +21,14 @@ module Support
       end
     end
 
+    def destroy
+      if user.destroy
+        redirect_to support_users_path, flash: { success: "User successfully deleted" }
+      else
+        redirect_to support_users_path, flash: { success: "This user has already been deleted" }
+      end
+    end
+
   private
 
     def user_params

--- a/app/controllers/support/users_controller.rb
+++ b/app/controllers/support/users_controller.rb
@@ -22,7 +22,7 @@ module Support
     end
 
     def destroy
-      if user.destroy
+      if user.discard
         redirect_to support_users_path, flash: { success: "User successfully deleted" }
       else
         redirect_to support_users_path, flash: { success: "This user has already been deleted" }

--- a/app/views/support/users/show.html.erb
+++ b/app/views/support/users/show.html.erb
@@ -7,3 +7,8 @@
 <%= render "support/providers/list", providers: @providers %>
 
 <%= render Paginator::View.new(scope: @providers) %>
+
+<%= govuk_button_to("Delete this user",
+      support_user_path(@user),
+      method: :delete,
+      class: "govuk-button govuk-button--warning") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
       get :users, on: :member
       resources :courses, only: %i[index]
     end
-    resources :users, only: %i[index show new create]
+    resources :users, only: %i[index show new create destroy]
 
     resources :allocations, only: %i[index show] do
       resources :uplifts, only: %i[edit update create new], controller: :allocation_uplifts

--- a/spec/features/support/users/deleting_a_user_spec.rb
+++ b/spec/features/support/users/deleting_a_user_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Deleting a new user" do
+  before do
+    given_i_am_authenticated(user: create(:user, :admin))
+    and_a_user_exists_to_delete
+    when_i_visit_the_user_show_page(@user_to_delete.id)
+  end
+
+  scenario "Deleting a user record" do
+    when_i_click_the_delete_button
+    then_i_am_taken_to_the_user_index_page
+    with_a_success_message
+  end
+
+private
+
+  def and_a_user_exists_to_delete
+    @user_to_delete = create(:user)
+  end
+
+  def when_i_visit_the_user_show_page(user_id)
+    users_show_page.load(id: user_id)
+  end
+
+  def when_i_click_the_delete_button
+    users_show_page.delete_button.click
+  end
+
+  def then_i_am_taken_to_the_user_index_page
+    expect(users_index_page).to be_displayed
+  end
+
+  def with_a_success_message
+    expect(users_index_page).to have_content("User successfully deleted")
+  end
+end

--- a/spec/features/support/users/deleting_a_user_spec.rb
+++ b/spec/features/support/users/deleting_a_user_spec.rb
@@ -13,6 +13,7 @@ feature "Deleting a new user" do
     when_i_click_the_delete_button
     then_i_am_taken_to_the_user_index_page
     with_a_success_message
+    and_the_user_is_in_a_discarded_state
   end
 
 private
@@ -35,5 +36,10 @@ private
 
   def with_a_success_message
     expect(users_index_page).to have_content("User successfully deleted")
+  end
+
+  def and_the_user_is_in_a_discarded_state
+    @user_to_delete.reload
+    expect(@user_to_delete.discarded?).to eq true
   end
 end

--- a/spec/support/page_objects/support/user_show_page.rb
+++ b/spec/support/page_objects/support/user_show_page.rb
@@ -6,6 +6,8 @@ module PageObjects
       set_url "/support/users/{id}"
 
       sections :provider_rows, PageObjects::Sections::Provider, ".qa-provider_row"
+
+      element :delete_button, ".govuk-button"
     end
   end
 end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/x5QrpcuK/368-allow-users-to-be-deleted-in-the-support-ui)

### Changes proposed in this pull request

- Add delete user functionality to support console

### Guidance to review

- Go to support console
- select user tab
- select a user by clicking their email address
- scroll to bottom of page and click delete this user

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
