### PR TITLE
Adding qa2 routes for publish-ttapi redirection

### DIFF
--- a/terraform/modules/paas/data.tf
+++ b/terraform/modules/paas/data.tf
@@ -6,6 +6,10 @@ data cloudfoundry_domain api_publish_service_gov_uk {
   name = "api.publish-teacher-training-courses.service.gov.uk"
 }
 
+data cloudfoundry_domain publish_service_gov_uk {
+  name = "publish-teacher-training-courses.service.gov.uk"
+}
+
 data cloudfoundry_org org {
   name = "dfe"
 }

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -74,6 +74,13 @@ resource cloudfoundry_route web_app_service_gov_uk_route {
   hostname = var.web_app_host_name
 }
 
+resource cloudfoundry_route web_app_publish_gov_uk_route {
+  for_each = toset(var.publish_gov_uk_host_names)
+  domain   = data.cloudfoundry_domain.publish_service_gov_uk.id
+  space    = data.cloudfoundry_space.space.id
+  hostname = each.value
+}
+
 resource cloudfoundry_service_instance postgres {
   name         = local.postgres_service_name
   space        = data.cloudfoundry_space.space.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -28,6 +28,11 @@ variable app_environment {}
 
 variable app_environment_variables { type = map }
 
+variable "publish_gov_uk_host_names" {
+  default = []
+  type = list
+}
+
 locals {
   app_name_suffix              = var.app_environment != "review" ? var.app_environment : "pr-${var.web_app_host_name}"
   web_app_name                 = "teacher-training-api-${local.app_name_suffix}"
@@ -55,5 +60,10 @@ locals {
     restore_from_latest_snapshot_of = local.qa_postgres_service_instance
   }
   postgres_params = merge(local.postgres_extensions, var.app_environment == "review" ? local.review_app_postgres_params : {})
-  web_app_routes  = [cloudfoundry_route.web_app_service_gov_uk_route, cloudfoundry_route.web_app_cloudapps_digital_route]
+
+  web_app_routes = flatten([
+    cloudfoundry_route.web_app_cloudapps_digital_route,
+    cloudfoundry_route.web_app_service_gov_uk_route,
+    values(cloudfoundry_route.web_app_publish_gov_uk_route)
+  ])
 }

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -59,6 +59,7 @@ module paas {
   postgres_service_plan     = var.paas_postgres_service_plan
   redis_service_plan        = var.paas_redis_service_plan
   app_environment_variables = local.paas_app_environment_variables
+  publish_gov_uk_host_names = var.publish_gov_uk_host_names
 }
 
 module statuscake {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,6 +36,11 @@ variable key_vault_infra_secret_name {}
 
 variable azure_credentials { default = null }
 
+variable "publish_gov_uk_host_names" {
+  default = []
+  type = list
+}
+
 variable statuscake_alerts {
   type    = map
   default = {}

--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -8,6 +8,7 @@ paas_worker_app_instances  = 1
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
+publish_gov_uk_host_names = ["qa2"]
 
 # KeyVault
 key_vault_resource_group = "s121d01-shared-rg"


### PR DESCRIPTION
### Context

Adding qa2 routes for publish-ttapi redirection

https://trello.com/c/uwBX42F6/392-publish-ttapi-merge-set-up-dns-record-for-www2

### Changes proposed in this pull request
-Following the same format as applied to apply-for-teacher-training
-Changing host names to a list
-Extra variable for redirect hostname
-Added redirect domain

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
