### PR TITLE
[376] Add to search via course code to Providers list on support

### DIFF
--- a/app/components/providers/filters/view.html.erb
+++ b/app/components/providers/filters/view.html.erb
@@ -11,7 +11,7 @@
 
       <!-- Div made focusable to 'catch' focus from filters. see https://github.com/DFE-Digital/apply-for-teacher-training/pull/2640 -->
       <div class="moj-filter__content" tabindex="-1">
-        <% if filters %>
+        <% if filters.present? %>
           <div class="moj-filter__selected">
             <div class="moj-filter__selected-heading">
               <div class="moj-filter__heading-title">
@@ -25,14 +25,22 @@
             </div>
 
             <% filters.each do |filter, value| %>
-              <h3 class="govuk-heading-s govuk-!-margin-bottom-0"><%= filter_label %></h3>
-              <ul class="moj-filter-tags">
-                <% tags_for_filter(filter, value).each do |tag| %>
-                  <li>
-                    <%= govuk_link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
-                  </li>
-                <% end %>
-              </ul>
+              <% if value.present? %>
+                <h3 class="govuk-heading-s govuk-!-margin-bottom-0">
+                  <% if course_search?(filter) %>
+                    <%= t("components.filter.providers.course_search") %>
+                  <% else %>
+                    <%= filter_label %>
+                  <% end %>
+                </h3>
+                <ul class="moj-filter-tags">
+                  <% tags_for_filter(filter, value).each do |tag| %>
+                    <li>
+                      <%= govuk_link_to(tag[:title], tag[:remove_link], class: "moj-filter__tag", draggable: "false") %>
+                    </li>
+                  <% end %>
+                </ul>
+              <% end %>
             <% end %>
           </div>
         <% end %>
@@ -41,10 +49,21 @@
           <form method="get">
             <%= submit_tag "Apply filters", class: "govuk-button" %>
 
-            <div class="govuk-form-group">
-              <%= label_tag "text_search", filter_label, class: "govuk-label govuk-label--s" %>
-              <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
-            </div>
+            <% if providers_list? %>
+              <div class="govuk-form-group">
+                <%= label_tag "provider_search", filter_label, class: "govuk-label govuk-label--s" %>
+                <%= text_field_tag "provider_search", (filters[:provider_search] if filters), spellcheck: false, class: "govuk-input" %>
+              </div>
+              <div class="govuk-form-group">
+                <%= label_tag "course_search", t("components.filter.providers.course_search"), class: "govuk-label govuk-label--s" %>
+                <%= text_field_tag "course_search", (filters[:course_search] if filters), spellcheck: false, class: "govuk-input" %>
+              </div>
+            <% else %>
+              <div class="govuk-form-group">
+                <%= label_tag "text_search", filter_label, class: "govuk-label govuk-label--s" %>
+                <%= text_field_tag "text_search", (filters[:text_search] if filters), spellcheck: false, class: "govuk-input" %>
+              </div>
+            <% end %>
           </form>
         </div>
       </div>

--- a/app/components/providers/filters/view.rb
+++ b/app/components/providers/filters/view.rb
@@ -17,6 +17,14 @@ module Providers
 
     private
 
+      def providers_list?
+        filter_label == t("components.filter.providers.provider_search")
+      end
+
+      def course_search?(filter)
+        filter == "course_search"
+      end
+
       def title_html(filter, value)
         tag.span("Remove ", class: "govuk-visually-hidden") + value + tag.span(" #{filter.humanize.downcase} filter", class: "govuk-visually-hidden")
       end

--- a/app/controllers/api/public/v1/provider_suggestions_controller.rb
+++ b/app/controllers/api/public/v1/provider_suggestions_controller.rb
@@ -7,7 +7,7 @@ module API
 
           found_providers = recruitment_cycle.providers
                               .with_findable_courses
