### PR TITLE
[0289] Remove accredited body salary validation

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -20,8 +20,6 @@ class Course < ApplicationRecord
             uniqueness: { scope: :provider_id },
             on: %i[create update]
 
-  validate :self_accredited_cannot_be_salary_funded
-
   enum program_type: {
     higher_education_programme: "HE",
     school_direct_training_programme: "SD",
@@ -523,7 +521,7 @@ class Course < ApplicationRecord
   end
 
   def self_accredited?
-    provider&.accredited_body?
+    provider.accredited_body?
   end
 
   def to_s
@@ -866,10 +864,6 @@ private
     @services.register(:content_status) do
       Courses::ContentStatusService.new
     end
-  end
-
-  def self_accredited_cannot_be_salary_funded
-    errors.add(:program_type, "Salary is not valid for a self accredited course") if self_accredited? && funding_type == "salary"
   end
 
   def accredited_body_exists_in_current_cycle

--- a/spec/models/course/assign_program_type_spec.rb
+++ b/spec/models/course/assign_program_type_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe Course, type: :model do
       context "a self accredited course" do
         let(:subject) { create(:course, :self_accredited) }
 
-        it "adds an error to the course object" do
-          expect(subject.errors.count).to eq 1
-          expect(subject.errors.messages[:program_type].first).to eq "Salary is not valid for a self accredited course"
+        it "does not error course object when updated to salaried course" do
+          subject.update(program_type: "school_direct_salaried_training_programme")
+          expect(subject.errors.count).to eq 0
         end
       end
     end

--- a/spec/models/course/funding_type_spec.rb
+++ b/spec/models/course/funding_type_spec.rb
@@ -2,15 +2,6 @@ require "rails_helper"
 
 RSpec.describe Course, type: :model do
   describe "#funding_type" do
-    describe "self accredited salary" do
-      let(:course) { create(:course, :self_accredited) }
-
-      it "adds an error" do
-        course.funding_type = "salary"
-        expect(course.errors.messages[:program_type]).to eq(["Salary is not valid for a self accredited course"])
-      end
-    end
-
     describe "higher education programme" do
       subject { create(:course, :with_higher_education) }
 

--- a/spec/services/courses/assign_program_type_service_spec.rb
+++ b/spec/services/courses/assign_program_type_service_spec.rb
@@ -20,14 +20,6 @@ describe Courses::AssignProgramTypeService do
         expect(course.program_type).to eq("school_direct_salaried_training_programme")
       end
     end
-
-    context "when the course is self accredited" do
-      let(:course) { create(:course, :self_accredited) }
-
-      it "an error should be added to the course object" do
-        expect(course.errors["program_type"].first).to eq("Salary is not valid for a self accredited course")
-      end
-    end
   end
 
   context "when the funding_type is apprenticeship" do


### PR DESCRIPTION
### Context

https://trello.com/c/Ihd5u7WM/289-bug-invalid-course-2vvz-cannot-be-edited

Sentry error triggered by validation of course with accredited body and salary.

After discussion with Matilde and Gaby it turns out that this is not 
required for editing a course. The ability for providers to create 
salaried courses does not exist so this should only affect those merged 
in recently.

### Changes proposed in this pull request

Removal of validation and assocaited tests

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
