### PR TITLE
Adding www2,staging2,sandbox2 routes for redirect

### DIFF
--- a/terraform/workspace_variables/production.tfvars
+++ b/terraform/workspace_variables/production.tfvars
@@ -8,6 +8,7 @@ paas_worker_app_instances  = 4
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "large-ha-11"
 paas_redis_service_plan    = "micro-ha-5_x"
+publish_gov_uk_host_names = ["www2"]
 
 # KeyVault
 key_vault_resource_group = "s121p01-shared-rg"

--- a/terraform/workspace_variables/sandbox.tfvars
+++ b/terraform/workspace_variables/sandbox.tfvars
@@ -8,6 +8,7 @@ paas_worker_app_instances  = 2
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "micro-5_x"
+publish_gov_uk_host_names = ["sandbox2"]
 
 # KeyVault
 key_vault_resource_group = "s121p01-shared-rg"

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -8,6 +8,7 @@ paas_worker_app_instances  = 1
 paas_worker_app_memory     = 512
 paas_postgres_service_plan = "small-11"
 paas_redis_service_plan    = "tiny-5_x"
+publish_gov_uk_host_names = ["staging2"]
 
 # KeyVault
 key_vault_resource_group = "s121t01-shared-rg"


### PR DESCRIPTION
### Context

Adding www2, staging2 and sandbox2 routes for publish-ttapi redirection
https://trello.com/c/uwBX42F6/392-publish-ttapi-merge-set-up-dns-record-for-www2

### Changes proposed in this pull request

Added publish_gov_uk_host_names variable for each env required

### Guidance to review

QA has already been completed on a previous PR.
check routes are created when merged and deployed

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