-                              .search(params[:query])
+                              .provider_search(params[:query])
                               .limit(10)
 
           render(

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -63,7 +63,7 @@ module API
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         found_providers = policy_scope(@recruitment_cycle.providers)
-          .search(params[:query])
+          .provider_search(params[:query])
           .limit(5)
 
         render(
@@ -80,7 +80,7 @@ module API
         return render(status: :bad_request) unless begins_with_alphanumeric(params[:query])
 
         scope = @recruitment_cycle.providers
-                                  .search(params[:query])
+                                  .provider_search(params[:query])
                                   .limit(5)
 
         scope = scope.accredited_body if only_accredited_body_filter?

--- a/app/controllers/api/v3/provider_suggestions_controller.rb
+++ b/app/controllers/api/v3/provider_suggestions_controller.rb
@@ -8,7 +8,7 @@ module API
 
         found_providers = @recruitment_cycle.providers
                               .with_findable_courses
-                              .search(params[:query])
+                              .provider_search(params[:query])
                               .limit(10)
 
         render(

--- a/app/controllers/api/v3/providers_controller.rb
+++ b/app/controllers/api/v3/providers_controller.rb
@@ -10,7 +10,7 @@ module API
 
         build_fields_for_index
         @providers = @recruitment_cycle.providers.includes(:recruitment_cycle)
-        @providers = @providers.search(params[:search]) if params[:search].present?
+        @providers = @providers.provider_search(params[:search]) if params[:search].present?
 
         render jsonapi: @providers.by_name_ascending, class: { Provider: API::V3::SerializableProvider }, fields: @fields
       end

--- a/app/controllers/support/providers_controller.rb
+++ b/app/controllers/support/providers_controller.rb
@@ -66,7 +66,7 @@ module Support
     end
 
     def filter_params
-      params.permit(:text_search, :page, :commit)
+      params.permit(:provider_search, :course_search, :page, :commit)
     end
 
     def provider

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -168,6 +168,10 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_provider_name(provider_name))
   end
 
+  scope :case_insensitve_search, ->(course_code) do
+    where("lower(course.course_code) = ?", course_code.downcase)
+  end
+
   scope :changed_since, ->(timestamp) do
     if timestamp.present?
       changed_at_since(timestamp)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -168,7 +168,7 @@ class Course < ApplicationRecord
     joins(:provider).merge(Provider.by_provider_name(provider_name))
   end
 
-  scope :case_insensitve_search, ->(course_code) do
+  scope :case_insensitive_search, ->(course_code) do
     where("lower(course.course_code) = ?", course_code.downcase)
   end
 

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -89,17 +89,17 @@ class Provider < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
-  scope :provider_and_course_search, ->(
-    provider_name_or_code: search_params[:provider_name_or_code],
-    course_code: search_params[:course_code]) do
-                                       if course_code.blank?
-                                         search(provider_name_or_code)
-                                       elsif provider_name_or_code.blank?
-                                         joins(:courses).merge(Course.case_insensitve_search(course_code))
-                                       else
-                                         search(provider_name_or_code).joins(:courses).merge(Course.case_insensitve_search(course_code))
-                                       end
-                                     end
+  scope :search, ->(
+    provider_name_or_code: nil,
+    course_code: nil) do
+                   if course_code.blank?
+                     provider_search(provider_name_or_code)
+                   elsif provider_name_or_code.blank?
+                     course_code_search(course_code)
+                   else
+                     provider_search(provider_name_or_code).course_code_search(course_code)
+                   end
+                 end
 
   scope :by_name_ascending, -> { order(provider_name: :asc) }
   scope :by_name_descending, -> { order(provider_name: :desc) }
@@ -157,7 +157,7 @@ class Provider < ApplicationRecord
 
   before_discard { discard_courses }
 
-  pg_search_scope :search, against: %i(provider_code provider_name), using: { tsearch: { prefix: true } }
+  pg_search_scope :provider_search, against: %i(provider_code provider_name), using: { tsearch: { prefix: true } }
 
   accepts_nested_attributes_for :sites
   accepts_nested_attributes_for :organisations
@@ -291,6 +291,8 @@ class Provider < ApplicationRecord
   end
 
 private
+
+  scope :course_code_search, ->(course_code) { joins(:courses).merge(Course.case_insensitive_search(course_code)) }
 
   def accrediting_provider_enrichment(provider_code)
     accrediting_provider_enrichments&.find do |enrichment|

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -89,6 +89,18 @@ class Provider < ApplicationRecord
     end.order(:changed_at, :id)
   end
 
+  scope :provider_and_course_search, ->(
+    provider_name_or_code: search_params[:provider_name_or_code],
+    course_code: search_params[:course_code]) do
+                                       if course_code.blank?
+                                         search(provider_name_or_code)
+                                       elsif provider_name_or_code.blank?
+                                         joins(:courses).merge(Course.case_insensitve_search(course_code))
+                                       else
+                                         search(provider_name_or_code).joins(:courses).merge(Course.case_insensitve_search(course_code))
+                                       end
+                                     end
+
   scope :by_name_ascending, -> { order(provider_name: :asc) }
   scope :by_name_descending, -> { order(provider_name: :desc) }
 

--- a/app/models/provider_filter.rb
+++ b/app/models/provider_filter.rb
@@ -16,12 +16,23 @@ private
   attr_reader :params
 
   def merged_filters
-    @merged_filters ||= text_search.with_indifferent_access
+    @merged_filters ||= params.include?("text_search") ? text_search.with_indifferent_access : provider_and_course_search.with_indifferent_access
   end
 
   def text_search
     return {} if params[:text_search].blank?
 
-    { "text_search" => params[:text_search] }
+    {
+      "text_search" => params[:text_search],
+    }
+  end
+
+  def provider_and_course_search
+    return {} if params[:provider_search].blank? && params[:course_search].blank?
+
+    {
+      "provider_search" => params[:provider_search],
+      "course_search" => params[:course_search],
+    }
   end
 end

--- a/app/models/provider_filter.rb
+++ b/app/models/provider_filter.rb
@@ -16,23 +16,14 @@ private
   attr_reader :params
 
   def merged_filters
-    @merged_filters ||= params.include?("text_search") ? text_search.with_indifferent_access : provider_and_course_search.with_indifferent_access
+    @merged_filters ||= params.include?("text_search") ? text_search : provider_and_course_search
   end
 
   def text_search
-    return {} if params[:text_search].blank?
-
-    {
-      "text_search" => params[:text_search],
-    }
+    params.slice(:text_search)
   end
 
   def provider_and_course_search
-    return {} if params[:provider_search].blank? && params[:course_search].blank?
-
-    {
-      "provider_search" => params[:provider_search],
-      "course_search" => params[:course_search],
-    }
+    params.slice(:provider_search, :course_search)
   end
 end

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -19,6 +19,18 @@ module Support
 
     attr_reader :model_data_scope, :filters
 
+    def provider_and_course_search(model_data_scope, provider_search, course_search)
+      return model_data_scope if provider_search.blank? && course_search.blank?
+
+      if course_search.blank?
+        model_data_scope.search(provider_search)
+      elsif provider_search.blank?
+        model_data_scope.joins(:courses).where("lower(course.course_code) = ?", course_search.downcase)
+      else
+        model_data_scope.search(provider_search).joins(:courses).where("lower(course.course_code) = ?", course_search.downcase)
+      end
+    end
+
     def text_search(model_data_scope, text_search)
       return model_data_scope if text_search.blank?
 
@@ -26,7 +38,11 @@ module Support
     end
 
     def filter_model_data_scope
-      text_search(model_data_scope, filters[:text_search])
+      if filters.include?(:provider_search)
+        provider_and_course_search(model_data_scope, filters[:provider_search], filters[:course_search])
+      else
+        text_search(model_data_scope, filters[:text_search])
+      end
     end
   end
 end

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -19,16 +19,11 @@ module Support
 
     attr_reader :model_data_scope, :filters
 
-    def provider_and_course_search(model_data_scope, provider_search, course_search)
-      return model_data_scope if provider_search.blank? && course_search.blank?
+    def provider_and_course_search(model_data_scope, filters)
+      search_params = { provider_name_or_code: filters[:provider_search], course_code: filters[:course_search] }
+      return model_data_scope if filters.values.none?
 
-      if course_search.blank?
-        model_data_scope.search(provider_search)
-      elsif provider_search.blank?
-        model_data_scope.joins(:courses).where("lower(course.course_code) = ?", course_search.downcase)
-      else
-        model_data_scope.search(provider_search).joins(:courses).where("lower(course.course_code) = ?", course_search.downcase)
-      end
+      model_data_scope.provider_and_course_search(search_params)
     end
 
     def text_search(model_data_scope, text_search)
@@ -39,7 +34,7 @@ module Support
 
     def filter_model_data_scope
       if filters.include?(:provider_search)
-        provider_and_course_search(model_data_scope, filters[:provider_search], filters[:course_search])
+        provider_and_course_search(model_data_scope, filters)
       else
         text_search(model_data_scope, filters[:text_search])
       end

--- a/app/services/support/filter.rb
+++ b/app/services/support/filter.rb
@@ -19,22 +19,23 @@ module Support
 
     attr_reader :model_data_scope, :filters
 
-    def provider_and_course_search(model_data_scope, filters)
-      search_params = { provider_name_or_code: filters[:provider_search], course_code: filters[:course_search] }
-      return model_data_scope if filters.values.none?
+    def search(model_data_scope, filters)
+      return model_data_scope if filters.values.all?(&:blank?)
 
-      model_data_scope.provider_and_course_search(search_params)
+      search_params = { provider_name_or_code: filters[:provider_search], course_code: filters[:course_search] }
+
+      model_data_scope.search(**search_params)
     end
 
     def text_search(model_data_scope, text_search)
       return model_data_scope if text_search.blank?
 
-      model_data_scope.search(text_search)
+      model_data_scope.provider_search(text_search)
     end
 
     def filter_model_data_scope
       if filters.include?(:provider_search)
-        provider_and_course_search(model_data_scope, filters)
+        search(model_data_scope, filters)
       else
         text_search(model_data_scope, filters[:text_search])
       end

--- a/app/views/support/providers/index.html.erb
+++ b/app/views/support/providers/index.html.erb
@@ -8,6 +8,6 @@
       new_support_provider_path,
       class: "govuk-button govuk-!-margin-bottom-6") %>
 
-<%= render PaginatedFilter::View.new(filters: @filters, collection: @providers, filter_label: t("components.filter.providers.text_search")) do %>
+<%= render PaginatedFilter::View.new(filters: @filters, collection: @providers, filter_label: t("components.filter.providers.provider_search")) do %>
   <%= render "list", providers: @providers %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,7 +34,8 @@ en:
           index: "Data exports"
     filter:
       providers:
-        text_search: "Name or code"
+        provider_search: "Provider name or code"
+        course_search: "Course code"
       allocations:
         text_search: "Name or code"
       users:
@@ -106,7 +107,7 @@ en:
               blank: "is missing"
         course:
           attributes:
-            course_code: 
+            course_code:
               taken: "Course code is already taken"
               blank: "Course code cannot be blank"
             level:

--- a/spec/features/support/providers/providers_filter_spec.rb
+++ b/spec/features/support/providers/providers_filter_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "View filtered providers" do
+  let(:user) { create(:user, :admin) }
+
+  before do
+    given_i_am_authenticated(user: user)
+    and_there_are_providers
+    when_i_visit_the_provider_index_page
+  end
+
+  scenario "i can view and filter the providers" do
+    then_i_see_the_providers
+
+    when_i_filter_by_provider
+    then_i_see_providers_filtered_by_provider_name
+
+    when_i_remove_the_provider_filter
+    then_i_see_the_unfiltered_providers
+
+    when_i_filter_by_course_code
+    then_i_see_the_providers_filtered_by_course_code
+
+    when_i_remove_the_course_code_filter
+    then_i_see_the_unfiltered_providers
+
+    when_i_filter_by_provider_code_and_course_code
+    then_i_see_the_providers_filtered_by_provider_code_and_course_code
+
+    when_i_remove_the_provider_code_and_course_code_filter
+    then_i_see_the_unfiltered_providers
+  end
+
+  def and_there_are_providers
+    create(:provider, provider_name: "Really big school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")])
+    create(:provider, provider_name: "Slightly smaller school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")])
+  end
+
+  def when_i_visit_the_provider_index_page
+    provider_index_page.load
+  end
+
+  def then_i_see_the_providers
+    expect(provider_index_page.providers.size).to eq(2)
+  end
+
+  alias_method :then_i_see_the_unfiltered_providers, :then_i_see_the_providers
+
+  def when_i_filter_by_provider
+    fill_in "Provider name or code", with: "Really big school"
+    click_button "Apply filters"
+  end
+
+  def when_i_filter_by_course_code
+    fill_in "Provider name or code", with: ""
+    fill_in "Course code", with: "2VVZ"
+    click_button "Apply filters"
+  end
+
+  def when_i_filter_by_provider_code_and_course_code
+    fill_in "Provider name or code", with: "A01"
+    fill_in "Course code", with: "2vvZ"
+    click_button "Apply filters"
+  end
+
+  def then_i_see_providers_filtered_by_provider_name
+    expect(provider_index_page.providers.size).to eq(1)
+    expect(provider_index_page.providers.first.text).to have_content("Really big school A01")
+  end
+
+  alias_method :then_i_see_the_providers_filtered_by_provider_code_and_course_code, :then_i_see_providers_filtered_by_provider_name
+
+  def then_i_see_the_providers_filtered_by_course_code
+    expect(provider_index_page.providers.size).to eq(2)
+    expect(provider_index_page.providers.first.text).to have_content("Really big school A01")
+    expect(provider_index_page.providers.last.text).to have_content("Slightly smaller school A02")
+  end
+
+  def when_i_remove_the_provider_filter
+    click_link "Remove Really big school provider search filter"
+  end
+
+  def when_i_remove_the_course_code_filter
+    click_link "Remove 2VVZ course search filter"
+  end
+
+  def when_i_remove_the_provider_code_and_course_code_filter
+    click_link "Remove A01 provider search filter"
+    click_link "Remove 2vvZ course search filter"
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -250,6 +250,16 @@ describe Course, type: :model do
       end
     end
 
