### PR TITLE
Migrate Provider and Contact details from Old Publish

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,7 +29,10 @@ private
   end
 
   def authenticate
-    redirect_to sign_in_path if !authenticated?
+    if !authenticated?
+      session["post_dfe_sign_in_path"] = request.fullpath
+      redirect_to sign_in_path
+    end
   end
 
   def not_found

--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -25,8 +25,8 @@ module PublishInterface
     def update
       authorize @provider, :update?
 
-      @about_form = PublishInterface::AboutYourOrganisationForm.build_from_provider(@provider)
-      @about_form.save(provider_params)
+      @about_form = PublishInterface::AboutYourOrganisationForm.build_from_controller_params(provider_params)
+      @about_form.save
 
       if @about_form.valid?
         flash[:success] = I18n.t("success.published")
@@ -38,7 +38,7 @@ module PublishInterface
         )
       else
         @errors = @about_form.errors.messages
-        render provider_params["page"].to_sym
+        render page_param
       end
     end
 
@@ -62,12 +62,16 @@ module PublishInterface
     def provider_params
       params
         .fetch(:publish_interface_about_your_organisation_form, {})
+        .except(:page)
         .permit(
-          :email, :telephone, :urn, :website, :ukprn, :address1, :address2,
-          :address3, :address4, :postcode, :region_code,
-          :page, :train_with_us, :train_with_disability,
-          accredited_bodies: [:provider_name, :provider_code, :description]
+          *AboutYourOrganisationForm::FIELDS,
+          accredited_bodies: %i[provider_name provider_code description],
         )
+        .merge(provider: @provider)
+    end
+
+    def page_param
+      params.fetch(:publish_interface_about_your_organisation_form).fetch(:page)
     end
   end
 end

--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -18,6 +18,10 @@ module PublishInterface
       @about_form = PublishInterface::AboutYourOrganisationForm.build_from_provider(@provider)
     end
 
+    def contact
+      @about_form = PublishInterface::AboutYourOrganisationForm.build_from_provider(@provider)
+    end
+
     def update
       authorize @provider, :update?
 
@@ -58,7 +62,12 @@ module PublishInterface
     def provider_params
       params
         .fetch(:publish_interface_about_your_organisation_form, {})
-        .permit(:page, :train_with_us, :train_with_disability, accredited_bodies: [:provider_name, :provider_code, :description])
+        .permit(
+          :email, :telephone, :urn, :website, :ukprn, :address1, :address2,
+          :address3, :address4, :postcode, :region_code,
+          :page, :train_with_us, :train_with_disability,
+          accredited_bodies: [:provider_name, :provider_code, :description]
+        )
     end
   end
 end

--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -14,6 +14,10 @@ module PublishInterface
       flash.delete(:error_summary)
     end
 
+    def about
+      show_deep_linked_errors(%i[train_with_us train_with_disability])
+    end
+
   private
 
     def build_recruitment_cycle
@@ -29,6 +33,12 @@ module PublishInterface
       flash[:error] = { id: "provider-error", message: "Please enter a UKPRN before continuing" }
 
       redirect_to contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    end
+
+    def show_deep_linked_errors(attributes)
+      return if params[:display_errors].blank?
+
+      @errors = @provider.errors.messages.select { |key| attributes.include? key }
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -35,7 +35,11 @@ class SessionsController < ApplicationController
 private
 
   def after_sign_in_path
-    if current_user.admin?
+    saved_path = session.delete("post_dfe_sign_in_path")
+
+    if saved_path
+      saved_path
+    elsif current_user.admin?
       support_providers_path
     else
       publish_root_path

