### PR TITLE
[544] Set root path to redirect to new publish

### DIFF
--- a/app/lib/publish_constraint.rb
+++ b/app/lib/publish_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class PublishConstraint
+  def matches?(request)
+    Settings.base_url.include?(request.host)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
   get :sha, controller: :heartbeat
   get :reporting, controller: :reporting
 
+  get "/" => redirect("/publish/organisations"), constraints: PublishConstraint.new
+
   mount OpenApi::Rswag::Ui::Engine => "/api-docs"
   mount OpenApi::Rswag::Api::Engine => "/api-docs"
 

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,13 +3,12 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 
-base_url: https://api.publish-teacher-training-courses.service.gov.uk
+base_url: https://www2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
-  base_url: https://api.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users
 
 bg_jobs:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -4,7 +4,7 @@ publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
-base_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
+base_url: https://qa2.publish-teacher-training-courses.service.gov.uk
 
 bg_jobs:
   save_statistic:

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -6,11 +6,10 @@ environment:
   label: "Sandbox"
   name: "sandbox"
 
-base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
+base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://oidc.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
   profile: https://profile.signin.education.gov.uk
-  base_url: https://sandbox.api.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://support.signin.education.gov.uk/users

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -4,13 +4,12 @@ publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
-base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
+base_url: https://staging2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:
   issuer: https://pp-oidc.signin.education.gov.uk
   profile: https://pp-profile.signin.education.gov.uk
   secret: please_change_me # Override with SETTINGS__DFE_SIGNIN__SECRET
-  base_url: https://staging.api.publish-teacher-training-courses.service.gov.uk
   user_search_url: https://pp-support.signin.education.gov.uk/users
 
 bg_jobs:


### PR DESCRIPTION
### Context

- https://trello.com/c/JuEEOo28/544-root-path-needs-to-serve-new-publish-app-instance-and-not-api-docs

### Changes proposed in this pull request

- Add a routing constraint to redirect root path to new publish and not api docs if the request url matches a new publish domain

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