+    describe "case_insensitve_search" do
+      let(:course) { create(:course, course_code: "2VVZ") }
+
+      subject { described_class.case_insensitve_search("2vvZ") }
+
+      it "returns correct course with incorrect" do
+        expect(subject).to eq([course])
+      end
+    end
+
     context "by name" do
       let(:course_a) do
         create(:course, name: "Course A")

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -250,10 +250,10 @@ describe Course, type: :model do
       end
     end
 
-    describe "case_insensitve_search" do
-      let(:course) { create(:course, course_code: "2VVZ") }
+    describe "case_insensitive_search" do
+      let(:course) { create(:course, course_code: "2VvZ") }
 
-      subject { described_class.case_insensitve_search("2vvZ") }
+      subject { described_class.case_insensitive_search("2vVZ") }
 
       it "returns correct course with incorrect" do
         expect(subject).to eq([course])

--- a/spec/models/provider_filter_spec.rb
+++ b/spec/models/provider_filter_spec.rb
@@ -4,8 +4,9 @@ require "rails_helper"
 
 describe ProviderFilter do
   let(:permitted_params) { ActionController::Parameters.new(params).permit(:text_search) }
+  let(:permitted_params2) { ActionController::Parameters.new(provider_and_course_params).permit(:provider_search, :course_search) }
 
