### PR TITLE
[398] Set session expiry to 3 days

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -49,6 +49,8 @@ module ManageCoursesBackend
 
     config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"
 
+    config.session_store :cookie_store, expire_after: 3.days
+
     config.skylight.environments = Settings.skylight.enable ? [Rails.env] : []
     config.skylight.logger = SemanticLogger[Skylight]
     config.skylight.log_level = :fatal


### PR DESCRIPTION
### Context

- https://trello.com/c/CaFE7I3v/398-increase-user-session-expiry

### Changes proposed in this pull request

Increase session expiry to 3 days to coincide with https://github.com/DFE-Digital/publish-teacher-training/pull/2048

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
