### PR TITLE
Add custom error pages

### DIFF
--- a/app/controllers/api_error_controller.rb
+++ b/app/controllers/api_error_controller.rb
@@ -1,5 +1,5 @@
-class ErrorController < ActionController::API
-  def error_500
+class APIErrorController < ActionController::API
+  def error500
     raise "This is an error that is triggered by the application when a user accesses the /error_500 route. If you are seeing this in logs, you can ignore it."
   end
 

--- a/app/controllers/api_error_controller.rb
+++ b/app/controllers/api_error_controller.rb
@@ -4,6 +4,6 @@ class APIErrorController < ActionController::API
   end
 
   def error_nodb
-    raise PG::ConnectionBad.new("This is an error that is triggered by the application when a user accesses the /error_nodb route. If you are seeing this in logs, you can ignore it.")
+    raise PG::ConnectionBad, "This is an error that is triggered by the application when a user accesses the /error_nodb route. If you are seeing this in logs, you can ignore it."
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,7 +32,7 @@ private
     redirect_to sign_in_path if !authenticated?
   end
 
-  def not_found
-    render "errors/not_found", status: :not_found
+  def render_not_found
+    render "errors/not_found", status: :not_found, formats: :html
   end
 end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,0 +1,13 @@
+class ErrorsController < ApplicationController
+  def not_found
+    render status: 404
+  end
+
+  def forbidden
+    render status: 403
+  end
+
+  def internal_server_error
+    render status: 500
+  end
+end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,4 +1,6 @@
 class ErrorsController < ApplicationController
+  skip_before_action :authenticate
+
   def not_found
     render status: 404
   end

--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -1,6 +1,6 @@
 module PublishInterface
   class ProvidersController < PublishInterfaceController
-    rescue_from ActiveRecord::RecordNotFound, with: :not_found
+    rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
     before_action :build_recruitment_cycle
     before_action :build_provider, except: [:index]
 

--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -17,8 +17,9 @@ module PublishInterface
   private
 
     def build_recruitment_cycle
-      cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_cycle
-      @recruitment_cycle = RecruitmentCycle.find_by(year: cycle_year)
+      cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+
+      @recruitment_cycle = RecruitmentCycle.find_by!(year: cycle_year)
     end
 
     def build_provider

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -51,6 +51,6 @@ private
   # end
 
   # def is_current_cycle(cycle_year)
-  #   Settings.current_cycle == cycle_year.to_i
+  #   Settings.current_recruitment_cycle_year == cycle_year.to_i
   # end
 end

--- a/app/views/errors/forbidden.html.erb
+++ b/app/views/errors/forbidden.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "You are not permitted to see this page" %>
+
+<div class="govuk-grid-row" data-qa="errors__forbidden">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">You are not permitted to see this page</h1>
+    <p class="govuk-body">This page is restricted to certain users only.</p>
+    <p class="govuk-body">
+      Contact us by email to request access: <%= bat_contact_mail_to subject: "Publish teacher training courses access request" %>
+    </p>
+  </div>
+</div>

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,11 @@
+<% content_for :page_title, "Sorry, there is a problem with the service" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+    <p class="govuk-body">Try again later.</p>
+    <p class="govuk-body">
+      If you continue to see this error contact the Becoming a Teacher team: <%= bat_contact_mail_to subject: "Problem with the service" %>
+    </p>
+  </div>
+</div>

--- a/app/views/layouts/publish_interface.html.erb
+++ b/app/views/layouts/publish_interface.html.erb
@@ -1,7 +1,7 @@
 <%= extends_layout :application do %>
   <%= content_for(:header) do %>
     <%= render Header::View.new(
-      service_name: I18n.t("publish_service_name"),
+      service_name: I18n.t("service_name"),
       items: header_items(@current_user),
     ) %>
   <% end %>

--- a/app/views/layouts/support.html.erb
+++ b/app/views/layouts/support.html.erb
@@ -1,7 +1,7 @@
 <%= extends_layout :application do %>
   <%= content_for(:header) do %>
     <%= render Header::View.new(
-      service_name: I18n.t("service_name"),
+      service_name: I18n.t("support_service_name"),
       items: header_items(@current_user),
     ) %>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -59,5 +59,7 @@ module ManageCoursesBackend
     config.view_component.show_previews = !Rails.env.production?
 
     config.analytics = config_for(:analytics)
+
+    config.exceptions_app = self.routes
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,6 +60,6 @@ module ManageCoursesBackend
 
     config.analytics = config_for(:analytics)
 
-    config.exceptions_app = self.routes
+    config.exceptions_app = routes
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,6 +1,6 @@
 en:
-  service_name: "Teacher Training API Admin"
-  publish_service_name: "Publish teacher training"
+  service_name: "Publish teacher training courses"
+  support_service_name: "Teacher training API Admin"
   header:
     items:
       sign_out: "Sign out"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -164,6 +164,6 @@ Rails.application.routes.draw do
     end
   end
 
-  get "error_500", to: "error#error_500"
-  get "error_nodb", to: "error#error_nodb"
+  get "error_500", to: "api_error#error500"
+  get "error_nodb", to: "api_error#error_nodb"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,12 @@ Rails.application.routes.draw do
     get "/auth/dfe/signout", to: "sessions#destroy"
   end
 
+  scope via: :all do
+    match "/404", to: "errors#not_found"
+    match "/500", to: "errors#internal_server_error"
+    match "/403", to: "errors#forbidden"
+  end
+
   namespace :publish_interface, path: :publish, as: :publish do
     get "/organisations", to: "providers#index", as: :root
 

--- a/spec/controllers/api_error_controller_spec.rb
+++ b/spec/controllers/api_error_controller_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe ErrorController, type: :controller do
-  describe "GET error_500" do
+RSpec.describe APIErrorController, type: :controller do
+  describe "GET error500" do
     it "throws an error" do
       expect {
-        get :error_500
+        get :error500
       }.to raise_exception RuntimeError
     end
   end


### PR DESCRIPTION
### Context
We don't have GOVUK style error pages for these HTTP response codes in TTAPI.

https://trello.com/c/4PUK3wCt

### Changes proposed in this pull request
- Copy the ones from Publish, along with the routing and controller code.
- Tweak the service name in the header so it makes sense across Support, New Publish, and these error pages.

![Screenshot_20211215_154004-1](https://user-images.githubusercontent.com/519250/146217182-040cd767-9c43-4ed3-bda9-9291c22bc304.png)

![Screenshot_20211215_154047](https://user-images.githubusercontent.com/519250/146217304-e972cfef-99ef-4a4b-a6f0-340a4734b674.png)

![Screenshot_20211215_154129](https://user-images.githubusercontent.com/519250/146217416-a01e5c93-3523-49e3-99e8-cf9d8681218f.png)



### Guidance to review
- Should be fairly easy to trigger a 404 and 403 in the review app, a 500 probably easier to do locally
- If testing locally, you'll need to set `config.consider_all_requests_local` to `false` in `development.rb`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