-  subject { ProviderFilter.new(params: permitted_params) }
+  subject { described_class.new(params: permitted_params) }
 
   describe "#filters" do
     context "with fully valid parameters" do
@@ -25,6 +26,57 @@ describe ProviderFilter do
 
       it "returns nil" do
         expect(subject.filters).to be_nil
+      end
+    end
+
+    context "provider and course params from providers controller" do
+      subject { described_class.new(params: permitted_params2) }
+
+      context "with fully valid course and provider parameters" do
+        let(:provider_and_course_params) do
+          {
+            provider_search: "T92",
+            course_search: "X130",
+          }
+        end
+
+        it "returns the correct filter hash" do
+          expect(subject.filters).to eq(permitted_params2.to_h)
+        end
+      end
+
+      context "with fully valid provider parameters" do
+        let(:provider_and_course_params) do
+          {
+            provider_search: "T92",
+            course_search: "",
+          }
+        end
+
+        it "returns the correct filter hash" do
+          expect(subject.filters).to eq(permitted_params2.to_h)
+        end
+      end
+
+      context "with fully valid course parameters" do
+        let(:provider_and_course_params) do
+          {
+            provider_search: "",
+            course_search: "X130",
+          }
+        end
+
+        it "returns the correct filter hash" do
+          expect(subject.filters).to eq(permitted_params2.to_h)
+        end
+      end
+
+      context "with empty params" do
+        let(:provider_and_course_params) { {} }
+
+        it "returns nil" do
+          expect(subject.filters).to be_nil
+        end
       end
     end
   end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -199,11 +199,11 @@ describe Provider, type: :model do
     end
   end
 
