### PR TITLE
[433] Allow support users to edit the details of a course

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -28,7 +28,7 @@ module Support
     end
 
     def update_course_params
-      params.require(:course).permit(:course_code)
+      params.require(:course).permit(:course_code, :name, :start_date)
     end
   end
 end

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -1,13 +1,19 @@
 <%= render PageTitle::View.new(title: "support.providers.courses.edit") %>
 
+<h1 class="govuk-heading-l">Edit course details</h1>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <%= form_with model: [:support, @provider, @course], local: true do |f| %>
-          
+
       <%= f.govuk_error_summary %>
 
-      <%= f.govuk_text_field(:course_code, 
-      label: { text: "Edit course code", tag: "h1", size: "l" }, width: 10) %>
+      <%= f.govuk_text_field(:course_code,
+      label: { text: "Course code", tag: "h1", size: "m" }, width: 10) %>
+      <%= f.govuk_text_field(:name,
+      label: { text: "Course title", tag: "h1", size: "m" }, width: 10) %>
+      <%= f.govuk_date_field(:start_date,
+      legend: { text: "Start date" }, width: 10) %>
+
       <%= f.govuk_submit %>
     <% end %>
 

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -8,9 +8,9 @@
       <%= f.govuk_error_summary %>
 
       <%= f.govuk_text_field(:course_code,
-      label: { text: "Course code", tag: "h1", size: "m" }, width: 10) %>
+      label: { text: "Course code", size: "m" }, width: 10) %>
       <%= f.govuk_text_field(:name,
-      label: { text: "Course title", tag: "h1", size: "m" }, width: 10) %>
+      label: { text: "Course title", size: "m" }, width: 10) %>
       <%= f.govuk_date_field(:start_date,
       legend: { text: "Start date" }, width: 10) %>
 

--- a/app/views/support/courses/index.html.erb
+++ b/app/views/support/courses/index.html.erb
@@ -3,8 +3,8 @@
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course name</th>
-      <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Course code</th>
+      <th scope="col" class="govuk-table__header">Course name and code</th>
+      <th scope="col" class="govuk-table__header"></th>
     </tr>
   </thead>
 
@@ -12,10 +12,10 @@
     <% @courses.each do |course| %>
       <tr class="govuk-table__row course-row">
         <td class="govuk-table__cell name">
-            <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %></span>
+          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.name %> (<%= course.course_code %>)</span>
         </td>
-        <td class="govuk-table__cell course_code">
-          <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= course.course_code %> (<%= govuk_link_to "Edit", edit_support_provider_course_url(@provider,course) %>)</span>
+        <td class="govuk-table__cell change">
+          <%= govuk_link_to "Change", edit_support_provider_course_url(@provider,course) %>
         </td>
       </tr>
     <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,7 +19,7 @@ en:
           show: "View a provider"
           courses:
             index: "Courses"
-            edit: "Edit course code"
+            edit: "Edit course details"
         users:
           index: "Users"
           show: "User overview"
@@ -109,6 +109,10 @@ en:
             course_code: 
               taken: "Course code is already taken"
               blank: "Course code cannot be blank"
+            start_date:
+              blank: "Start date cannot have blank values"
+            name:
+              blank: "Course title cannot be blank"
             level:
               blank: "^Select a course level"
             qualification:

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -2,41 +2,58 @@
 
 require "rails_helper"
 
-feature "Edit provider course code" do
+feature "Edit provider course details" do
+  around do |example|
+    Timecop.freeze(2021, 8, 1, 12) do
+      example.run
+    end
+  end
+
   before do
     given_i_am_authenticated_as_an_admin_user
     and_there_is_a_provider_with_courses
     when_i_visit_the_provider_courses_index_page
-    and_click_on_the_first_course_code_edit_link
+    and_click_on_the_first_course_change_link
     then_i_am_on_the_course_edit_page
   end
 
   context "valid details" do
