### PR TITLE
Add 'changed_at' to SerializableCourse 'jsonapi_cache_key'

### DIFF
--- a/app/serializers/api/v3/serializable_course.rb
+++ b/app/serializers/api/v3/serializable_course.rb
@@ -2,7 +2,7 @@ module API
   module V3
     class SerializableCourse < JSONAPI::Serializable::Resource
       include TimeFormat
-      include JsonapiCacheKeyHelper
+      include JsonapiCourseCacheKeyHelper
 
       class << self
         def enrichment_attribute(name, enrichment_name = name)

--- a/app/serializers/jsonapi_course_cache_key_helper.rb
+++ b/app/serializers/jsonapi_course_cache_key_helper.rb
@@ -1,0 +1,7 @@
+module JsonapiCourseCacheKeyHelper
+  # When a course has sites updated the course's 'changed_at' field is touched
+  # We need to add the 'changed_at' value to the cache key so that the cache is refreshed
+  def jsonapi_cache_key(options)
+    "#{self.class}/#{@object.cache_key_with_version}/#{@object.changed_at} " + super(options)
+  end
+end


### PR DESCRIPTION
### Context
We currently have caching on the [V3 Courses Controller](https://github.com/DFE-Digital/teacher-training-api/blob/master/app/controllers/api/v3/courses_controller.rb#L16).

However, when a provider updates a course’s locations in Publish (eg adds a site) the cache does not expire and the updated sites are not showing on the results page in Find (_Nearest of X locations to choose from_  has the wrong total)

This is because when a course is touched `#updated_changed_at` only updates the `changed_at` column in the course table and the ~`jsonapi_rails` gem~ custom cache key we specify for jsonapi_rails expects the `updated_at` column to be updated.

### Changes proposed in this pull request

- Create `JsonapiCourseCacheKeyHelper` and include this helper in the SerializableCourse class. This adds the 'changed_at' value to the cache key so that the cache is refreshed

### Guidance to review

Slack discussion - https://ukgovernmentdfe.slack.com/archives/C02D2L94TPH/p1637680981004500

### Trello
https://trello.com/c/Eb5xaR9n/4144-bug-locations-bug

### Checklist

- [x] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
