### PR TITLE
[411] Rake task to fix incorrect subject position

### DIFF
--- a/lib/tasks/correct_subject_positions.rake
+++ b/lib/tasks/correct_subject_positions.rake
@@ -1,9 +1,8 @@
 namespace :correct_subject_positions do
-  desc "Flip subject position of incorrect courses"
-  task flip_subjects: :environment do |_task, _args|
-    incorrect_course_ids = [12961064, 12965012, 12959155, 12967294, 12958088, 12957580, 12966949, 12958520, 12968910, 12961946, 12960955, 12966226, 12962223, 12963101, 12963100, 12968676, 12957029, 12963084, 12968508, 12968055, 12960926, 12963105, 12959891, 12968271, 12957706, 12965139, 12959109, 12961976, 12968191, 12959929, 12963964, 12964636, 12963103, 12965902, 12965498, 12959910, 12961660, 12966539, 12966275, 12962607, 12963107, 12965263, 12957009, 12960084, 12964549, 12966653, 12964903, 12967192, 12961478, 12967945, 12969557, 12963106, 12960232, 12958474, 12957707]
-
-    RecruitmentCycle.current.courses.where(id: incorrect_course_ids).each do |course|
+  desc "Flip incorrect subject position of courses"
+  task :flip_subjects, [:course_ids] => :environment do |_task, args|
+    course_ids = args[:course_ids].split.map(&:to_i)
+    RecruitmentCycle.current.courses.where(id: course_ids).each do |course|
       course.course_subjects.each_with_index do |course_subject, index|
         case index
         when 0

--- a/lib/tasks/correct_subject_positions.rake
+++ b/lib/tasks/correct_subject_positions.rake
@@ -1,0 +1,18 @@
+namespace :correct_subject_positions do
+  desc "Flip subject position of incorrect courses"
+  task flip_subjects: :environment do |_task, _args|
+    incorrect_course_ids = [12961064, 12965012, 12959155, 12967294, 12958088, 12957580, 12966949, 12958520, 12968910, 12961946, 12960955, 12966226, 12962223, 12963101, 12963100, 12968676, 12957029, 12963084, 12968508, 12968055, 12960926, 12963105, 12959891, 12968271, 12957706, 12965139, 12959109, 12961976, 12968191, 12959929, 12963964, 12964636, 12963103, 12965902, 12965498, 12959910, 12961660, 12966539, 12966275, 12962607, 12963107, 12965263, 12957009, 12960084, 12964549, 12966653, 12964903, 12967192, 12961478, 12967945, 12969557, 12963106, 12960232, 12958474, 12957707]
+
+    RecruitmentCycle.current.courses.where(id: incorrect_course_ids).each do |course|
+      course.course_subjects.each_with_index do |course_subject, index|
+        case index
+        when 0
+          course_subject.position = 1
+        when 1
+          course_subject.position = 0
+        end
+        course_subject.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/VoUTfJmm/411-ensure-the-financial-incentive-is-only-applied-to-the-first-major-subject-on-a-course)
- Some courses have subjects that are in an incorrect position/order. This trickles down into an incorrect Financial Incentive being applied to them, as we always take the financial incentive from the *first* subject.

### Changes proposed in this pull request

- Create a rake task to fix the incorrect subject positions

### Guidance to review

- You will need to run the rake task with arguments. It takes arguments of course_ids, seperated by spaces. For example...
- `bundle exec rake correct_subject_positions:flip_subjects'[id1 id2 id3]'`
- Run the rake task to see the courses get fixed

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
