### PR TITLE
[499] Add locations list to providers tab in support console

### DIFF
--- a/app/controllers/support/locations_controller.rb
+++ b/app/controllers/support/locations_controller.rb
@@ -1,0 +1,17 @@
+module Support
+  class LocationsController < SupportController
+    def index
+      @sites = provider.sites.order(:location_name).page(params[:page] || 1)
+      render layout: "provider_record"
+    rescue ActiveRecord::RecordNotFound
+      flash[:warning] = "Provider not found"
+      redirect_to support_providers_path
+    end
+
+  private
+
+    def provider
+      @provider ||= RecruitmentCycle.current.providers.find(params[:provider_id])
+    end
+  end
+end

--- a/app/views/layouts/provider_record.html.erb
+++ b/app/views/layouts/provider_record.html.erb
@@ -14,6 +14,7 @@
     { name: "Details", url: support_provider_path(@provider) },
     { name: "Users", url: users_support_provider_path(@provider) },
     { name: "Courses", url: support_provider_courses_path(@provider) },
+    { name: "Locations", url: support_provider_locations_path(@provider) },
   ]) %>
 
   <%= yield %>

--- a/app/views/support/locations/index.html.erb
+++ b/app/views/support/locations/index.html.erb
@@ -1,0 +1,35 @@
+<%= render PageTitle::View.new(title: "support.providers.locations.index") %>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th scope="col" class="govuk-table__header">Name</th>
+      <th scope="col" class="govuk-table__header">Location code</th>
+      <th scope="col" class="govuk-table__header">URN</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <% if @sites.any? %>
+      <% @sites.each do |site| %>
+        <tr class="govuk-table__row location-row">
+          <td class="govuk-table__cell name">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1"><%= site.location_name %></span>
+          </td>
+          <td class="govuk-table__cell code">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= site.code %> <%= site.code == "-" ? "(dash)" : "" %>
+            </span>
+          </td>
+          <td class="govuk-table__cell urn">
+            <span class="govuk-!-display-block govuk-!-margin-bottom-1">
+              <%= site.urn.presence || "<strong class='govuk-error-message govuk-\!-display-inline'>(Missing)</strong>".html_safe %>
+            </span>
+          </td>
+        </tr>
+      <% end %>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render Paginator::View.new(scope: @sites) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -22,6 +22,8 @@ en:
           courses:
             index: "Courses"
             edit: "Edit course details"
+          locations:
+            index: "Locations"
         users:
           index: "Users"
           show: "User overview"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     resources :providers, except: %i[destroy] do
       get :users, on: :member
       resources :courses, only: %i[index edit update]
+      resources :locations, only: :index
     end
     resources :users, only: %i[index show new create destroy]
 

--- a/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
+++ b/spec/features/support/providers/courses/viewing_providers_courses_spec.rb
@@ -17,7 +17,7 @@ private
   end
 
   def provider
-    @provider ||= create(:provider, courses: [build(:course), build(:course)], discarded_at: Time.zone.now)
+    @provider ||= create(:provider, courses: [build(:course)], discarded_at: Time.zone.now)
   end
 
   def and_there_is_a_discarded_provider_with_courses

--- a/spec/features/support/providers/locations/locations_list_spec.rb
+++ b/spec/features/support/providers/locations/locations_list_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing a providers courses" do
+  scenario "i can a provider's locations" do
+    given_i_am_authenticated(user: create(:user, :admin))
+    when_i_visit_a_provider_locations_page
+    then_i_should_see_a_list_of_locations
+  end
+
+  def when_i_visit_a_provider_locations_page
+    provider_locations_index_page.load(provider_id: provider.id)
+  end
+
+  def then_i_should_see_a_list_of_locations
+    expect(provider_locations_index_page.locations.size).to eq(1)
+
+    expect(provider_locations_index_page.locations.first.name).to have_text(site.location_name)
+    expect(provider_locations_index_page.locations.first.code).to have_text(site.code)
+    expect(provider_locations_index_page.locations.first.urn).to have_text(site.urn)
+  end
+
+  def provider
+    @provider ||= create(:provider, sites: [build(:site)])
+  end
+
+  def site
+    @site ||= provider.sites.first
+  end
+end

--- a/spec/support/feature_helpers/support_pages.rb
+++ b/spec/support/feature_helpers/support_pages.rb
@@ -26,6 +26,10 @@ module FeatureHelpers
       @provider_courses_index_page ||= PageObjects::Support::Provider::CoursesIndex.new
     end
 
+    def provider_locations_index_page
+      @provider_locations_index_page ||= PageObjects::Support::Provider::LocationsIndex.new
+    end
+
     def course_edit_page
       @course_edit_page ||= PageObjects::Support::Provider::CourseEdit.new
     end

--- a/spec/support/page_objects/sections/location.rb
+++ b/spec/support/page_objects/sections/location.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class Location < PageObjects::Sections::Base
+      element :name, ".name"
+      element :code, ".code"
+      element :urn, ".urn"
+    end
+  end
+end

--- a/spec/support/page_objects/support/provider/locations_index_page.rb
+++ b/spec/support/page_objects/support/provider/locations_index_page.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    module Provider
+      class LocationsIndex < PageObjects::Base
+        set_url "/support/providers/{provider_id}/locations"
+
+        sections :locations, Sections::Location, ".location-row"
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/qHQhzncn/499-add-locations-tab-in-support-console

### Changes proposed in this pull request

- Add the locations list to the providers tab in the support console

<img width="1101" alt="Screenshot 2021-12-23 at 16 47 22" src="https://user-images.githubusercontent.com/616080/147270062-b4d27624-9820-4a30-8f97-204b6adc61b7.png">

### Guidance to review

`support/providers/18035/locations`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