--- a/app/forms/publish_interface/about_your_organisation_form.rb
+++ b/app/forms/publish_interface/about_your_organisation_form.rb
@@ -1,0 +1,72 @@
+module PublishInterface
+  class AboutYourOrganisationForm
+    include ActiveModel::Model
+    include ActiveModel::Validations
+
+    attr_accessor :provider
+    attr_accessor(
+      :provider_code, :recruitment_cycle_year, :provider_name,
+      :train_with_us, :train_with_disability
+    )
+
+    def self.build_from_provider(provider)
+      new(
+        provider: provider,
+        provider_code: provider.provider_code,
+        recruitment_cycle_year: provider.recruitment_cycle_year,
+        provider_name: provider.provider_name,
+        train_with_us: provider.train_with_us,
+        train_with_disability: provider.train_with_disability,
+      )
+    end
+
+    def accredited_bodies
+      @accredited_bodies ||= @provider.accredited_bodies.map do |ab|
+        AccreditedBody.new(
+          provider_name: ab[:provider_name],
+          provider_code: ab[:provider_code],
+          description: ab[:description],
+        )
+      end
+    end
+
+    def valid?
+      @provider.valid?
+    end
+
+    def save(params)
+      accredited_bodies_params = params.delete(:accredited_bodies)
+      provider_params = params.except(:page)
+
+      # update_provider
+      @provider.assign_attributes(provider_params)
+      @provider.save
+
+      # update_accrediting_enrichment
+      @provider.accrediting_provider_enrichments =
+        accredited_bodies_params.map do |accredited_body|
+          {
+            UcasProviderCode: accredited_body["provider_code"],
+            Description: accredited_body["description"],
+          }
+        end
+      @provider.save
+
+      promote_errors
+    end
+
+  private
+
+    def promote_errors
+      @provider.errors.each do |attribute, error|
+        errors.add(attribute, error)
+      end
+    end
+
+    class AccreditedBody
+      include ActiveModel::Model
+
+      attr_accessor :provider_name, :provider_code, :description
+    end
+  end
+end

--- a/app/forms/publish_interface/about_your_organisation_form.rb
+++ b/app/forms/publish_interface/about_your_organisation_form.rb
@@ -6,7 +6,9 @@ module PublishInterface
     attr_accessor :provider
     attr_accessor(
       :provider_code, :recruitment_cycle_year, :provider_name,
-      :train_with_us, :train_with_disability
+      :train_with_us, :train_with_disability,
+      :email, :telephone, :urn, :website, :ukprn, :address1, :address2,
+      :address3, :address4, :postcode, :region_code
     )
 
     def self.build_from_provider(provider)
@@ -17,6 +19,18 @@ module PublishInterface
         provider_name: provider.provider_name,
         train_with_us: provider.train_with_us,
         train_with_disability: provider.train_with_disability,
+
+        email: provider.email,
+        telephone: provider.telephone,
+        urn: provider.urn,
+        website: provider.website,
+        ukprn: provider.ukprn,
+        address1: provider.address1,
+        address2: provider.address2,
+        address3: provider.address3,
+        address4: provider.address4,
+        postcode: provider.postcode,
+        region_code: provider.region_code,
       )
     end
 
@@ -38,11 +52,21 @@ module PublishInterface
       accredited_bodies_params = params.delete(:accredited_bodies)
       provider_params = params.except(:page)
 
-      # update_provider
+      update_provider(provider_params)
+      update_accrediting_enrichment(accredited_bodies_params)
+      promote_errors
+    end
+
+  private
+
+    def update_provider(provider_params)
       @provider.assign_attributes(provider_params)
       @provider.save
+    end
 
-      # update_accrediting_enrichment
+    def update_accrediting_enrichment(accredited_bodies_params)
+      return if accredited_bodies_params.blank?
+
       @provider.accrediting_provider_enrichments =
         accredited_bodies_params.map do |accredited_body|
           {
@@ -51,11 +75,7 @@ module PublishInterface
           }
         end
       @provider.save
-
-      promote_errors
     end
-
-  private
 
     def promote_errors
       @provider.errors.each do |attribute, error|

--- a/app/forms/publish_interface/about_your_organisation_form.rb
+++ b/app/forms/publish_interface/about_your_organisation_form.rb
@@ -78,8 +78,8 @@ module PublishInterface
     end
 
     def promote_errors
-      @provider.errors.each do |attribute, error|
-        errors.add(attribute, error)
+      @provider.errors.each do |error|
+        errors.add(error.attribute, error.full_message)
       end
     end
 

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,16 +1,16 @@
 module ViewHelper
-  # def govuk_back_link_to(url = :back, body = "Back")
-  #   render GovukComponent::BackLinkComponent.new(
-  #     text: body,
-  #     href: url,
-  #     classes: "govuk-!-display-none-print",
-  #     html_attributes: {
-  #       data: {
-  #         qa: "page-back",
-  #       },
-  #     },
-  #   )
-  # end
+  def govuk_back_link_to(url = :back, body = "Back")
+    render GovukComponent::BackLinkComponent.new(
+      text: body,
+      href: url,
+      classes: "govuk-!-display-none-print",
+      html_attributes: {
+        data: {
+          qa: "page-back",
+        },
+      },
+    )
+  end
 
   # def search_ui_url(relative_path)
   #   URI.join(Settings.search_ui.base_url, relative_path).to_s

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -312,6 +312,10 @@ class Provider < ApplicationRecord
     can_sponsor_student_visa && !can_sponsor_skilled_worker_visa
   end
 
