### PR TITLE
[0365]  Amended so that admin can set `send value` after course is published

### DIFF
--- a/app/controllers/api/v2/courses_controller.rb
+++ b/app/controllers/api/v2/courses_controller.rb
@@ -187,7 +187,7 @@ module API
 
       def update_course
         return unless course_params.values.present? || funding_type_params.present? || qualification_params.present?
-        return unless @course.course_params_assignable(course_params)
+        return unless @course.course_params_assignable(course_params, current_user.admin?)
 
         @course.assign_attributes(course_params)
         @course.save

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -536,8 +536,8 @@ class Course < ApplicationRecord
 
   # Ideally this would just use the validation, but:
   # https://github.com/rails/rails/issues/13971
-  def course_params_assignable(course_params)
-    assignable_after_publish(course_params) &&
+  def course_params_assignable(course_params, is_admin)
+    assignable_after_publish(course_params, is_admin) &&
       entry_requirements_assignable(course_params) &&
       qualification_assignable(course_params)
   end
@@ -646,8 +646,9 @@ private
     enrichments.max_by(&:created_at)
   end
 
-  def assignable_after_publish(course_params)
-    relevant_params = course_params.slice(:is_send, :applications_open_from, :application_start_date)
+  def assignable_after_publish(course_params, is_admin)
+    params_keys = [*(:is_send unless is_admin), :applications_open_from, :application_start_date]
+    relevant_params = course_params.slice(*params_keys)
 
     return true if relevant_params.empty? || !is_published?
 

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2240,49 +2240,49 @@ describe Course, type: :model do
   end
 
   describe "#course_params_assignable" do
+    let(:is_admin) { false }
+
     describe "when setting the entry requirement" do
       it "can assign a valid value" do
-        expect(course.course_params_assignable(maths: "equivalence_test")).to eq(true)
+        expect(course.course_params_assignable({ maths: "equivalence_test" }, is_admin)).to eq(true)
         expect(course.errors.messages).to eq({})
       end
 
       it "cannot be assigned an invalid value" do
-        expect(course.course_params_assignable(maths: "test")).to eq(false)
+        expect(course.course_params_assignable({ maths: "test" }, is_admin)).to eq(false)
         expect(course.errors.messages).to eq(maths: ["is invalid"])
       end
     end
 
     describe "when setting the qualification" do
       it "can assign a valid qualification" do
-        expect(course.course_params_assignable(qualification: "pgce_with_qts")).to eq(true)
+        expect(course.course_params_assignable({ qualification: "pgce_with_qts" }, is_admin)).to eq(true)
         expect(course.errors.messages).to eq({})
       end
 
       it "cannot assign invalid qualification" do
-        expect(course.course_params_assignable(qualification: "invalid")).to eq(false)
+        expect(course.course_params_assignable({ qualification: "invalid" }, is_admin)).to eq(false)
         expect(course.errors.messages).to eq(qualification: ["is invalid"])
       end
     end
 
     describe "for publishing" do
-      let(:user) { create(:user) }
-
       context "when not published" do
         let(:enrichment) { create(:course_enrichment, :initial_draft) }
         let(:course) { create(:course, enrichments: [enrichment]) }
 
         it "can assign to SEND" do
-          expect(course.course_params_assignable(is_send: true)).to eq(true)
+          expect(course.course_params_assignable({ is_send: true }, is_admin)).to eq(true)
           expect(course.errors.messages).to eq({})
         end
 
         it "can assign to applications open from" do
-          expect(course.course_params_assignable(applications_open_from: "25/08/2019")).to eq(true)
+          expect(course.course_params_assignable({ applications_open_from: "25/08/2019" }, is_admin)).to eq(true)
           expect(course.errors.messages).to eq({})
         end
 
         it "can assign to applications open from" do
-          expect(course.course_params_assignable(application_start_date: "25/08/2019")).to eq(true)
+          expect(course.course_params_assignable({ application_start_date: "25/08/2019" }, is_admin)).to eq(true)
           expect(course.errors.messages).to eq({})
         end
       end
@@ -2292,18 +2292,27 @@ describe Course, type: :model do
         let(:course) { create(:course, enrichments: [enrichment]) }
 
         it "cannot assign to SEND" do
-          expect(course.course_params_assignable(is_send: true)).to eq(false)
+          expect(course.course_params_assignable({ is_send: true }, is_admin)).to eq(false)
           expect(course.errors.messages).to eq(is_send: ["cannot be changed after publish"])
         end
 
         it "cannot assign to applications open from" do
-          expect(course.course_params_assignable(applications_open_from: "25/08/2019")).to eq(false)
+          expect(course.course_params_assignable({ applications_open_from: "25/08/2019" }, is_admin)).to eq(false)
           expect(course.errors.messages).to eq(applications_open_from: ["cannot be changed after publish"])
         end
 
         it "cannot assign to applications open from" do
-          expect(course.course_params_assignable(application_start_date: "25/08/2019")).to eq(false)
+          expect(course.course_params_assignable({ application_start_date: "25/08/2019" }, is_admin)).to eq(false)
           expect(course.errors.messages).to eq(application_start_date: ["cannot be changed after publish"])
+        end
+
+        context "is_admin is set to true" do
+          let(:is_admin) { true }
+
+          it "can assign to SEND" do
+            expect(course.course_params_assignable({ is_send: true }, is_admin)).to eq(true)
+            expect(course.errors.messages).to eq({})
+          end
         end
       end
     end


### PR DESCRIPTION
### Context
Admin can set `send value` after course is published
### Changes proposed in this pull request
Amended so that admin can set `send value` after course is published

### Guidance to review
This PR is standalone but lays the ground works for

https://github.com/DFE-Digital/publish-teacher-training/pull/1999
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
