### PR TITLE
[489] Rubocop ToDo: Rename Accessor Methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,12 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 2
-Naming/AccessorMethodName:
-  Exclude:
-    - 'app/controllers/api/v2/providers_controller.rb'
-    - 'app/models/course.rb'
-
 # Offense count: 1
 # Configuration parameters: IgnoredPatterns.
 # SupportedStyles: snake_case, camelCase

--- a/app/controllers/api/v2/providers_controller.rb
+++ b/app/controllers/api/v2/providers_controller.rb
@@ -1,7 +1,7 @@
 module API
   module V2
     class ProvidersController < API::V2::ApplicationController
-      before_action :get_user, if: -> { params[:user_id].present? }
+      before_action :find_user, if: -> { params[:user_id].present? }
       before_action :build_recruitment_cycle
       before_action :build_provider, except: %i[index suggest suggest_any]
 
@@ -115,7 +115,7 @@ module API
                       )
       end
 
-      def get_user
+      def find_user
         @user = User.find(params[:user_id])
       end
 

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -82,12 +82,12 @@ class Course < ApplicationRecord
   has_many :course_subjects,
            -> { order :position },
            inverse_of: :course,
-           before_add: :set_subject_position
+           before_add: :assign_subject_position
 
   delegate :recruitment_cycle, :provider_code, to: :provider, allow_nil: true
   delegate :after_2021?, to: :recruitment_cycle, allow_nil: true, prefix: :recruitment_cycle
 
-  def set_subject_position(course_subject)
+  def assign_subject_position(course_subject)
     return unless course_subject.subject.secondary_subject?
 
     secondary_course_subjects = course_subjects.select { |cs| cs.subject.secondary_subject? }


### PR DESCRIPTION
### Context

Clear up of Rubocop to do: https://trello.com/c/UhJu4WFi/489-clear-rubocoptodo-part-2

### Changes proposed in this pull request

Renaming methods to comply with linter

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