+  def can_only_sponsor_skilled_worker_visa?
+    !can_sponsor_student_visa && can_sponsor_skilled_worker_visa
+  end
+
 private
 
   scope :course_code_search, ->(course_code) { joins(:courses).merge(Course.case_insensitive_search(course_code)) }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title><%= yield :page_title %></title>
+    <title><%= yield :page_title %> - Publish teacher training courses - GOV.UK</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= canonical_tag %>
@@ -43,6 +43,7 @@
     <div class="govuk-width-container">
       <div class="govuk-width-container">
         <%= yield :breadcrumbs %>
+        <%= yield :before_content %>
       </div>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-width-container">

--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -1,0 +1,91 @@
+<% page_title = "About your organisation" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: provider,
+      url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
+      </h1>
+
+      <%= f.hidden_field :page, value: :about %>
+
+      <p class="govuk-body">Tell applicants why they should choose to train with you. Say:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>who you are</li>
+        <li>who you work with</li>
+      </ul>
+      <p class="govuk-body">You could mention:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>your key values</li>
+        <li>your specialisms</li>
+        <li>your past achievements (eg student successes, Ofsted ratings)</li>
+      </ul>
+      <p class="govuk-body">Be specific with any claims you make, and support them with evidence. For example:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>don’t say “our students are some of the happiest in the country”</li>
+        <li>do say “the Times Educational Supplement ranked our students as 4th happiest in the country”</li>
+      </ul>
+
+      <%= f.govuk_text_area(:train_with_us,
+        form_group: { id: "train-with-us" },
+        label: { size: "m" },
+        max_words: 250,
+        rows: 15) %>
+
+      <% if provider.accredited_bodies.present? %>
+        <% accredited_body = "accredited body".pluralize(provider.accredited_bodies.count) %>
+
+        <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+        <h2 class="govuk-heading-m">About your <%= accredited_body %></h2>
+
+        <p class="govuk-body">Tell applicants about your <%= accredited_body %> – you could mention their academic specialities and achievements.</p>
+        <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
+
+        <%= f.fields model: :accredited_bodies do |abf| %>
+          <%= abf.hidden_field :provider_name %>
+          <%= abf.hidden_field :provider_code %>
+          <%= abf.govuk_text_area(:description,
+            form_group: { id: "accrediting-provider-#{abf.object.provider_code}" },
+            label: { text: "#{abf.object.provider_name} (optional)", size: "s" },
+            max_words: 100,
+            rows: 10) %>
+        <% end %>
+      <% end %>
+
+      <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
+
+      <h2 class="govuk-heading-m">Training with disabilities and other needs</h2>
+      <p class="govuk-body">Say how you support candidates with disabilities and other needs. This could include candidates with:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>dyslexia</li>
+        <li>physical, hearing and visual impairments</li>
+        <li>mental health conditions</li>
+      </ul>
+      <p class="govuk-body">If accessibility varies between locations, give details. It’s also useful for applicants to know how you’ve accommodated others with specific access needs in the past.</p>
+
+      <%= f.govuk_text_area(:train_with_disability,
+        form_group: { id: "train-with-disability" },
+        label: { size: "s" },
+        max_words: 250,
+        rows: 15) %>
+
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
+      <%= f.govuk_submit "Save and publish changes" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -2,22 +2,21 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
-      model: provider,
-      url: about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      model: @about_form,
+      url: about_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year),
       method: :put,
-      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
     ) do |f| %>
 
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <span class="govuk-caption-l"><%= @about_form.provider_name %></span>
         <%= page_title %>
       </h1>
 
@@ -42,12 +41,12 @@
 
       <%= f.govuk_text_area(:train_with_us,
         form_group: { id: "train-with-us" },
-        label: { size: "m" },
+        label: { text: "Training with you", size: "m" },
         max_words: 250,
         rows: 15) %>
 
-      <% if provider.accredited_bodies.present? %>
-        <% accredited_body = "accredited body".pluralize(provider.accredited_bodies.count) %>
+      <% if @about_form.accredited_bodies.present? %>
+        <% accredited_body = "accredited body".pluralize(@about_form.accredited_bodies.count) %>
 
         <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--l">
 
@@ -56,14 +55,16 @@
         <p class="govuk-body">Tell applicants about your <%= accredited_body %> – you could mention their academic specialities and achievements.</p>
         <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
 
