### PR TITLE
[xxx] Make metadata links absolute

### DIFF
--- a/app/controllers/concerns/pagy_pagination.rb
+++ b/app/controllers/concerns/pagy_pagination.rb
@@ -16,7 +16,7 @@ private
   attr_accessor :pagy_results
 
   def pagination_links
-    meta = pagy_metadata(pagy_results.first)
+    meta = pagy_metadata(pagy_results.first, absolute: true)
 
     {
       first: meta[:first_url],

--- a/spec/controllers/api/public/v1/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/courses_controller_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe API::Public::V1::CoursesController do
           let(:last_page) { 3 }
 
           let(:url_prefix) do
-            "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/courses?page="
+            "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/courses?page="
           end
 
           context "page 1" do

--- a/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers/courses_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe API::Public::V1::Providers::CoursesController do
         let(:last_page) { 3 }
 
         let(:url_prefix) do
-          "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}/courses?page="
+          "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers/#{provider.provider_code}/courses?page="
         end
 
         context "page 1" do

--- a/spec/controllers/api/public/v1/providers_controller_spec.rb
+++ b/spec/controllers/api/public/v1/providers_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe API::Public::V1::ProvidersController do
           let(:last_page) { 3 }
 
           let(:url_prefix) do
-            "/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?page="
+            "http://test.host/api/public/v1/recruitment_cycles/#{recruitment_cycle.year}/providers?page="
           end
 
           context "page 1" do


### PR DESCRIPTION
### Context

We updated the Pagy gem recently and the the update removed the hostname
prefix from the metadata pagination links which is a breaking change to
the API and not what we wanted. This change puts the full absolute links
back.

### Changes proposed in this pull request

* Add `absolute: true` argument for pagy metadata

### Guidance to review

Run the API -> http://localhost:3001/api/public/v1/courses should have absolute pagination links.

<img width="804" alt="Screenshot 2021-12-02 at 15 45 16" src="https://user-images.githubusercontent.com/5216/144454809-1cfaaa29-fa2f-4cc6-9263-0ae3350342d1.png">

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