-    scenario "I can edit a course code" do
-      when_i_fill_in_a valid_course_code
+    scenario "I can edit a course details" do
+      when_i_fill_in_course_code_with valid_course_code
+      and_i_fill_in_course_title_with valid_course_name
+      and_i_fill_in_course_start_date_with start_date_day, start_date_month, valid_start_date_year
       and_i_click_the_continue_button
       then_i_am_redirected_back_to_the_provider_courses_index_page
-      and_the_course_code_is_updated
+      and_the_course_name_and_code_are_updated
+      when_i_return_to_the_edit_page
+      then_i_see_the_updated_start_date
     end
   end
 
   context "invalid details" do
-    scenario "I cannot use a taken course code" do
-      when_i_fill_in_a existing_course_code
+    scenario "I cannot use invlaid course details" do
+      when_i_fill_in_course_code_with existing_course_code
+      and_i_fill_in_course_title_with valid_course_name
+      and_i_fill_in_course_start_date_with start_date_day, start_date_month, invalid_start_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
+      and_it_contains_invalid_value_errors
     end
 
-    scenario "I cannot use a blank course code" do
-      when_i_fill_in_a blank_course_code
+    scenario "I cannot use a blank course details" do
+      when_i_fill_in_course_code_with blank_value
+      and_i_fill_in_course_title_with blank_value
+      and_i_fill_in_course_start_date_with blank_value, blank_value, blank_value
       and_i_click_the_continue_button
       then_i_see_the_error_summary
+      and_it_contains_blank_errors
     end
   end
 
 private
 
   def given_i_am_authenticated_as_an_admin_user
+    Timecop.travel(1.second.from_now)
     given_i_am_authenticated(user: create(:user, :admin))
   end
 
@@ -52,9 +69,11 @@ private
     provider_courses_index_page.load(provider_id: provider.id)
   end
 
-  def and_click_on_the_first_course_code_edit_link
-    provider_courses_index_page.courses_row.first.edit_link.click
+  def and_click_on_the_first_course_change_link
+    provider_courses_index_page.courses_row.first.change_link.click
   end
+
+  alias_method :when_i_return_to_the_edit_page, :and_click_on_the_first_course_change_link
 
   def then_i_am_on_the_course_edit_page
     course_edit_page.load(provider_id: provider.id, course_id: provider.courses.first.id)
@@ -64,20 +83,54 @@ private
     @course_code ||= "D0N3"
   end
 
+  def course_name
+    @course_name ||= "Geography"
+  end
+
+  def start_date_day
+    @start_date_day ||= "1"
+  end
+
+  def start_date_month
+    @start_date_month ||= "10"
+  end
+
   def valid_course_code
     @valid_course_code ||= course_code
+  end
+
+  def valid_course_name
+    @valid_course_name ||= course_name
   end
 
   def existing_course_code
     @existing_course_code ||= provider.courses.second.course_code
   end
 
-  def blank_course_code
-    @blank_course_code ||= ""
+  def valid_start_date_year
+    @valid_start_date_year ||= "2021"
   end
 
-  def when_i_fill_in_a(course_code)
+  def invalid_start_date_year
+    @invalid_start_date_year ||= "2026"
+  end
+
+  def blank_value
+    @blank_value ||= ""
+  end
+
+  def when_i_fill_in_course_code_with(course_code)
     course_edit_page.course_code.set(course_code)
+  end
+
+  def and_i_fill_in_course_title_with(course_name)
+    course_edit_page.name.set(course_name)
+  end
+
+  def and_i_fill_in_course_start_date_with(day, month, year)
+    course_edit_page.start_date_day.set(day)
+    course_edit_page.start_date_month.set(month)
+    course_edit_page.start_date_year.set(year)
   end
 
   def and_i_click_the_continue_button
@@ -88,11 +141,29 @@ private
     expect(provider_courses_index_page).to be_displayed
   end
 
-  def and_the_course_code_is_updated
+  def and_the_course_name_and_code_are_updated
     expect(provider_courses_index_page).to have_text(course_code)
