### PR TITLE
[500] Add application_open_from in the edit course form

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -46,9 +46,9 @@ module Support
       when "start_date(3i)" then "start_date_day"
       when "start_date(2i)" then "start_date_month"
       when "start_date(1i)" then "start_date_year"
-      when "applications_open_from(3i)" then "applications_open_from_date_day"
-      when "applications_open_from(2i)" then "applications_open_from_date_month"
-      when "applications_open_from(1i)" then "applications_open_from_date_year"
+      when "applications_open_from(3i)" then "applications_open_from_day"
+      when "applications_open_from(2i)" then "applications_open_from_month"
+      when "applications_open_from(1i)" then "applications_open_from_year"
       else key
       end
     end

--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -36,15 +36,19 @@ module Support
     def update_course_params
       params.require(:support_edit_course_form).permit(
         *EditCourseForm::FIELDS,
-        :"start_date(3i)", :"start_date(2i)", :"start_date(1i)"
-      ).transform_keys { |key| start_date_field_to_attribute(key) }
+        :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
+        :"applications_open_from(3i)", :"applications_open_from(2i)", :"applications_open_from(1i)"
+      ).transform_keys { |key| date_field_to_attribute(key) }
     end
 
-    def start_date_field_to_attribute(key)
+    def date_field_to_attribute(key)
       case key
       when "start_date(3i)" then "start_date_day"
       when "start_date(2i)" then "start_date_month"
       when "start_date(1i)" then "start_date_year"
+      when "applications_open_from(3i)" then "applications_open_from_date_day"
+      when "applications_open_from(2i)" then "applications_open_from_date_month"
+      when "applications_open_from(1i)" then "applications_open_from_date_year"
       else key
       end
     end

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -8,8 +8,9 @@ module Support
     ].freeze
 
     attr_accessor(*FIELDS)
-    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course
+    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_date_day, :applications_open_from_date_month, :applications_open_from_date_year
     validate :validate_start_date_format
+    validate :validate_applications_open_from_date_format
 
     def initialize(course)
       @course = course
@@ -20,6 +21,9 @@ module Support
         start_date_day: @course.start_date&.day,
         start_date_month: @course.start_date&.month,
         start_date_year: @course.start_date&.year,
+        applications_open_from_date_day: @course.applications_open_from&.day,
+        applications_open_from_date_month: @course.applications_open_from&.month,
+        applications_open_from_date_year: @course.applications_open_from&.year,
       )
     end
 
@@ -38,24 +42,44 @@ module Support
     end
 
     def start_date
-      @start_date ||= check_start_date
+      @start_date ||= check_date(:start_date)
+    end
+
+    def applications_open_from_date
+      @applications_open_from_date ||= check_date(:applications_open_from_date)
     end
 
   private
 
-    def check_start_date
-      date_args = [start_date_year, start_date_month, start_date_day].map(&:to_i)
+    def check_date(date_type)
+      date_args = date_array(date_type).map(&:to_i)
 
-      Date.valid_date?(*date_args) ? Date.new(*date_args) : Struct.new(:day, :month, :year).new(start_date_day, start_date_month, start_date_year)
+      if Date.valid_date?(*date_args)
+        Date.new(*date_args)
+      elsif date_args_blank?(date_type)
+        nil
+      else
+        OpenStruct.new(
+          day: send("#{date_type}_day"),
+          month: send("#{date_type}_month"),
+          year: send("#{date_type}_year"),
+        )
+      end
+    end
+
+    def date_array(date_type)
+      [send("#{date_type}_year"), send("#{date_type}_month"), send("#{date_type}_day")]
     end
 
     def assign_attributes_to_course
       attributes = {
         course_code: course_code,
         name: name,
+        start_date: start_date,
+        applications_open_from: applications_open_from_date,
       }
 
-      attributes[:start_date] = start_date if valid_date? || date_args_blank?
+      attributes[:applications_open_from] = applications_open_from_date if valid_date?(:applications_open_from_date)
 
       course.assign_attributes(attributes)
     end
@@ -65,17 +89,25 @@ module Support
     end
 
     def validate_start_date_format
-      return if date_args_blank?
-
-      errors.add(:start_date, "Start date format is invalid") unless valid_date?
+      validate_date(:start_date)
     end
 
-    def valid_date?
-      start_date.is_a?(Date)
+    def validate_applications_open_from_date_format
+      validate_date(:applications_open_from_date)
     end
 
