### PR TITLE
Add additional Persona users

### DIFF
--- a/app/components/persona/view.html.erb
+++ b/app/components/persona/view.html.erb
@@ -1,15 +1,6 @@
-<h2 class="govuk-heading-m">Colin</h2>
-
-  <p class="govuk-body"><%= govuk_tag(text: "Admin", colour: "blue") %></p>
-
-  <p class="govuk-body">
-    Colin is a DfE support agent who has administrator access to all organisations.
-  </p>
-</h2>
-
 <%= form_tag("/auth/developer/callback") do %>
   <%= hidden_field_tag "email", email_address %>
   <%= hidden_field_tag "first_name", first_name %>
   <%= hidden_field_tag "last_name", last_name %>
-  <%= submit_tag "Login as Colin", class: "govuk-button govuk-!-margin-bottom-2" %>
+  <%= submit_tag "Login as #{last_name}", class: "govuk-button govuk-!-margin-bottom-2" %>
 <% end %>

--- a/app/views/personas/index.html.erb
+++ b/app/views/personas/index.html.erb
@@ -1,15 +1,65 @@
 <% content_for :page_title, I18n.t("components.page_titles.sign_in.personas") %>
 
-<h1 class="govuk-heading-xl">
-  <span class="govuk-caption-xl">
-    Teacher Training API
-  </span>
-  Personas
-</h1>
+<h1 class="govuk-heading-l">Publish test users</h1>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
-<%= render Persona::View.new(email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
-                              first_name: "Support agent",
-                              last_name: "Colin")
-%>
+<h2 class="govuk-heading-m">Anne</h2>
+<p class="govuk-body"><%= govuk_tag(text: "School Direct", colour: "blue") %></p>
+<p class="govuk-body">
+  Anne is a course administrator who belongs to one school direct.
+</p>
+<%= render Persona::View.new(
+  email_address: "anonimized-user-10599@example.org",
+  first_name: "Course administrator",
+  last_name: "Anne"
+) %>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Susy</h2>
+<p class="govuk-body"><%= govuk_tag(text: "Accredited body", colour: "blue") %></p>
+<p class="govuk-body">
+  Susy is a SCITT service manager who belongs to one accredited body.
+</p>
+<%= render Persona::View.new(
+  email_address:  "anonimized-user-8847@example.org",
+  first_name:  "ITT partnership manager",
+  last_name: "Susy"
+) %>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Mary</h2>
+<p class="govuk-body">
+  <%= govuk_tag(text: "Multi-org", colour: "blue") %>
+  <%= govuk_tag(text: "Accredited body", colour: "blue") %>
+  <%= govuk_tag(text: "School Direct", colour: "blue") %>
+</p>
+<p class="govuk-body">
+  Mary is a SCITT Business Support Coordinator who belongs to:
+</p>
+<ul class="govuk-list govuk-list--bullet">
+  <li>multiple accredited bodies, <strong>Suffolk and Norfolk Primary SCITT</strong> and <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+  <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses accredited by <strong>Suffolk and Norfolk Secondary SCITT</strong></li>
+  <li>a school direct <strong>Thorpe St Andrew School and Sixth Form</strong> with courses also accredited by an organisation not associated with Mary</li>
+</ul>
+
+<%= render Persona::View.new(
+  email_address: "anonimized-user-7839@example.org",
+  first_name:  "Multi-org administrator",
+  last_name: "Mary"
+) %>
+
+<hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+<h2 class="govuk-heading-m">Colin</h2>
+<p class="govuk-body"><%= govuk_tag(text: "Admin", colour: "blue") %></p>
+<p class="govuk-body">
+  Colin is a DfE support agent who has administrator access to all organisations.
+</p>
+<%= render Persona::View.new(
+  email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
+  first_name: "Support agent",
+  last_name: "Colin"
+) %>

--- a/spec/features/auth/persona_spec.rb
+++ b/spec/features/auth/persona_spec.rb
@@ -2,15 +2,23 @@
 
 require "rails_helper"
 
-feature "sign in page" do
-  before do
+feature "Authentication with Personas" do
+  scenario "Sign in with a persona" do
+    given_persona_based_authentication_is_active
+    when_i_go_to_sign_in
+    then_i_am_given_the_option_to_sign_in_with_a_persona
+  end
+
+  def given_persona_based_authentication_is_active
     allow(AuthenticationService).to receive(:mode).and_return("persona")
+  end
+
+  def when_i_go_to_sign_in
     sign_in_page.load
   end
 
-  scenario "navigate to persona when mode is 'persona'" do
+  def then_i_am_given_the_option_to_sign_in_with_a_persona
     expect(sign_in_page).to have_text("Use Personas to access an account.")
-    expect(sign_in_page).to have_title("Sign in - Teacher Training API Admin")
     expect(sign_in_page).to have_link("Sign in using a Persona")
   end
 end


### PR DESCRIPTION


### Context
A persona-based authentication mode exists for use in development and
QA. Currently this supports sign in of a support user only.

https://trello.com/c/Ghmij2De

### Changes proposed in this pull request

Enhance this with additional users ported across from the Publish
app. Each of these users maps to an anonymised account in the TTAPI
database dump available on Github.

### Guidance to review
- Can be accessed via `/sign-in` when running locally with persona auth mode enabled.
- Doesn't do much right now — you'll go to support if you sign in as Colin, everyone else will go to the blank Publish holding page.
- Have retained (but re-written) the lightweight feature spec that was already there. This is probably sufficient given this is an internally-facing bit of functionality. Also, our route definitions don't define the developer-mode endpoints unless the app is started in persona mode (rightly, imo), so we'd have to rewrite route definitions on the fly to test an actual persona sign in. Not worth the additional complexity I think.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [ ] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