-  describe "provider_and_course_search" do
+  describe "#search" do
     let(:provider) { create(:provider, provider_name: "Really big school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")]) }
     let(:provider2) { create(:provider, provider_name: "Slightly smaller school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")]) }
 
-    subject { Provider.provider_and_course_search(search_params) }
+    subject { described_class.search(search_params) }
 
     context "when provider code only is given" do
       let(:search_params) do
@@ -736,11 +736,11 @@ describe Provider, type: :model do
     end
   end
 
-  describe "#search" do
+  describe "#provider_search" do
     let!(:matching_provider) { create(:provider, provider_code: "ABC", provider_name: "Dave's Searches") }
     let!(:non_matching_provider) { create(:provider) }
 
-    subject { described_class.search(search_term) }
+    subject { described_class.provider_search(search_term) }
 
     context "with an exactly matching code" do
       let(:search_term) { "ABC" }

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -199,6 +199,52 @@ describe Provider, type: :model do
     end
   end
 
+  describe "provider_and_course_search" do
+    let(:provider) { create(:provider, provider_name: "Really big school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")]) }
+    let(:provider2) { create(:provider, provider_name: "Slightly smaller school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")]) }
+
+    subject { Provider.provider_and_course_search(search_params) }
+
+    context "when provider code only is given" do
+      let(:search_params) do
+        {
+          provider_name_or_code: "A01",
+          course_code: nil,
+        }
+      end
+
+      it "returns the correct list of providers" do
+        expect(subject).to eq([provider])
+      end
+    end
+
+    context "when course code only is present" do
+      let(:search_params) do
+        {
+          provider_name_or_code: nil,
+          course_code: "2VVZ",
+        }
+      end
+
+      it "returns the correct list of providers" do
+        expect(subject).to eq([provider, provider2])
+      end
+    end
+
+    context "when provider code and course are present" do
+      let(:search_params) do
+        {
+          provider_name_or_code: "A01",
+          course_code: "2VVZ",
+        }
+      end
+
+      it "returns the correct list of providers" do
+        expect(subject).to eq([provider])
+      end
+    end
+  end
+
   describe "#update_changed_at" do
     let(:provider) { create(:provider, changed_at: 1.hour.ago) }
 