+    expect(provider_courses_index_page).to have_text(course_name)
+  end
+
+  def then_i_see_the_updated_start_date
+    expect(course_edit_page.start_date_day.value).to eq(start_date_day)
+    expect(course_edit_page.start_date_month.value).to eq(start_date_month)
+    expect(course_edit_page.start_date_year.value).to eq(valid_start_date_year)
   end
 
   def then_i_see_the_error_summary
     expect(course_edit_page.error_summary).to be_visible
+  end
+
+  def and_it_contains_invalid_value_errors
+    expect(course_edit_page.error_summary.text).to include("Course code is already taken")
+    expect(course_edit_page.error_summary.text).to include("October 2026 is not in the 2022 cycle")
+  end
+
+  def and_it_contains_blank_errors
+    expect(course_edit_page.error_summary.text).to include("Course code cannot be blank")
+    expect(course_edit_page.error_summary.text).to include("Course title cannot be blank")
+    expect(course_edit_page.error_summary.text).to include("Start date cannot have blank values")
   end
 end

--- a/spec/features/support/providers/provider_courses_list_spec.rb
+++ b/spec/features/support/providers/provider_courses_list_spec.rb
@@ -37,7 +37,7 @@ feature "View provider courses" do
     expect(provider_courses_index_page.courses_row.size).to eq(1)
 
     expect(provider_courses_index_page.courses_row.first.name).to have_text(course.name)
-    expect(provider_courses_index_page.courses_row.first.course_code).to have_text(course.course_code)
-    expect(provider_courses_index_page.courses_row.first.edit_link).to have_text("Edit")
+    expect(provider_courses_index_page.courses_row.first.name).to have_text(course.course_code)
+    expect(provider_courses_index_page.courses_row.first.change_link).to have_text("Change")
   end
 end

--- a/spec/requests/api/v2/build_new_course_spec.rb
+++ b/spec/requests/api/v2/build_new_course_spec.rb
@@ -211,7 +211,7 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid title",
-          "detail" => "Title can't be blank",
+          "detail" => "Title Course title cannot be blank",
           "source" => {
             "pointer" => "/data/attributes/name",
           },
@@ -232,7 +232,7 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid start date",
-          "detail" => "Start date can't be blank",
+          "detail" => "Start date Start date cannot have blank values",
           "source" => {
             "pointer" => "/data/attributes/start_date",
           },
@@ -292,7 +292,7 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid title",
-          "detail" => "Title can't be blank",
+          "detail" => "Title Course title cannot be blank",
           "source" => {
             "pointer" => "/data/attributes/name",
           },
@@ -320,7 +320,7 @@ describe "/api/v2/build_new_course", type: :request do
         },
         {
           "title" => "Invalid start date",
-          "detail" => "Start date can't be blank",
+          "detail" => "Start date Start date cannot have blank values",
           "source" => {
             "pointer" => "/data/attributes/start_date",
           },

--- a/spec/support/page_objects/sections/course.rb
+++ b/spec/support/page_objects/sections/course.rb
@@ -6,8 +6,7 @@ module PageObjects
   module Sections
     class Course < PageObjects::Sections::Base
       element :name, ".name"
-      element :course_code, ".course_code"
-      element :edit_link, ".course_code a.govuk-link"
+      element :change_link, ".change a.govuk-link"
     end
   end
 end

--- a/spec/support/page_objects/support/provider/course_edit_page.rb
+++ b/spec/support/page_objects/support/provider/course_edit_page.rb
@@ -7,6 +7,10 @@ module PageObjects
         set_url "/support/providers/{provider_id}/courses/{course_id}/edit"
 
         element :course_code, "#course-course-code-field"
+        element :name, "#course-name-field"
+        element :start_date_day, "#course_start_date_3i"
+        element :start_date_month, "#course_start_date_2i"
+        element :start_date_year, "#course_start_date_1i"
         element :error_summary, ".govuk-error-summary"
         element :continue, ".govuk-button"
       end


### PR DESCRIPTION
### Context

As part of ongoing improvemtns to the support console, support users need the ability to update more course details than just the course code.

### Changes proposed in this pull request

This PR adds additional field to the course edit page to allow both course title and start date to be updated as well as course code.

### Guidance to review

Test in review app, plz let me know RE: any refactor.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