-    def date_args_blank?
-      [start_date_year, start_date_month, start_date_day].any?(&:blank?)
+    def validate_date(date_type)
+      return if date_args_blank?(date_type)
+
+      errors.add(date_type, "#{date_type.to_s.humanize.capitalize} format is invalid") unless valid_date?(date_type)
+    end
+
+    def valid_date?(date_type)
+      send(date_type).is_a?(Date)
+    end
+
+    def date_args_blank?(date_type)
+      date_array(date_type).any?(&:blank?)
     end
   end
 end

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -97,7 +97,16 @@ module Support
     def validate_date(date_type)
       return if date_args_blank?(date_type)
 
-      errors.add(date_type, "#{date_type.to_s.humanize.capitalize} format is invalid") unless valid_date?(date_type)
+      errors.add(date_type, "#{attribute(date_type)} format is invalid") unless valid_date?(date_type)
+    end
+
+    def attribute(date_type)
+      case date_type
+      when :applications_open_from
+        "#{date_type.to_s.humanize.capitalize} date"
+      else
+        date_type.to_s.humanize.capitalize
+      end
     end
 
     def valid_date?(date_type)

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -8,9 +8,9 @@ module Support
     ].freeze
 
     attr_accessor(*FIELDS)
-    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_date_day, :applications_open_from_date_month, :applications_open_from_date_year
+    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year
     validate :validate_start_date_format
-    validate :validate_applications_open_from_date_format
+    validate :validate_applications_open_from_format
 
     def initialize(course)
       @course = course
@@ -21,9 +21,9 @@ module Support
         start_date_day: @course.start_date&.day,
         start_date_month: @course.start_date&.month,
         start_date_year: @course.start_date&.year,
-        applications_open_from_date_day: @course.applications_open_from&.day,
-        applications_open_from_date_month: @course.applications_open_from&.month,
-        applications_open_from_date_year: @course.applications_open_from&.year,
+        applications_open_from_day: @course.applications_open_from&.day,
+        applications_open_from_month: @course.applications_open_from&.month,
+        applications_open_from_year: @course.applications_open_from&.year,
       )
     end
 
@@ -45,8 +45,8 @@ module Support
       @start_date ||= check_date(:start_date)
     end
 
-    def applications_open_from_date
-      @applications_open_from_date ||= check_date(:applications_open_from_date)
+    def applications_open_from
+      @applications_open_from ||= check_date(:applications_open_from)
     end
 
   private
@@ -54,7 +54,17 @@ module Support
     def check_date(date_type)
       date_args = date_array(date_type).map(&:to_i)
 
-      Date.new(*date_args) if Date.valid_date?(*date_args)
+      return Date.new(*date_args) if Date.valid_date?(*date_args)
+
+      date_struct(date_type)
+    end
+
+    def date_struct(date_type)
+      Struct.new(:day, :month, :year).new(
+        send("#{date_type}_day"),
+        send("#{date_type}_month"),
+        send("#{date_type}_year"),
+      )
     end
 
     def date_array(date_type)
@@ -66,10 +76,8 @@ module Support
         course_code: course_code,
         name: name,
         start_date: start_date,
-        applications_open_from: applications_open_from_date,
+        applications_open_from: applications_open_from,
       }
-
-      attributes[:applications_open_from] = applications_open_from_date if valid_date?(:applications_open_from_date)
 
       course.assign_attributes(attributes)
     end
@@ -82,8 +90,8 @@ module Support
       validate_date(:start_date)
     end
 
-    def validate_applications_open_from_date_format
-      validate_date(:applications_open_from_date)
+    def validate_applications_open_from_format
+      validate_date(:applications_open_from)
     end
 
     def validate_date(date_type)

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -54,17 +54,7 @@ module Support
     def check_date(date_type)
       date_args = date_array(date_type).map(&:to_i)
 
-      if Date.valid_date?(*date_args)
-        Date.new(*date_args)
-      elsif date_args_blank?(date_type)
-        nil
-      else
-        OpenStruct.new(
-          day: send("#{date_type}_day"),
-          month: send("#{date_type}_month"),
-          year: send("#{date_type}_year"),
-        )
-      end
+      Date.new(*date_args) if Date.valid_date?(*date_args)
     end
 
     def date_array(date_type)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -768,7 +768,7 @@ private
   end
 
   def validate_applications_open_from
-    if applications_open_from.blank?
+    if applications_open_from.blank? || applications_open_from.is_a?(Struct)
       errors.add(:applications_open_from, :blank)
     elsif !valid_date_range.include?(applications_open_from)
       chosen_date = short_date(applications_open_from)

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -13,6 +13,8 @@
 
       <%= f.govuk_date_field(:start_date, legend: { text: "Start date" }) %>
 
+      <%= f.govuk_date_field(:applications_open_from, legend: { text: "Applications open from date" }) %>
+
       <%= f.govuk_submit t("support.update_record") %>
     <% end %>
 

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -36,6 +36,7 @@ feature "Edit provider course details" do
       when_i_fill_in_course_code_with existing_course_code
       and_i_fill_in_course_title_with valid_course_name
       and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, invalid_date_year
