### PR TITLE
[515] Create helper to generate old publish link for migration

### DIFF
--- a/app/helpers/publish_helper.rb
+++ b/app/helpers/publish_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module PublishHelper
+  def old_publish_link_for(path)
+    "#{Settings.publish_url}#{path.sub(/\/publish\//, '/')}"
+  end
+end

--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -2,7 +2,12 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(
+      old_publish_link_for(
+        details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)
+      )
+    ) 
+  %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish_interface/providers/contacts/edit.html.erb
+++ b/app/views/publish_interface/providers/contacts/edit.html.erb
@@ -2,7 +2,12 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @provider_contact_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider_contact_form.provider_code, @provider_contact_form.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(
+      old_publish_link_for(
+        details_publish_provider_recruitment_cycle_path(@provider_contact_form.provider_code, @provider_contact_form.recruitment_cycle_year)
+      )
+    ) 
+  %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish_interface/providers/visas/edit.html.erb
+++ b/app/views/publish_interface/providers/visas/edit.html.erb
@@ -2,7 +2,12 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @provider_visa_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(
+      old_publish_link_for(
+        details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+      )
+    )
+  %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/spec/helpers/publish_helper_spec.rb
+++ b/spec/helpers/publish_helper_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe PublishHelper do
+  include PublishHelper
+
+  describe "#old_publish_link_for" do
+    let(:path) { "/publish/organisations/random" }
+    let(:expected_path) { "#{Settings.publish_url}/organisations/random" }
+
+    it "returns a correct url linking back to the old publish" do
+      expect(old_publish_link_for(path)).to eq(expected_path)
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/6Ay3bdEp/515-add-breadcrumbs-helper-for-migrated-publish-code

### Changes proposed in this pull request

Create a helper for generating return links to old publish for migrated sections

### Guidance to review

Head to https://teacher-training-api-pr-2394.london.cloudapps.digital/publish/organisations/2AT/2022/details (sign in as colin) and click on any of change links, the back link at the top should return you to old publish

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
