### PR TITLE
Adjust back links in Publish 'About Your Organisation' section

### DIFF
--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -2,12 +2,7 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      old_publish_link_for(
-        details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)
-      )
-    ) 
-  %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish_interface/providers/contacts/edit.html.erb
+++ b/app/views/publish_interface/providers/contacts/edit.html.erb
@@ -2,12 +2,7 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @provider_contact_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      old_publish_link_for(
-        details_publish_provider_recruitment_cycle_path(@provider_contact_form.provider_code, @provider_contact_form.recruitment_cycle_year)
-      )
-    ) 
-  %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider_contact_form.provider_code, @provider_contact_form.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">

--- a/app/views/publish_interface/providers/details.html.erb
+++ b/app/views/publish_interface/providers/details.html.erb
@@ -1,6 +1,12 @@
 <% content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
-<% # TODO: breadcrumbs %>
-<%# <%= content_for :before_content, render_breadcrumbs(:organisation_details) %1> %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    old_publish_link_for(
+      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    )
+  ) %>
+<% end %>
 
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">

--- a/app/views/publish_interface/providers/visas/edit.html.erb
+++ b/app/views/publish_interface/providers/visas/edit.html.erb
@@ -2,12 +2,7 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @provider_visa_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      old_publish_link_for(
-        details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-      )
-    )
-  %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -28,8 +23,8 @@
       </h1>
 
       <p class="govuk-body">
-        If you’re unsure if your courses can sponsor visas, check the 
-        <%= govuk_link_to("Register of Student sponsors", "https://www.gov.uk/government/publications/register-of-licensed-sponsors-students") %> 
+        If you’re unsure if your courses can sponsor visas, check the
+        <%= govuk_link_to("Register of Student sponsors", "https://www.gov.uk/government/publications/register-of-licensed-sponsors-students") %>
         and <%= govuk_link_to("Register of Worker and Temporary Worker licensed sponsors", "https://www.gov.uk/government/publications/register-of-licensed-sponsors-workers") %>.
       </p>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
     get "/organisations", to: "providers#index", as: :root
 
     resources :providers, path: "organisations", param: :code, only: [] do
-      resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [] do
+      resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [:show] do
         get "/about", on: :member, to: "providers#about"
         put "/about", on: :member, to: "providers#update"
         get "/details", on: :member, to: "providers#details"


### PR DESCRIPTION


### Context
We need to be able to link back to Old Publish from New Publish.
https://trello.com/c/feaDdPif

### Changes proposed in this pull request
- Make back links in each subsection go back to the About Your Org root
  page
- Make the back link on the root page go to Old Publish, where the
  Provider root page currently sits

### Guidance to review
Navigate around the About Your Org section and inspect back link destinations.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