+      and_i_fill_in_course_application_open_from_with valid_date_day, valid_date_month, invalid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
       and_it_contains_invalid_value_errors
@@ -43,15 +44,18 @@ feature "Edit provider course details" do
 
     scenario "I cannot use invalid date format" do
       when_i_fill_in_course_start_date_with invalid_date_day, invalid_date_month, valid_date_year
+      and_i_fill_in_course_application_open_from_with invalid_date_day, invalid_date_month, valid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
       and_it_contains_start_date_format_error
+      and_it_contains_applications_open_from_format_error
     end
 
     scenario "I cannot use a blank course details" do
       when_i_fill_in_course_code_with blank_value
       and_i_fill_in_course_title_with blank_value
       and_i_fill_in_course_start_date_with blank_value, blank_value, blank_value
+      and_i_fill_in_course_application_open_from_with blank_value, blank_value, blank_value
       and_i_click_the_continue_button
       then_i_see_the_error_summary
       and_it_contains_blank_errors
@@ -190,9 +194,14 @@ private
     expect(course_edit_page.error_summary.text).to include("Start date format is invalid")
   end
 
+  def and_it_contains_applications_open_from_format_error
+    expect(course_edit_page.error_summary.text).to include("Applications open from format is invalid")
+  end
+
   def and_it_contains_blank_errors
     expect(course_edit_page.error_summary.text).to include("Course code cannot be blank")
     expect(course_edit_page.error_summary.text).to include("Course title cannot be blank")
     expect(course_edit_page.error_summary.text).to include("Start date cannot have blank values")
+    expect(course_edit_page.error_summary.text).to include("Select when applications will open and enter the date if applicable")
   end
 end

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -195,7 +195,7 @@ private
   end
 
   def and_it_contains_applications_open_from_format_error
-    expect(course_edit_page.error_summary.text).to include("Applications open from format is invalid")
+    expect(course_edit_page.error_summary.text).to include("Applications open from date format is invalid")
   end
 
   def and_it_contains_blank_errors

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -21,7 +21,8 @@ feature "Edit provider course details" do
     scenario "I can edit a course details" do
       when_i_fill_in_course_code_with valid_course_code
       and_i_fill_in_course_title_with valid_course_name
-      and_i_fill_in_course_start_date_with valid_start_date_day, valid_start_date_month, valid_start_date_year
+      and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, valid_date_year
+      and_i_fill_in_course_application_open_from_with valid_date_day, valid_date_month, valid_date_year
       and_i_click_the_continue_button
       then_i_am_redirected_back_to_the_provider_courses_index_page
       and_the_course_name_and_code_are_updated
@@ -34,14 +35,14 @@ feature "Edit provider course details" do
     scenario "I cannot use invalid course details" do
       when_i_fill_in_course_code_with existing_course_code
       and_i_fill_in_course_title_with valid_course_name
-      and_i_fill_in_course_start_date_with valid_start_date_day, valid_start_date_month, invalid_start_date_year
+      and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, invalid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
       and_it_contains_invalid_value_errors
     end
 
     scenario "I cannot use invalid date format" do
-      when_i_fill_in_course_start_date_with invalid_start_date_day, invalid_start_date_month, valid_start_date_year
+      when_i_fill_in_course_start_date_with invalid_date_day, invalid_date_month, valid_date_year
       and_i_click_the_continue_button
       then_i_see_the_error_summary
       and_it_contains_start_date_format_error
@@ -94,20 +95,20 @@ private
     @course_name ||= "Geography"
   end
 
-  def valid_start_date_day
-    @valid_start_date_day ||= "1"
+  def valid_date_day
+    @valid_date_day ||= "1"
   end
 
-  def invalid_start_date_day
-    @invalid_start_date_day ||= "111"
+  def invalid_date_day
+    @invalid_date_day ||= "111"
   end
 
-  def valid_start_date_month
-    @valid_start_date_month ||= "10"
+  def valid_date_month
+    @valid_date_month ||= "10"
   end
 
-  def invalid_start_date_month
-    @invalid_start_date_month ||= "90"
+  def invalid_date_month
+    @invalid_date_month ||= "90"
   end
 
   def valid_course_code
@@ -122,12 +123,12 @@ private
     @existing_course_code ||= provider.courses.second.course_code
   end
 
-  def valid_start_date_year
-    @valid_start_date_year ||= "2021"
+  def valid_date_year
+    @valid_date_year ||= "2021"
   end
 
