### PR TITLE
[397] Fix Stats service to pass in correct cycle

### DIFF
--- a/app/services/statistic_service.rb
+++ b/app/services/statistic_service.rb
@@ -4,7 +4,7 @@ class StatisticService
       providers: ProviderReportingService.call(providers_scope: recruitment_cycle.providers),
       courses: CourseReportingService.call(courses_scope: recruitment_cycle.courses),
       publish: PublishReportingService.call(recruitment_cycle_scope: recruitment_cycle),
-      allocations: AllocationReportingService.call(recruitment_cycle_scope: recruitment_cycle),
+      allocations: AllocationReportingService.call(recruitment_cycle_scope: RecruitmentCycle.find_by(year: Settings.allocation_cycle_year)),
       rollover: RolloverReportingService.call,
     }
   end

--- a/spec/factories/recruitment_cycles.rb
+++ b/spec/factories/recruitment_cycles.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     trait :current_allocation do
       year { Settings.allocation_cycle_year }
     end
+
+    trait :previous_allocation_cycle do
+      year { (Settings.allocation_cycle_year - 1).to_s }
+    end
   end
 end

--- a/spec/requests/reporting_spec.rb
+++ b/spec/requests/reporting_spec.rb
@@ -179,17 +179,27 @@ describe "GET /reporting" do
     }.with_indifferent_access
   end
 
+  let(:recruitment_cycle) {
+    find_or_create(:recruitment_cycle)
+  }
+
   let(:previous_recruitment_cycle) {
     find_or_create(:recruitment_cycle, :previous)
   }
 
-  let(:next_recruitment_cycle) {
-    find_or_create(:recruitment_cycle, :next)
+  let(:allocation_recruitment_cycle) {
+    find_or_create(:recruitment_cycle, :current_allocation)
+  }
+
+  let(:previous_allocation_cycle) {
+    find_or_create(:recruitment_cycle, :previous_allocation_cycle)
   }
 
   it "returns status success" do
+    recruitment_cycle
     previous_recruitment_cycle
-    next_recruitment_cycle
+    allocation_recruitment_cycle
+    previous_allocation_cycle
     get "/reporting"
     expect(response.status).to eq(200)
     expect(JSON.parse(response.body)).to eq(expected)

--- a/spec/services/statistic_service_spec.rb
+++ b/spec/services/statistic_service_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 describe StatisticService do
   let(:recruitment_cycle) { find_or_create(:recruitment_cycle) }
   let!(:previous_recruitment_cycle) { find_or_create(:recruitment_cycle, :previous) }
+  let!(:allocation_recruitment_cycle) { find_or_create(:recruitment_cycle, :current_allocation) }
+  let!(:previous_allocation_cycle) { find_or_create(:recruitment_cycle, :previous_allocation_cycle) }
 
   describe "#reporting" do
     subject { described_class.reporting(recruitment_cycle: recruitment_cycle) }
@@ -23,7 +25,7 @@ describe StatisticService do
     end
 
     it "calls the allocation reporting service" do
-      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: allocation_recruitment_cycle)
       subject
     end
 
@@ -58,7 +60,7 @@ describe StatisticService do
     end
 
     it "calls the allocation reporting service" do
-      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: recruitment_cycle)
+      expect(AllocationReportingService).to receive(:call).with(recruitment_cycle_scope: allocation_recruitment_cycle)
       subject
     end
 


### PR DESCRIPTION
### Context

The statistics for allocations on the performance Dashboard are coming 
through incorrectly. After looking into this the service is workingas it 
should be. It's just that because Allocations take place in June/July 
i.e. before cycle starts they are associated with previous year's 
recruitment cycle. 

### Changes proposed in this pull request

The quick fix here is to pass in the previous year.  I've done this and run the numbers past Adam who says they all look as 
expect for the previous and current cycles.

### Guidance to review

Would this need a feature/system spec?

or should we backfill all of the allocations to match the revruitment cycle they are for?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
