### PR TITLE
[319] Update pagy gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "active_model_serializers"
 gem "kaminari"
 
 # Pagination for API
-gem "pagy", "~> 3.13"
+gem "pagy", "~> 5.1"
 
 # JSON:API Ruby Client
 gem "jsonapi-rails", github: "DFE-Digital/jsonapi-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -387,7 +387,7 @@ GEM
       webfinger (>= 1.0.1)
     optimist (3.0.1)
     os (1.1.4)
-    pagy (3.13.0)
+    pagy (5.6.3)
     parallel (1.21.0)
     parallel_tests (3.7.3)
       parallel
@@ -690,7 +690,7 @@ DEPENDENCIES
   open_api-rswag-api
   open_api-rswag-specs
   open_api-rswag-ui
-  pagy (~> 3.13)
+  pagy (~> 5.1)
   parallel_tests
   pg
   pg_search

--- a/app/controllers/concerns/pagy_pagination.rb
+++ b/app/controllers/concerns/pagy_pagination.rb
@@ -16,7 +16,7 @@ private
   attr_accessor :pagy_results
 
   def pagination_links
-    meta = pagy_metadata(pagy_results.first, urls: true)
+    meta = pagy_metadata(pagy_results.first)
 
     {
       first: meta[:first_url],

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe API::Public::V1::CoursesController do
           let(:last_page) { 3 }
 
           let(:url_prefix) do
-            "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/courses?page="
+            "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/courses?page="
           end
 
           context "page 1" do

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
         let(:last_page) { 3 }
 
         let(:url_prefix) do
-          "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}/courses?page="
+          "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}/courses?page="
         end
 
         context "page 1" do

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe API::Public::V1::ProvidersController do
           let(:last_page) { 3 }
 
           let(:url_prefix) do
-            "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?page="
+            "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?page="
           end
 
           context "page 1" do


### PR DESCRIPTION
### Context

Dependabot failed to update the Pagy gem as it introduced breaking changes

### Changes proposed in this pull request

After updating the gem locally it looks as if certain syntax around Pagy has been updated. There's no longer a need to specify `urls: true` in concerns.  Also, there is no longer a need to include a fake protocol and domain of `http://test.host` for url prefixes in tests that use the gem.

### Guidance to review

Have I overlooked anything?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
