### PR TITLE
[535] Add is_send to the course edit form on Support Console

### DIFF
--- a/app/controllers/support/courses_controller.rb
+++ b/app/controllers/support/courses_controller.rb
@@ -37,7 +37,8 @@ module Support
       params.require(:support_edit_course_form).permit(
         *EditCourseForm::FIELDS,
         :"start_date(3i)", :"start_date(2i)", :"start_date(1i)",
-        :"applications_open_from(3i)", :"applications_open_from(2i)", :"applications_open_from(1i)"
+        :"applications_open_from(3i)", :"applications_open_from(2i)", :"applications_open_from(1i)",
+        :is_send
       ).transform_keys { |key| date_field_to_attribute(key) }
     end
 

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -8,7 +8,7 @@ module Support
     ].freeze
 
     attr_accessor(*FIELDS)
-    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year
+    attr_accessor :start_date_day, :start_date_month, :start_date_year, :course, :applications_open_from_day, :applications_open_from_month, :applications_open_from_year, :is_send
     validate :validate_start_date_format
     validate :validate_applications_open_from_format
 
@@ -24,6 +24,7 @@ module Support
         applications_open_from_day: @course.applications_open_from&.day,
         applications_open_from_month: @course.applications_open_from&.month,
         applications_open_from_year: @course.applications_open_from&.year,
+        is_send: @course.is_send,
       )
     end
 
@@ -77,6 +78,7 @@ module Support
         name: name,
         start_date: start_date,
         applications_open_from: applications_open_from,
+        is_send: send?,
       }
 
       course.assign_attributes(attributes)
@@ -84,6 +86,10 @@ module Support
 
     def promote_errors_from_course
       errors.merge!(course.errors)
+    end
+
+    def send?
+      JSON(is_send)
     end
 
     def validate_start_date_format

--- a/app/forms/support/edit_course_form.rb
+++ b/app/forms/support/edit_course_form.rb
@@ -89,7 +89,7 @@ module Support
     end
 
     def send?
-      JSON(is_send)
+      ActiveModel::Type::Boolean.new.cast(is_send)
     end
 
     def validate_start_date_format

--- a/app/views/support/courses/edit.html.erb
+++ b/app/views/support/courses/edit.html.erb
@@ -15,6 +15,10 @@
 
       <%= f.govuk_date_field(:applications_open_from, legend: { text: "Applications open from date" }) %>
 
+      <%= f.govuk_check_boxes_fieldset :is_send, legend: { text: "Special Education Needs and Disability (SEND)" }, multiple: false do %>
+        <% f.govuk_check_box :is_send, :true, :false, label: { text: 'This course has an additional SEND specialism' }, multiple: false %>
+      <% end %>
+
       <%= f.govuk_submit t("support.update_record") %>
     <% end %>
 

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -25,6 +25,7 @@ FactoryBot.define do
     degree_grade { :two_one }
     additional_degree_subject_requirements { true }
     degree_subject_requirements { "Completed at least one programming module." }
+    is_send { false }
 
     trait :with_gcse_equivalency do
       accept_pending_gcse { [true, false].sample }

--- a/spec/features/support/providers/courses/editing_a_course_spec.rb
+++ b/spec/features/support/providers/courses/editing_a_course_spec.rb
@@ -23,11 +23,14 @@ feature "Edit provider course details" do
       and_i_fill_in_course_title_with valid_course_name
       and_i_fill_in_course_start_date_with valid_date_day, valid_date_month, valid_date_year
       and_i_fill_in_course_application_open_from_with valid_date_day, valid_date_month, valid_date_year
+      and_i_select_the_send_checkbox
       and_i_click_the_continue_button
       then_i_am_redirected_back_to_the_provider_courses_index_page
       and_the_course_name_and_code_are_updated
       when_i_return_to_the_edit_page
       then_i_see_the_updated_start_date
+      then_i_see_the_updated_applications_open_from_date
+      and_i_see_the_updated_send_specialism
     end
   end
 
@@ -175,10 +178,24 @@ private
     expect(provider_courses_index_page).to have_text(course_name)
   end
 
+  def and_i_select_the_send_checkbox
+    course_edit_page.send_specialism_checkbox.check
+  end
+
   def then_i_see_the_updated_start_date
     expect(course_edit_page.start_date_day.value).to eq(valid_date_day)
     expect(course_edit_page.start_date_month.value).to eq(valid_date_month)
     expect(course_edit_page.start_date_year.value).to eq(valid_date_year)
+  end
+
+  def then_i_see_the_updated_applications_open_from_date
+    expect(course_edit_page.application_open_from_day.value).to eq(valid_date_day)
+    expect(course_edit_page.application_open_from_month.value).to eq(valid_date_month)
+    expect(course_edit_page.application_open_from_year.value).to eq(valid_date_year)
+  end
+
+  def and_i_see_the_updated_send_specialism
+    expect(course_edit_page.send_specialism_checkbox.checked?).to eq true
   end
 
   def then_i_see_the_error_summary

--- a/spec/forms/edit_course_form_spec.rb
+++ b/spec/forms/edit_course_form_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 module Support
   describe EditCourseForm do
     let(:course) { create(:course, course_code: "T92", name: "Universitry of Oxfords", start_date: Date.new(2022, 9, 1)) }
-    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2022", applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: "2022" } }
+    let(:valid_attributes) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2022", applications_open_from_day: "5", applications_open_from_month: "7", applications_open_from_year: "2022", is_send: "true" } }
     let(:attributes_with_invalid_date_format) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "222", start_date_month: "90", start_date_year: "2022", applications_open_from_day: "500x", applications_open_from_month: "7", applications_open_from_year: "2022" } }
     let(:attributes_with_invalid_date_year) { { course_code: "T92", name: "Universitry of Oxfords", start_date_day: "2", start_date_month: "9", start_date_year: "2027", applications_open_from_day: "4", applications_open_from_month: "8", applications_open_from_year: "2000" } }
     let(:blank_attributes) { { course_code: "", name: "", start_date_day: "", start_date_month: "", start_date_year: "", applications_open_from_day: "", applications_open_from_month: "", applications_open_from_year: "" } }

--- a/spec/support/page_objects/support/provider/course_edit_page.rb
+++ b/spec/support/page_objects/support/provider/course_edit_page.rb
@@ -14,6 +14,7 @@ module PageObjects
         element :application_open_from_day, "#support_edit_course_form_applications_open_from_3i"
         element :application_open_from_month, "#support_edit_course_form_applications_open_from_2i"
         element :application_open_from_year, "#support_edit_course_form_applications_open_from_1i"
+        element :send_specialism_checkbox, "#support-edit-course-form-is-send-true-field"
         element :error_summary, ".govuk-error-summary"
         element :continue, ".govuk-button"
       end


### PR DESCRIPTION
### Context

- [This trello ticket](https://trello.com/c/6mK3z3TA/535-include-send-option-in-course-info-on-the-support-console)

### Changes proposed in this pull request

- Add is_send? option on the support console on the course edit form

### Guidance to review

- Log in as Colin on the SC
- Navigate to providers
- Navigate to courses
- Select a course and edit it
- See the changes on the course form

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