-  def invalid_start_date_year
-    @invalid_start_date_year ||= "2026"
+  def invalid_date_year
+    @invalid_date_year ||= "2026"
   end
 
   def blank_value
@@ -148,7 +149,14 @@ private
     course_edit_page.start_date_year.set(year)
   end
 
+  def when_i_fill_in_course_application_open_from_with(day, month, year)
+    course_edit_page.application_open_from_day.set(day)
+    course_edit_page.application_open_from_month.set(month)
+    course_edit_page.application_open_from_year.set(year)
+  end
+
   alias_method :and_i_fill_in_course_start_date_with, :when_i_fill_in_course_start_date_with
+  alias_method :and_i_fill_in_course_application_open_from_with, :when_i_fill_in_course_application_open_from_with
 
   def and_i_click_the_continue_button
     course_edit_page.continue.click
@@ -164,9 +172,9 @@ private
   end
 
   def then_i_see_the_updated_start_date
-    expect(course_edit_page.start_date_day.value).to eq(valid_start_date_day)
-    expect(course_edit_page.start_date_month.value).to eq(valid_start_date_month)
-    expect(course_edit_page.start_date_year.value).to eq(valid_start_date_year)
+    expect(course_edit_page.start_date_day.value).to eq(valid_date_day)
+    expect(course_edit_page.start_date_month.value).to eq(valid_date_month)
+    expect(course_edit_page.start_date_year.value).to eq(valid_date_year)
   end
 
   def then_i_see_the_error_summary

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -65,7 +65,7 @@ module Support
           expect(subject.valid?).to eq(false)
           expect(subject.errors.messages.count).to eq(2)
           expect(subject.errors.messages[:start_date]).to include("Start date format is invalid")
-          expect(subject.errors.messages[:applications_open_from]).to include("Applications open from format is invalid")
+          expect(subject.errors.messages[:applications_open_from]).to include("Applications open from date format is invalid")
         end
       end
 

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 module Support
   describe EditCourseForm do
     let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(2022, 9, 1)) }
-    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2022" } }
-    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: "2022" } }
-    let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027" } }
-    let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "" } }
+    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2022", applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: "2022", applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
+    let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }
 
     subject { described_class.new(course) }
 
@@ -63,8 +63,9 @@ module Support
           subject.save
 
           expect(subject.valid?).to eq(false)
-          expect(subject.errors.messages.count).to eq(1)
+          expect(subject.errors.messages.count).to eq(2)
           expect(subject.errors.messages[:start_date]).to include("Start date format is invalid")
+          expect(subject.errors.messages[:applications_open_from]).to include("Applications open from format is invalid")
         end
       end
 
@@ -74,10 +75,11 @@ module Support
           subject.save
           subject.valid?
 
-          expect(subject.errors.messages.count).to eq(3)
+          expect(subject.errors.messages.count).to eq(4)
           expect(subject.errors.messages[:course_code]).to include("Course code cannot be blank")
           expect(subject.errors.messages[:name]).to include("Course title cannot be blank")
           expect(subject.errors.messages[:start_date]).to include("Start date cannot have blank values")
+          expect(subject.errors.messages[:applications_open_from]).to include("^Select when applications will open and enter the date if applicable")
         end
       end
 
@@ -87,8 +89,9 @@ module Support
           subject.save
           subject.valid?
 
-          expect(subject.errors.messages.count).to eq(1)
+          expect(subject.errors.messages.count).to eq(2)
           expect(subject.errors.messages[:start_date]).to include("September 2027 is not in the 2022 cycle")
+          expect(subject.errors.messages[:applications_open_from]).to include("04/08/2000 is not valid for the 2022 cycle. A valid date must be between 01/10/2021 and 30/09/2022")
         end
       end
     end

--- a/spec/support/page_objects/support/provider/course_edit_page.rb
+++ b/spec/support/page_objects/support/provider/course_edit_page.rb
@@ -11,6 +11,9 @@ module PageObjects
         element :start_date_day, "#support_edit_course_form_start_date_3i"
         element :start_date_month, "#support_edit_course_form_start_date_2i"
         element :start_date_year, "#support_edit_course_form_start_date_1i"
+        element :application_open_from_day, "#support_edit_course_form_applications_open_from_3i"
+        element :application_open_from_month, "#support_edit_course_form_applications_open_from_2i"
+        element :application_open_from_year, "#support_edit_course_form_applications_open_from_1i"
         element :error_summary, ".govuk-error-summary"
         element :continue, ".govuk-button"
       end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/3QK8OQMI/500-allow-application-open-date-to-be-editable-in-the-support-console)

### Changes proposed in this pull request

- Allow support users to input a application form start date input in the SC
- Edit course details form to take dynamic date values to cut down code overhead

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
