### PR TITLE
[xxx] AB name and code added to allocation support console

### DIFF
--- a/app/views/support/allocations/_list.html.erb
+++ b/app/views/support/allocations/_list.html.erb
@@ -1,8 +1,10 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-half">Provider name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Provider name</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Provider code</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Accredited Body Name</th>
+      <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Accredited Body Code</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Number of allocations</th>
       <th scope="col" class="govuk-table__header govuk-!-width-one-eighth">Number of Uplifts</th>
     </tr>
@@ -20,6 +22,18 @@
         <td class="govuk-table__cell">
           <span class="govuk-!-display-block govuk-!-margin-bottom-1">
             <%= provider.provider_code %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.allocations.last.accredited_body.provider_name %>
+          </span>
+        </td>
+
+        <td class="govuk-table__cell">
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+            <%= provider.allocations.last.accredited_body.provider_code %>
           </span>
         </td>
 

--- a/app/views/support/allocations/show.html.erb
+++ b/app/views/support/allocations/show.html.erb
@@ -15,8 +15,20 @@
   end
 
   component.row do |row|
+    row.key { "Provider Code" }
+    row.value { @allocation.provider.provider_code }
+    row.action(href: nil)
+  end
+
+  component.row do |row|
     row.key { "Accredited Body Name" }
     row.value { @allocation.accredited_body.provider_name }
+    row.action(href: nil)
+  end
+
+  component.row do |row|
+    row.key { "Accredited Body Code" }
+    row.value { @allocation.accredited_body.provider_code }
     row.action(href: nil)
   end
 


### PR DESCRIPTION
### Context

- Adding Accredited Body Name and Code to the allocation support soncole

### Changes proposed in this pull request

- Adding Accredited Body Name and Code to the allocation support soncole

### Guidance to review

- Go to support console
- Click on the PE Allocations tab
- View the changes on the table

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
