### PR TITLE
[395] Add new sign in content for old publish sign in flow

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,6 @@ AllCops:
     - "bin/*"
     - "db/schema.rb"
     - "node_modules/**/*"
+
+RSpec/AnyInstance:
+  Enabled: false

--- a/app/helpers/signin_helper.rb
+++ b/app/helpers/signin_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module SigninHelper
+  def from_old_publish?
+    request.referer&.include?(Settings.publish_url) && FeatureService.enabled?(:display_migration_signin)
+  end
+end

--- a/app/views/sign_in/_default_signin_content.html.erb
+++ b/app/views/sign_in/_default_signin_content.html.erb
@@ -1,0 +1,14 @@
+
+<h1 class="govuk-heading-l">Sign in to <%= I18n.t("service_name") %></h1>
+
+<% if AuthenticationService.dfe_signin? %>
+  <p class="govuk-body-m">Use DfE Sign-in to access your account.</p>
+
+  <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
+  
+  <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name") %>, email <%= support_email %>.</p>
+<% else %>
+  <p class="govuk-body-m">Use Personas to access an account.</p>
+  
+  <%= govuk_link_to "Sign in using a Persona", "/personas", class: "govuk-button" %>
+<% end %>

--- a/app/views/sign_in/_migration_signin_content.html.erb
+++ b/app/views/sign_in/_migration_signin_content.html.erb
@@ -1,0 +1,12 @@
+
+<h1 class="govuk-heading-l">Sign in to continue</h1>
+
+<% if AuthenticationService.dfe_signin? %>
+  <p class="govuk-body-m">We're making improvements to Publish. To continue, you'll need to sign in again to use the latest version.</p>
+
+  <%= govuk_button_to("Sign in", "/auth/dfe", class: "qa-sign_in_button") %>
+<% else %>
+  <p class="govuk-body-m">Use Personas to continue signing in.</p>
+
+  <%= govuk_link_to "Sign in", "/personas", class: "govuk-button" %>
+<% end %>

--- a/app/views/sign_in/index.html.erb
+++ b/app/views/sign_in/index.html.erb
@@ -3,16 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-    <h1 class="govuk-heading-l">Sign in to <%= I18n.t("service_name") %></h1>
-
-    <% if AuthenticationService.dfe_signin? %>
-        <p class="govuk-body-m">Use DfE Sign-in to access your account.</p>
-        <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
-        <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name") %>, email <%= support_email %>.
-        </p>
+    <% if from_old_publish? %>
+      <%= render partial: "migration_signin_content" %>
     <% else %>
-        <p class="govuk-body-m">Use Personas to access an account.</p>
-        <%= govuk_link_to "Sign in using a Persona", "/personas", button: true %>
+      <%= render partial: "default_signin_content" %>
     <% end %>
   </div>
 </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -67,6 +67,7 @@ google:
 
 features:
   send_request_data_to_bigquery: false
+  display_migration_signin: false
   rollover:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -25,3 +25,4 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
+  display_migration_signin: true

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -19,7 +19,7 @@ feature "Authentication" do
       enable_features(:display_migration_signin)
     end
 
-    scenario "users are shown the right signin content" do
+    scenario "users are shown the right signin content when arriving from Old Publish" do
       given_i_am_a_provider_user
       when_i_arrive_from_the_old_publish
       then_i_am_shown_the_right_content

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -12,6 +12,20 @@ feature "Authentication" do
     and_i_cannot_access_the_support_interface
   end
 
+  context "publish migration" do
+    before do
+      allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return(Settings.publish_url)
+      disable_features(:send_request_data_to_bigquery)
+      enable_features(:display_migration_signin)
+    end
+
+    scenario "users are shown the right signin content" do
+      given_i_am_a_provider_user
+      when_i_arrive_from_the_old_publish
+      then_i_am_shown_the_right_content
+    end
+  end
+
   def given_i_am_a_provider_user
     @current_user = create(:user)
     user_exists_in_dfe_sign_in(user: @current_user)
@@ -38,5 +52,14 @@ feature "Authentication" do
     visit support_providers_path
     expect(page).to have_content "User is not an admin"
     expect(page).to have_current_path sign_in_path
+  end
+
+  def when_i_arrive_from_the_old_publish
+    sign_in_page.load
+  end
+
+  def then_i_am_shown_the_right_content
+    expect(sign_in_page).to have_text("Sign in to continue")
+    expect(sign_in_page).to have_button("Sign in")
   end
 end

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -12,24 +12,24 @@ feature "Authentication" do
     and_i_cannot_access_the_support_interface
   end
 
-  context "publish migration" do
-    before do
-      allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return(Settings.publish_url)
-      disable_features(:send_request_data_to_bigquery)
-      enable_features(:display_migration_signin)
-    end
+  scenario "users are shown the right signin content when arriving from Old Publish" do
+    given_i_arrive_from_old_publish
+    and_i_am_a_provider_user
+    then_i_see_the_signin_page
+    and_i_am_shown_the_right_content
+  end
 
-    scenario "users are shown the right signin content when arriving from Old Publish" do
-      given_i_am_a_provider_user
-      when_i_arrive_from_the_old_publish
-      then_i_am_shown_the_right_content
-    end
+  def given_i_arrive_from_old_publish
+    allow_any_instance_of(ActionDispatch::Request).to receive(:referer).and_return(Settings.publish_url)
+    disable_features(:send_request_data_to_bigquery)
+    enable_features(:display_migration_signin)
   end
 
   def given_i_am_a_provider_user
     @current_user = create(:user)
     user_exists_in_dfe_sign_in(user: @current_user)
   end
+  alias_method :and_i_am_a_provider_user, :given_i_am_a_provider_user
 
   def when_i_visit_the_root_path
     visit publish_root_path
@@ -54,11 +54,11 @@ feature "Authentication" do
     expect(page).to have_current_path sign_in_path
   end
 
-  def when_i_arrive_from_the_old_publish
+  def then_i_see_the_signin_page
     sign_in_page.load
   end
 
-  def then_i_am_shown_the_right_content
+  def and_i_am_shown_the_right_content
     expect(sign_in_page).to have_text("Sign in to continue")
     expect(sign_in_page).to have_button("Sign in")
   end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+def enable_features(*feature_keys)
+  allow(FeatureService).to receive(:enabled?).and_return(false)
+  feature_keys.each do |feature_key|
+    allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(true)
+  end
+end
+
+def disable_features(*feature_keys)
+  feature_keys.each do |feature_key|
+    allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(false)
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/i4t2NzH7/395-update-sign-in-page-copy-on-ttapi

### Changes proposed in this pull request

- Add some new content for users coming in from old publish who need to re-authenticate
- Put the above behind a flag which is only enabled during the migration

### Guidance to review

<img width="1120" alt="Screenshot 2022-01-10 at 14 38 17" src="https://user-images.githubusercontent.com/616080/148805923-0674ce28-2ebf-43a4-a9ac-e8b32ac1d9c1.png">

This depends on the PRs in this ticket getting merged in to properly test https://trello.com/c/6Ay3bdEp/515-add-breadcrumbs-helper-for-migrated-publish-code.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally