### PR TITLE
[489] Rubocop To Do: Extract embedded classes from code blocks

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,15 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 8
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: enums
-Lint/ConstantDefinitionInBlock:
-  Exclude:
-    - 'lib/tasks/big_query.rake'
-    - 'spec/validators/phone_validator_spec.rb'
-    - 'spec/validators/reference_number_format_validator_spec.rb'
-
 # Offense count: 2
 # Configuration parameters: IgnoreLiteralBranches, IgnoreConstantBranches.
 Lint/DuplicateBranch:

--- a/lib/tasks/big_query.rake
+++ b/lib/tasks/big_query.rake
@@ -1,19 +1,17 @@
 require "csv"
 
 namespace :big_query do
-  ON_REDIS_ERROR_WAIT_TIME_IN_SECONDS = 10
-  ON_REDIS_ERROR_RETRY_ATTEMPTS = 5
+  Object.const_set("ON_REDIS_ERROR_WAIT_TIME_IN_SECONDS", 10)
+  Object.const_set("ON_REDIS_ERROR_RETRY_ATTEMPTS", 5)
 
   desc <<~DESC
     Send import events for configured entities
   DESC
 
   task send_import_events: :environment do
-    class CourseSite < ApplicationRecord; end
-
-    class OrganisationProvider < ApplicationRecord; end
-
-    class Session < ApplicationRecord; end
+    Object.const_set("CourseSite", Class.new(ApplicationRecord))
+    Object.const_set("OrganisationProvider", Class.new(ApplicationRecord))
+    Object.const_set("Session", Class.new(ApplicationRecord))
 
     conf = Rails.configuration.analytics
 

--- a/spec/validators/phone_validator_spec.rb
+++ b/spec/validators/phone_validator_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
+class PhoneValidatorTest
+  include ActiveRecord::Validations
+
+  attr_accessor :phone_number
+
+  validates :phone_number, phone: true
+end
+
 describe PhoneValidator do
-  class PhoneValidatorTest
-    include ActiveRecord::Validations
-
-    attr_accessor :phone_number
-
-    validates :phone_number, phone: true
-  end
-
   let(:model) do
     PhoneValidatorTest.new
   end

--- a/spec/validators/reference_number_format_validator_spec.rb
+++ b/spec/validators/reference_number_format_validator_spec.rb
@@ -1,14 +1,14 @@
 require "rails_helper"
 
+class ReferenceNumberFormatValidatorTest
+  include ActiveModel::Validations
+
+  attr_accessor :reference_number
+
+  validates :reference_number, reference_number_format: { allow_blank: true, maximum: 8, minimum: 8, message: "error" }
+end
+
 describe ReferenceNumberFormatValidator do
-  class ReferenceNumberFormatValidatorTest
-    include ActiveModel::Validations
-
-    attr_accessor :reference_number
-
-    validates :reference_number, reference_number_format: { allow_blank: true, maximum: 8, minimum: 8, message: "error" }
-  end
-
   let(:reference_number) { "12345678" }
 
   let(:model) do


### PR DESCRIPTION
### Context

Clearing rubocop to do: https://trello.com/c/UhJu4WFi/489-clear-rubocoptodo-part-2

### Changes proposed in this pull request

For the validator spec files i have moved the classes outside of the test describe blocks.

For the rake task I have done the same, but I had to additionally redefine ActiveRecord as classes are now outside of the namespace. Additionally, constants triggered a further linting error and so have moved themout too.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