-        <%= f.fields model: :accredited_bodies do |abf| %>
-          <%= abf.hidden_field :provider_name %>
-          <%= abf.hidden_field :provider_code %>
-          <%= abf.govuk_text_area(:description,
-            form_group: { id: "accrediting-provider-#{abf.object.provider_code}" },
-            label: { text: "#{abf.object.provider_name} (optional)", size: "s" },
-            max_words: 100,
-            rows: 10) %>
+        <% @about_form.accredited_bodies.each_with_index do |accredited_body| %>
+          <%= f.fields_for :accredited_bodies, accredited_body, index: nil do |abf| %>
+            <%= abf.hidden_field :provider_name %>
+            <%= abf.hidden_field :provider_code %>
+            <%= abf.govuk_text_area(:description,
+              form_group: { id: "accrediting-provider-#{accredited_body.provider_code}" },
+              label: { text: "#{accredited_body.provider_name} (optional)", size: "s" },
+              max_words: 100,
+              rows: 10) %>
+          <% end %>
         <% end %>
       <% end %>
 
@@ -80,7 +81,7 @@
 
       <%= f.govuk_text_area(:train_with_disability,
         form_group: { id: "train-with-disability" },
-        label: { size: "s" },
+        label: { text: "Training with disabilities and other needs", size: "s" },
         max_words: 250,
         rows: 15) %>
 

--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -55,7 +55,7 @@
         <p class="govuk-body">Tell applicants about your <%= accredited_body %> – you could mention their academic specialities and achievements.</p>
         <p class="govuk-body">Be specific with the claims you make, and support them with evidence.</p>
 
-        <% @about_form.accredited_bodies.each_with_index do |accredited_body| %>
+        <% @about_form.accredited_bodies.each do |accredited_body| %>
           <%= f.fields_for :accredited_bodies, accredited_body, index: nil do |abf| %>
             <%= abf.hidden_field :provider_name %>
             <%= abf.hidden_field :provider_code %>

--- a/app/views/publish_interface/providers/contact.html.erb
+++ b/app/views/publish_interface/providers/contact.html.erb
@@ -1,0 +1,102 @@
+<% page_title = "Contact details" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @provider,
+      url: contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <%= page_title %>
+      </h1>
+
+      <%= f.hidden_field :page, value: :contact %>
+
+      <% if current_user["admin"] %>
+        <div class="app-status-box app-status-box--admin">
+          <p class="govuk-body">
+            <%= govuk_tag(text: "Admin feature", colour: "purple") %>
+          </p>
+
+          <%= f.govuk_text_field(:provider_name,
+            label: { size: "m" },
+            data: { qa: "provider_name" }) %>
+        </div>
+      <% end %>
+
+      <%= f.govuk_text_field(:email,
+        form_group: { id: "email" },
+        label: { size: "m" },
+        autocomplete: "email",
+        spellcheck: false,
+        data: { qa: "email" }) %>
+
+      <%= f.govuk_text_field(:telephone,
+        form_group: { id: "telephone" },
+        label: { size: "m" },
+        width: 20,
+        autocomplete: "tel",
+        data: { qa: "telephone" }) %>
+
+      <%= f.govuk_text_field(:website,
+        form_group: { id: "website" },
+        label: { size: "m" },
+        data: { qa: "website" }) %>
+
+      <%= f.govuk_text_field(:ukprn,
+        form_group: { id: "ukprn" },
+        label: { size: "m" },
+        width: 10,
+        data: { qa: "ukprn" }) %>
+
+      <% if @provider.provider_type == "lead_school" %>
+        <%= f.govuk_text_field(:urn,
+          form_group: { id: "urn" },
+          label: { size: "m" },
+          width: 10,
+          data: { qa: "urn" }) %>
+      <% end %>
+
+      <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" }, id: "address" do %>
+        <%= f.govuk_text_field(:address1,
+          label: -> { safe_join([t("helpers.label.provider.address1"), " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
+          autocomplete: "address-line1",
+          data: { qa: "address1" }) %>
+
+        <%= f.govuk_text_field(:address2,
+          label: { hidden: true },
+          autocomplete: "address-line2",
+          data: { qa: "address2" }) %>
+
+        <%= f.govuk_text_field(:address3,
+          width: "two-thirds",
+          autocomplete: "address-level2",
+          data: { qa: "address3" }) %>
+
+        <%= f.govuk_text_field(:address4,
+          width: "two-thirds",
+          autocomplete: "address-level1",
+          data: { qa: "address4" }) %>
+
+        <%= f.govuk_text_field(:postcode,
+          width: 10,
+          autocomplete: "postal-code",
+          data: { qa: "postcode" }) %>
+      <% end %>
+
+      <%= render GovukComponent::InsetTextComponent.new(text: I18n.t("success.changes_ttl")) %>
+      <%= f.govuk_submit "Save and publish changes" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish_interface/providers/contact.html.erb
+++ b/app/views/publish_interface/providers/contact.html.erb
@@ -2,14 +2,14 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
-      model: @provider,
-      url: contact_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      model: @about_form,
+      url: contact_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year),
       method: :put,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,
     ) do |f| %>
@@ -17,34 +17,22 @@
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
+        <span class="govuk-caption-l"><%= @about_form.provider_name %></span>
         <%= page_title %>
       </h1>
 
       <%= f.hidden_field :page, value: :contact %>
 
-      <% if current_user["admin"] %>
-        <div class="app-status-box app-status-box--admin">
-          <p class="govuk-body">
-            <%= govuk_tag(text: "Admin feature", colour: "purple") %>
-          </p>
-
-          <%= f.govuk_text_field(:provider_name,
-            label: { size: "m" },
-            data: { qa: "provider_name" }) %>
-        </div>
-      <% end %>
-
       <%= f.govuk_text_field(:email,
         form_group: { id: "email" },
-        label: { size: "m" },
+        label: { text: "Email address", size: "m" },
         autocomplete: "email",
         spellcheck: false,
         data: { qa: "email" }) %>
 
       <%= f.govuk_text_field(:telephone,
         form_group: { id: "telephone" },
-        label: { size: "m" },
+        label: { text: "Telephone number", size: "m" },
         width: 20,
         autocomplete: "tel",
         data: { qa: "telephone" }) %>
@@ -60,7 +48,7 @@
         width: 10,
         data: { qa: "ukprn" }) %>
 
