### PR TITLE
[411] Course financial incentives scoped to first subject

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -499,7 +499,7 @@ class Course < ApplicationRecord
   end
 
   def has_bursary?
-    !bursary_amount.nil?
+    bursary_amount.present?
   end
 
   def has_scholarship_and_bursary?
@@ -507,11 +507,11 @@ class Course < ApplicationRecord
   end
 
   def has_scholarship?
-    !scholarship_amount.nil?
+    scholarship_amount.present?
   end
 
   def has_early_career_payments?
-    !financial_incentive&.early_career_payments.nil?
+    financial_incentive&.early_career_payments.present?
   end
 
   def bursary_amount

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -523,7 +523,10 @@ class Course < ApplicationRecord
   end
 
   def financial_incentive
-    subjects.first.financial_incentive
+    # Ignore "modern languages" as financial incentives
+    # differ based on the language selected
+
+    subjects.reject { |subject| subject.subject_name == "Modern Languages" }.first.financial_incentive
   end
 
   def self_accredited?

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -499,27 +499,31 @@ class Course < ApplicationRecord
   end
 
   def has_bursary?
-    financial_incentives.any?(&:bursary_amount?)
+    !bursary_amount.nil?
   end
 
   def has_scholarship_and_bursary?
-    financial_incentives.any?(&:scholarship?) && financial_incentives.any?(&:bursary_amount?)
+    has_scholarship? && has_bursary?
   end
 
   def has_scholarship?
-    financial_incentives.any?(&:scholarship?)
+    !scholarship_amount.nil?
   end
 
   def has_early_career_payments?
-    financial_incentives.any?(&:early_career_payments?)
+    !financial_incentive&.early_career_payments.nil?
   end
 
   def bursary_amount
-    financial_incentives&.first&.bursary_amount
+    financial_incentive&.bursary_amount
   end
 
   def scholarship_amount
-    financial_incentives&.first&.scholarship
+    financial_incentive&.scholarship
+  end
+
+  def financial_incentive
+    subjects.first.financial_incentive
   end
 
   def self_accredited?

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -1913,12 +1913,6 @@ describe Course, type: :model do
 
         subject { create(:course, :skip_validate, level: "secondary", subjects: [modern_languages, french, german, spanish]) }
 
-        before do
-          french_financial_incentive
-          german_financial_incentive
-          spanish_financial_incentive
-        end
-
         it "reads financial incentives from only the first subject, and ignores the 'Modern Languages' subject" do
           expect(subject.bursary_amount).to eq french.financial_incentive.bursary_amount
           expect(subject.has_bursary?).to eq true


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/VoUTfJmm/411-ensure-the-financial-incentive-is-only-applied-to-the-first-major-subject-on-a-course)

### Changes proposed in this pull request

- Courses have `financial_incentives`. While the relationship is correct, we only need to worry about the incentive of the *main*, or first subject
- This PR changes so it only worries about the first `financial_incentive` (note the lack of pluralisation) on the first, or *main* subject, rather than checking through each subject for an incentive. 

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
