### PR TITLE
[448] Rescue from discarded provider in support providers controller

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -3,6 +3,9 @@ module Support
     def index
       @courses = provider.courses.order(:name).page(params[:page] || 1)
       render layout: "provider_record"
+    rescue ActiveRecord::RecordNotFound
+      flash[:warning] = "Provider not found"
+      redirect_to support_providers_path
     end
 
     def edit

--- a/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing a providers courses" do
+  scenario "Provider is discarded" do
+    given_i_am_authenticated_as_an_admin_user
+    and_there_is_a_discarded_provider_with_courses
+    when_i_visit_the_provider_courses_index_page
+    then_i_am_redirected_to_the_providers_page
+  end
+
+private
+
+  def given_i_am_authenticated_as_an_admin_user
+    given_i_am_authenticated(user: create(:user, :admin))
+  end
+
+  def provider
+    @provider ||= create(:provider, courses: [build(:course), build(:course)], discarded_at: Time.zone.now)
+  end
+
+  def and_there_is_a_discarded_provider_with_courses
+    provider
+  end
+
+  def when_i_visit_the_provider_courses_index_page
+    provider_courses_index_page.load(provider_id: provider.id)
+  end
+
+  def then_i_am_redirected_to_the_providers_page
+    expect(provider_index_page).to be_displayed
+  end
+end


### PR DESCRIPTION
### Context

https://sentry.io/organizations/dfe-bat/issues/2827983994/?project=1377944&referrer=slack
https://trello.com/c/oX1yp6n4/448-server-error-when-accessing-deleted-provider

### Changes proposed in this pull request

This error was triggered by trying to access a provider which was discarded from the support console. This may have been a red herring and somebody accessing the provider's courses via the url directly as the providers list in the support console already filters out discarded providers.

The API already returns a 404 so I think this may have just been an edge case with the scenario described above. I've added a fallback for now.

<img width="1214" alt="Screenshot 2021-12-15 at 18 08 51" src="https://user-images.githubusercontent.com/616080/146245900-46e4d5ac-de99-456c-a407-4b73c39255e2.png">

### Guidance to review

- Try to access the same url the sentry error got triggered by `https://localhost:3001/support/providers/17139/courses` and it should redirect to the support providers list

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