-      <% if @provider.provider_type == "lead_school" %>
+      <% if @about_form.provider.provider_type == "lead_school" %>
         <%= f.govuk_text_field(:urn,
           form_group: { id: "urn" },
           label: { size: "m" },
@@ -70,7 +58,7 @@
 
       <%= f.govuk_fieldset legend: { text: "Contact address", size: "m" }, id: "address" do %>
         <%= f.govuk_text_field(:address1,
-          label: -> { safe_join([t("helpers.label.provider.address1"), " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
+          label: -> { safe_join(["Building and street", " ", tag.span("line 1 of 2", class: "govuk-visually-hidden")]) },
           autocomplete: "address-line1",
           data: { qa: "address1" }) %>
 
@@ -80,11 +68,13 @@
           data: { qa: "address2" }) %>
 
         <%= f.govuk_text_field(:address3,
+          label: { text: "Town or city" },
           width: "two-thirds",
           autocomplete: "address-level2",
           data: { qa: "address3" }) %>
 
         <%= f.govuk_text_field(:address4,
+          label: { text: "County" },
           width: "two-thirds",
           autocomplete: "address-level1",
           data: { qa: "address4" }) %>

--- a/app/views/publish_interface/providers/details.html.erb
+++ b/app/views/publish_interface/providers/details.html.erb
@@ -47,10 +47,10 @@
             summary_list,
             :provider,
             "#{accredited_provider[:provider_name]} (optional)",
-            accredited_provider["description"],
-            ["accrediting_provider_#{accredited_provider['provider_code']}"],
-            action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider['provider_code']}",
-            action_visually_hidden_text: "details about #{accredited_provider['provider_name']}",
+            accredited_provider[:description],
+            ["accrediting_provider_#{accredited_provider[:provider_code]}"],
+            action_path: "#{about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)}#accrediting-provider-#{accredited_provider[:provider_code]}",
+            action_visually_hidden_text: "details about #{accredited_provider[:provider_name]}",
           ) %>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -212,3 +212,6 @@ en:
       detail: "Something has gone wrong, please try again in a few minutes"
   pagy:
     overflow: "The requested page param was out of range and invalid for this request."
+  success:
+    published: "Your changes have been published."
+    changes_ttl: "Changes will appear on Find postgraduate teacher training within 15 minutes."

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -6,6 +6,8 @@ en:
       sign_out: "Sign out"
   cancel: "Cancel"
   change: "Change"
+  page_titles:
+    error_prefix: "Error: "
   components:
     page_titles:
       sign_in:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
         get "/about", on: :member, to: "providers#about"
         put "/about", on: :member, to: "providers#update"
         get "/contact", on: :member, to: "providers#contact"
+        put "/contact", on: :member, to: "providers#update"
         get "/details", on: :member, to: "providers#details"
         get "/visas", to: "providers/visas#edit"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
     resources :providers, path: "organisations", param: :code, only: [] do
       resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [] do
         get "/about", on: :member, to: "providers#about"
+        put "/about", on: :member, to: "providers#update"
         get "/contact", on: :member, to: "providers#contact"
         get "/details", on: :member, to: "providers#details"
         get "/visas", to: "providers/visas#edit"

--- a/spec/features/publish_interface/edit_provider_details_spec.rb
+++ b/spec/features/publish_interface/edit_provider_details_spec.rb
@@ -28,20 +28,28 @@ feature "About Your Organisation section" do
   end
 
   def when_i_visit_the_details_page
-    visit details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    click_button "Sign in using DfE Sign-in"
+    provider_details_show_page.load(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+    )
+    sign_in_page.sign_in_button.click
   end
 
   def then_i_can_edit_info_about_training_with_us
-    click_link "Change details about training with your organisation"
-    fill_in "Training with you", with: ""
-    click_button "Save and publish changes"
-    within ".govuk-error-summary__body" do
+    provider_details_show_page.train_with_us_link.click
+    expect(page).to have_current_path provider_details_edit_page.url(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+    )
+
+    provider_details_edit_page.training_with_you_field.set ""
+    provider_details_edit_page.save_and_publish.click
+    within provider_details_edit_page.error_summary do
       expect(page).to have_content "Enter details about training with you"
     end
 
-    fill_in "Training with you", with: "Updated: Training with you"
-    click_button "Save and publish changes"
+    provider_details_edit_page.training_with_you_field.set "Updated: Training with you"
+    provider_details_edit_page.save_and_publish.click
 
     expect(page).to have_content "Your changes have been published"
     within_summary_row "Training with your organisation" do
@@ -51,8 +59,9 @@ feature "About Your Organisation section" do
 
   def then_i_can_edit_info_about_our_accredited_bodies
     click_link "Change details about #{@accrediting_provider.provider_name}"
-    fill_in @accrediting_provider.provider_name, with: "Updated: accredited body description"
-    click_button "Save and publish changes"
+
+    provider_details_edit_page.accredited_body_description_field.set "Updated: accredited body description"
+    provider_details_edit_page.save_and_publish.click
 
     expect(page).to have_content "Your changes have been published"
     within_summary_row @accrediting_provider.provider_name do
@@ -61,9 +70,10 @@ feature "About Your Organisation section" do
   end
 
   def then_i_can_edit_info_about_disabilities_and_other_needs
-    click_link "Change details about training with disabilities and other needs"
-    fill_in "Training with disabilities and other needs", with: "Updated: training with disabilities"
-    click_button "Save and publish changes"
+    provider_details_show_page.train_with_disability_link.click
+
+    provider_details_edit_page.train_with_disability_field.set "Updated: training with disabilities"
+    provider_details_edit_page.save_and_publish.click
 
     expect(page).to have_content "Your changes have been published"
     within_summary_row "Training with disabilities and other needs" do
@@ -72,12 +82,12 @@ feature "About Your Organisation section" do
   end
 
   def then_i_can_edit_contact_details
-    click_link "Change email address"
+    provider_details_show_page.email_link.click
 
-    fill_in "Email address", with: "updated@email.com"
-    fill_in "Telephone number", with: "11111 111111"
-    fill_in "Building and street", with: "123 Updated Street"
-    click_button "Save and publish changes"
+    provider_contact_details_edit_page.email.set "updated@email.com"
+    provider_contact_details_edit_page.telephone.set "11111 111111"
+    provider_contact_details_edit_page.address1.set "123 Updated Street"
+    provider_details_edit_page.save_and_publish.click
 
     expect(page).to have_content "Your changes have been published"
     within_summary_row "Email address" do

--- a/spec/features/publish_interface/edit_provider_details_spec.rb
+++ b/spec/features/publish_interface/edit_provider_details_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "About Your Organisation section" do
+  scenario "Provider user edits provider details" do
+    given_i_am_a_provider_user
+    and_my_provider_has_accrediting_providers
+    when_i_visit_the_details_page
+    then_i_can_edit_info_about_training_with_us
+    then_i_can_edit_info_about_our_accredited_bodies
+    then_i_can_edit_info_about_disabilities_and_other_needs
+    # TODO: then_i_can_edit_info_about_visa_sponsorship
+    then_i_can_edit_contact_details
+  end
+
+  def given_i_am_a_provider_user
+    @current_user = create(:user, :with_provider)
+    @provider = @current_user.providers.first
+    # Mark visa fields as false - switch to true when implementing visa section
+    @provider.update!(can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: false)
+    user_exists_in_dfe_sign_in(user: @current_user)
+  end
+
+  def and_my_provider_has_accrediting_providers
+    @provider.courses << create(:course, :with_accrediting_provider)
+    @accrediting_provider = @provider.accrediting_providers.first
+  end
+
+  def when_i_visit_the_details_page
+    visit details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    click_button "Sign in using DfE Sign-in"
+  end
+
+  def then_i_can_edit_info_about_training_with_us
+    click_link "Change details about training with your organisation"
+    fill_in "Training with you", with: ""
+    click_button "Save and publish changes"
+    within ".govuk-error-summary__body" do
+      expect(page).to have_content "Enter details about training with you"
+    end
+
+    fill_in "Training with you", with: "Updated: Training with you"
+    click_button "Save and publish changes"
+
+    expect(page).to have_content "Your changes have been published"
+    within_summary_row "Training with your organisation" do
+      expect(page).to have_content "Updated: Training with you"
+    end
+  end
+
+  def then_i_can_edit_info_about_our_accredited_bodies
+    click_link "Change details about #{@accrediting_provider.provider_name}"
+    fill_in @accrediting_provider.provider_name, with: "Updated: accredited body description"
+    click_button "Save and publish changes"
+
+    expect(page).to have_content "Your changes have been published"
+    within_summary_row @accrediting_provider.provider_name do
+      expect(page).to have_content "Updated: accredited body description"
+    end
+  end
+
+  def then_i_can_edit_info_about_disabilities_and_other_needs
+    click_link "Change details about training with disabilities and other needs"
+    fill_in "Training with disabilities and other needs", with: "Updated: training with disabilities"
+    click_button "Save and publish changes"
+
+    expect(page).to have_content "Your changes have been published"
+    within_summary_row "Training with disabilities and other needs" do
+      expect(page).to have_content "Updated: training with disabilities"
+    end
+  end
+
+  def then_i_can_edit_contact_details
+    click_link "Change email address"
+
+    fill_in "Email address", with: "updated@email.com"
+    fill_in "Telephone number", with: "11111 111111"
+    fill_in "Building and street", with: "123 Updated Street"
+    click_button "Save and publish changes"
+
+    expect(page).to have_content "Your changes have been published"
+    within_summary_row "Email address" do
+      expect(page).to have_content "updated@email.com"
+    end
+    within_summary_row "Telephone number" do
+      expect(page).to have_content "11111 111111"
+    end
+    within_summary_row "Contact address" do
+      expect(page).to have_content "123 Updated Street"
+    end
+  end
+end

--- a/spec/features/publish_interface/edit_provider_details_spec.rb
+++ b/spec/features/publish_interface/edit_provider_details_spec.rb
@@ -10,15 +10,12 @@ feature "About Your Organisation section" do
     then_i_can_edit_info_about_training_with_us
     then_i_can_edit_info_about_our_accredited_bodies
     then_i_can_edit_info_about_disabilities_and_other_needs
-    # TODO: then_i_can_edit_info_about_visa_sponsorship
     then_i_can_edit_contact_details
   end
 
   def given_i_am_a_provider_user
     @current_user = create(:user, :with_provider)
     @provider = @current_user.providers.first
-    # Mark visa fields as false - switch to true when implementing visa section
-    @provider.update!(can_sponsor_student_visa: false, can_sponsor_skilled_worker_visa: false)
     user_exists_in_dfe_sign_in(user: @current_user)
   end
 

--- a/spec/support/feature_helpers/govuk_components.rb
+++ b/spec/support/feature_helpers/govuk_components.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  module GovukComponents
+    def within_summary_row(row_description, &block)
+      within(page.all(".govuk-summary-list__row").find { |row| row.has_text?(row_description) }) do
+        block.call
+      end
+    end
+  end
+end

--- a/spec/support/feature_helpers/publish_interface_pages.rb
+++ b/spec/support/feature_helpers/publish_interface_pages.rb
@@ -1,0 +1,15 @@
+module FeatureHelpers
+  module PublishInterfacePages
+    def provider_details_show_page
+      @provider_details_show_page ||= PageObjects::PublishInterface::ProviderDetailsShow.new
+    end
+
+    def provider_details_edit_page
+      @provider_details_edit_page ||= PageObjects::PublishInterface::ProviderDetailsEdit.new
+    end
+
+    def provider_contact_details_edit_page
+      @provider_contact_details_edit_page ||= PageObjects::PublishInterface::ProviderContactDetailsEdit.new
+    end
+  end
+end

--- a/spec/support/feature_helpers/support_pages.rb
+++ b/spec/support/feature_helpers/support_pages.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module FeatureHelpers
-  module Pages
+  module SupportPages
     def provider_index_page
       @provider_index_page ||= PageObjects::Support::ProviderIndex.new
     end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -6,6 +6,7 @@ require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
   config.include FeatureHelpers::Authentication, type: :feature
+  config.include FeatureHelpers::GovukComponents, type: :feature
   config.include FeatureHelpers::Pages, type: :feature
   config.include DfESignInUserHelper, type: :feature
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require_relative "feature_helpers/authentication"
-require_relative "feature_helpers/pages"
+require_relative "feature_helpers/support_pages"
+require_relative "feature_helpers/publish_interface_pages"
 require_relative "dfe_sign_in_user_helper"
 
 RSpec.configure do |config|
   config.include FeatureHelpers::Authentication, type: :feature
   config.include FeatureHelpers::GovukComponents, type: :feature
-  config.include FeatureHelpers::Pages, type: :feature
+  config.include FeatureHelpers::SupportPages, type: :feature
+  config.include FeatureHelpers::PublishInterfacePages, type: :feature
   config.include DfESignInUserHelper, type: :feature
 end

--- a/spec/support/page_objects/publish_interface/provider_contact_details_edit.rb
+++ b/spec/support/page_objects/publish_interface/provider_contact_details_edit.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module PublishInterface
+    class ProviderContactDetailsEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/contact"
+
+      element :error_summary, ".govuk-error-summary"
+      element :email, "#publish-interface-about-your-organisation-form-email-field"
+      element :telephone, "#publish-interface-about-your-organisation-form-telephone-field"
+      element :address1, "#publish-interface-about-your-organisation-form-address1-field"
+
+      element :save_and_publish, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/publish_interface/provider_details_edit.rb
+++ b/spec/support/page_objects/publish_interface/provider_details_edit.rb
@@ -1,0 +1,14 @@
+module PageObjects
+  module PublishInterface
+    class ProviderDetailsEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/about"
+
+      element :error_summary, ".govuk-error-summary"
+      element :training_with_you_field, "textarea[name=\"publish_interface_about_your_organisation_form[train_with_us]\"]"
+      element :accredited_body_description_field, "textarea[name=\"publish_interface_about_your_organisation_form[accredited_bodies][][description]\"]"
+      element :train_with_disability_field, "textarea[name=\"publish_interface_about_your_organisation_form[train_with_disability]\"]"
+
+      element :save_and_publish, ".govuk-button"
+    end
+  end
+end

--- a/spec/support/page_objects/publish_interface/provider_details_show.rb
+++ b/spec/support/page_objects/publish_interface/provider_details_show.rb
@@ -1,0 +1,13 @@
+module PageObjects
+  module PublishInterface
+    class ProviderDetailsShow < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/details"
+
+      element :title, ".govuk-heading-l"
+      element :caption, ".govuk-caption-l"
+      element :train_with_us_link, "[data-qa=enrichment__train_with_us] a"
+      element :train_with_disability_link, "[data-qa=enrichment__train_with_disability] a"
+      element :email_link, "[data-qa=enrichment__email] a"
+    end
+  end
+end


### PR DESCRIPTION
### Context
We're gradually moving Publish into the TTAPI codebase. This is the next set of code to be migrated across.

https://trello.com/c/wlq5VfsQ

### Changes proposed in this pull request

- Move over most of the About Your Organisation section (everything except Visa sponsorship, which will follow in a later PR)
- Small improvements to application layout and sign in flow
- See commits for more detail

### Guidance to review
- In a review app or locally, navigate straight to the About Your Organisation section, eg— http://localhost:3001/publish/organisations/1O8/2022/details
- All edits and validation errors should match what's currently in Old Publish (except Visas, tbc)
- The behaviour in the controller actions is essentially a combination of the behaviour in Old Publish and in the V2 API endpoint that Old Publish calls. I've used a form object to combine these things — this seemed clearer and simpler than just dropping the required logic straight into the controller action.
- As per the guidelines [here](https://ukgovernmentdfe.slack.com/archives/C02D2L94TPH/p1637140879014200?thread_ts=1637140438.013100&cid=C02D2L94TPH), route structures and controller actions are a copy of what's in Old Publish currently. There's definitely scope to refactor some of this once the apps are merged, eg—having separate controllers and form objects for 'about your org' details vs contact details, using more Rails-like action names, etc.


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