--- a/spec/services/support/filters/filter_spec.rb
+++ b/spec/services/support/filters/filter_spec.rb
@@ -3,8 +3,8 @@
 require "rails_helper"
 
 describe Support::Filter do
-  let(:provider) { create(:provider) }
-  let(:provider2) { create(:provider) }
+  let(:provider) { create(:provider, provider_name: "Really big school", provider_code: "A01", courses: [build(:course, course_code: "2VVZ")]) }
+  let(:provider2) { create(:provider, provider_name: "Slightly smaller school", provider_code: "A02", courses: [build(:course, course_code: "2VVZ")]) }
 
   subject { Support::Filter.call(model_data_scope: Provider.all, filters: params) }
 
@@ -43,6 +43,45 @@ describe Support::Filter do
 
       it "returns all results" do
         expect(subject.length).to eq 2
+        expect(subject).to eq([provider, provider2])
+      end
+    end
+
+    context "filtering with a known provider and course code" do
+      let(:params) do
+        {
+          provider_search: "A01",
+          course_search: provider.courses.first.course_code,
+        }
+      end
+
+      it "filters the provider out" do
+        expect(subject).to eq([provider])
+      end
+    end
+
+    context "filtering with a known provider only" do
+      let(:params) do
+        {
+          provider_search: "A01",
+          course_search: "",
+        }
+      end
+
+      it "filters the provider out" do
+        expect(subject).to eq([provider])
+      end
+    end
+
+    context "filtering with a known course code only" do
+      let(:params) do
+        {
+          provider_search: "",
+          course_search: "2VVZ",
+        }
+      end
+
+      it "filters the provider out" do
         expect(subject).to eq([provider, provider2])
       end
     end


### PR DESCRIPTION
### Context

As part of ongoing improvements to the ttapi support console, it has been asked that the filter on the provider page has the capacity to filter by course code as well as provider name/code.

### Changes proposed in this pull request

This PR adds in the functionality to the current view filter and associated services.

Search by course code:

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/62567622/145190206-363cb998-585e-4ed4-838c-bd3acf5e1bbc.png">

search by provider code and course code:

<img width="1787" alt="image" src="https://user-images.githubusercontent.com/62567622/145190233-ab66d3a0-ea7a-45f2-afae-d535fcbeb8ea.png">

### Guidance to review
Will this be okay for now? We may want to consider refactoring into it's own filter if filters in general across the service become more complex.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
