### PR TITLE
[0509] Refactor about your organisation to use BaseProviderForm

### DIFF
--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -15,16 +15,15 @@ module PublishInterface
     end
 
     def about
-      @about_form = PublishInterface::AboutYourOrganisationForm.build_from_provider(@provider)
+      @about_form = AboutYourOrganisationForm.new(@provider)
     end
 
     def update
       authorize @provider, :update?
 
-      @about_form = PublishInterface::AboutYourOrganisationForm.build_from_controller_params(provider_params)
-      @about_form.save
+      @about_form = AboutYourOrganisationForm.new(@provider, params: provider_params)
 
-      if @about_form.valid?
+      if @about_form.save!
         flash[:success] = I18n.t("success.published")
         redirect_to(
           details_publish_provider_recruitment_cycle_path(
@@ -34,7 +33,7 @@ module PublishInterface
         )
       else
         @errors = @about_form.errors.messages
-        render page_param
+        render :about
       end
     end
 
@@ -59,16 +58,10 @@ module PublishInterface
     def provider_params
       params
         .fetch(:publish_interface_about_your_organisation_form, {})
-        .except(:page)
         .permit(
           *AboutYourOrganisationForm::FIELDS,
           accredited_bodies: %i[provider_name provider_code description],
         )
-        .merge(provider: @provider)
-    end
-
-    def page_param
-      params.fetch(:publish_interface_about_your_organisation_form).fetch(:page)
     end
   end
 end

--- a/app/forms/publish_interface/about_your_organisation_form.rb
+++ b/app/forms/publish_interface/about_your_organisation_form.rb
@@ -1,8 +1,12 @@
 module PublishInterface
   class AboutYourOrganisationForm < BaseProviderForm
-  class AboutYourOrganisationForm
-    include ActiveModel::Model
-    include ActiveModel::Validations
+    validates :train_with_us, presence: { message: "Enter details about training with you" }, if: :train_with_us_changed?
+    validates :train_with_disability, presence: { message: "Enter details about training with a disability" }, if: :train_with_disability_changed?
+
+    validates :train_with_us, words_count: { maximum: 250, message: "Reduce the word count for training with you" }
+    validates :train_with_disability, words_count: { maximum: 250, message: "Reduce the word count for training with disabilities and other needs" }
+
+    validate :add_enrichment_errors
 
     FIELDS = %i[
       train_with_us
@@ -19,6 +23,18 @@ module PublishInterface
     end
 
   private
+
+    def train_with_us_changed?
+      changed?(:train_with_us)
+    end
+
+    def train_with_disability_changed?
+      changed?(:train_with_disability)
+    end
+
+    def changed?(attribute)
+      public_send(attribute) != @provider.public_send(attribute)
+    end
 
     def accredited_body(provider_name:, provider_code:, description:)
       AccreditedBody.new(
@@ -59,6 +75,9 @@ module PublishInterface
 
     class AccreditedBody
       include ActiveModel::Model
+      validates :description, words_count: { maximum: 100, message: lambda do |object, _data|
+        "Reduce the word count for #{object.provider_name}"
+      end }
 
       attr_accessor :provider_name, :provider_code, :description
     end

--- a/app/views/publish_interface/providers/about.html.erb
+++ b/app/views/publish_interface/providers/about.html.erb
@@ -2,25 +2,23 @@
 <% content_for :page_title, title_with_error_prefix(page_title, @errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
 <% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @about_form,
-      url: about_publish_provider_recruitment_cycle_path(@about_form.provider_code, @about_form.recruitment_cycle_year),
+      url: about_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
       method: :put,
     ) do |f| %>
 
       <%= f.govuk_error_summary %>
 
       <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l"><%= @about_form.provider_name %></span>
+        <span class="govuk-caption-l"><%= @provider.provider_name %></span>
         <%= page_title %>
       </h1>
-
-      <%= f.hidden_field :page, value: :about %>
 
       <p class="govuk-body">Tell applicants why they should choose to train with you. Say:</p>
       <ul class="govuk-list govuk-list--bullet">


### PR DESCRIPTION
### Context
`BaseProviderForm` should be used instead

### Changes proposed in this pull request
Refactor about your organisation to use BaseProviderForm
Removed unneeded `page` params

### Guidance to review
Just a refactor, have a play around.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
