### PR TITLE
Spike proxying of requests from Old Publish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,8 @@ ruby "2.7.4"
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "6.1.4.4"
 
+gem 'rack-cors'
+
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem "webpacker", "~> 5.4"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,8 @@ GEM
     raabro (1.1.6)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-oauth2 (1.16.0)
       activesupport
       attr_required
@@ -710,6 +712,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.5)
   pundit
+  rack-cors
   rails (= 6.1.4.4)
   rails-controller-testing
   rails-erd

--- a/app/controllers/publish_interface/publish_interface_controller.rb
+++ b/app/controllers/publish_interface/publish_interface_controller.rb
@@ -1,5 +1,50 @@
 module PublishInterface
   class PublishInterfaceController < ApplicationController
     layout "publish_interface"
+
+    def current_user
+      @current_user ||= begin
+                          old_publish_cookies = cookies[:_publish_teacher_training_courses_session]
+
+                          if old_publish_cookies.present?
+                            cookie_payload = decrypt_cookie old_publish_cookies
+                            decoded_stored_value = Base64.decode64 cookie_payload["_rails"]["message"]
+                            stored_value = JSON.parse decoded_stored_value
+
+                            email_from_old_publish = stored_value["auth_user"]["uid"]
+                            User.find_by(email: email_from_old_publish)
+                          else
+                            User.find_by(email: user_session&.email)
+                          end
+                        end
+    end
+
+    def authenticated?
+      current_user.present?
+    end
+
+    def decrypt_cookie(cookie)
+      cookie = URI.unescape(cookie)
+      data, iv, auth_tag = cookie.split("--").map do |v|
+        Base64.strict_decode64(v)
+      end
+      cipher = OpenSSL::Cipher.new("aes-256-gcm")
+
+      # Compute the encryption key
+      secret_key_base = Rails.application.secret_key_base
+      secret = OpenSSL::PKCS5.pbkdf2_hmac_sha1(secret_key_base, "authenticated encrypted cookie", 1000, cipher.key_len)
+
+      # Setup cipher for decryption and add inputs
+      cipher.decrypt
+      cipher.key = secret
+      cipher.iv  = iv
+      cipher.auth_tag = auth_tag
+      cipher.auth_data = ""
+
+      # Perform decryption
+      cookie_payload = cipher.update(data)
+      cookie_payload << cipher.final
+      JSON.parse cookie_payload
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,6 +23,8 @@ Bundler.require(*Rails.groups)
 
 module ManageCoursesBackend
   class Application < Rails::Application
+    config.hosts << "www.ttapi.test"
+    config.hosts << "www.publish.test"
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,2 @@
+Rails.application.config.action_controller.asset_host = "www.ttapi.test:3001"
+

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,6 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "http://www.publish.test:3000"
+    resource "*", headers: :any, methods: %i[get post]
+  end
+end


### PR DESCRIPTION
### Context
Our current strategy for moving user traffic between Old and New Publish involves redirecting and linking users explicitly between two different subdomains (`www` and `www2`), followed by a CNAME switch at the end of the migration and a period of time where we have permanent redirects in the app.

An alternative is for Old Publish to transparently proxy requests to New Publish when the user navigates to migrated sections. TTAPI master now contains all of Old Publish's "About Your Organisation" section, so we can test the proxy idea against a substantial part of the app.

### Changes proposed in this pull request

This draft PR includes the minimum set of changes required to:

- Identify migrated parts of the app in Old Publish, and proxy the requests to New Publish
- Ensure assets load correctly when rendering a response from New Publish
- Authenticate against New Publish using the Old Publish session cookie (ie—if you've logged in on Old Publish side, the user should be able to access their New Publish pages without issue).

### Guidance to review
This is easiest to test locally. 

- In addition to running TTAPI with this branch, you'll need to run Old Publish with [this one](https://github.com/DFE-Digital/publish-teacher-training/pull/2037).

- Prior to running the apps, you'll need both of them to have the same secret_key_base. In both directories, put the same string value in `tmp/development_secret.txt` (the value can be anything).

- Add the following to your /etc/hosts:
```
127.0.0.1  www.publish.test
127.0.0.1  www.ttapi.test
```
- Navigate to http://www.publish.test:3000

- Log in as the Mary persona

- Click through any provider and access the "About your organisation" section.

- This should load the response from TTAPI (note the slight change in the application header, which hasn't been aligned between the two apps yet; log entries should also show a response served by TTAPI).

In terms of review, I think we need to decide:

- Is this worth proceeding with, rather than the redirect-based approach we've outlined previously?
- Which of these two approaches is conceptually easier to work with, and likely to create the least amount of complexity as the migration progresses?

**Some additional things to consider**

This approach was originally suggested as a way to avoid the following:
- Managing redirects, including adding long-lived ones at the end of the migration to pick up any stale requests to `www2`
- Double authentication (with both Old Publish and New Publish), which would temporarily be required during the migration

In practice, we'll need redirects at the end of the migration one way or another because New Publish namespaces the app routes under `/publish`, whereas Old Publish doesn't.

- We'll need config in all production-like environments to make the secret key base the same in both apps
- We've added some non-trivial cookie decryption code to New Publish, which presents the risk of some maintenance overhead during the migration if cookie signing/encryption behaviour changes at all (in a Rails upgrade, for example).

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
