### PR TITLE
Verify authorization in PublishInterface

### DIFF
--- a/app/controllers/publish_interface/providers_controller.rb
+++ b/app/controllers/publish_interface/providers_controller.rb
@@ -4,7 +4,9 @@ module PublishInterface
     before_action :build_recruitment_cycle
     before_action :build_provider, except: [:index]
 
-    def index; end
+    def index
+      authorize :provider, :index?
+    end
 
     def details
       authorize @provider, :show?
@@ -15,6 +17,8 @@ module PublishInterface
     end
 
     def about
+      authorize @provider, :show?
+
       @about_form = AboutYourOrganisationForm.new(@provider)
     end
 

--- a/app/controllers/publish_interface/publish_interface_controller.rb
+++ b/app/controllers/publish_interface/publish_interface_controller.rb
@@ -1,5 +1,7 @@
 module PublishInterface
   class PublishInterfaceController < ApplicationController
     layout "publish_interface"
+
+    after_action :verify_authorized
   end
 end

--- a/spec/features/publish_interface/edit_provider_details_spec.rb
+++ b/spec/features/publish_interface/edit_provider_details_spec.rb
@@ -10,6 +10,7 @@ feature "About Your Organisation section" do
     then_i_can_edit_info_about_training_with_us
     then_i_can_edit_info_about_our_accredited_bodies
     then_i_can_edit_info_about_disabilities_and_other_needs
+    and_i_cannot_access_a_provider_i_do_not_have_permissions_for
   end
 
   def given_i_am_a_provider_user
@@ -75,5 +76,15 @@ feature "About Your Organisation section" do
     within_summary_row "Training with disabilities and other needs" do
       expect(page).to have_content "Updated: training with disabilities"
     end
+  end
+
+  def and_i_cannot_access_a_provider_i_do_not_have_permissions_for
+    @another_provider = create(:provider)
+    expect {
+      provider_details_show_page.load(
+        provider_code: @another_provider.provider_code,
+        recruitment_cycle_year: @another_provider.recruitment_cycle_year,
+      )
+    } .to raise_error(Pundit::NotAuthorizedError)
   end
 end


### PR DESCRIPTION
### Context
The original Trello card called for better authorization specs. I looked at a few different ways of doing this and settled on a different approach to help ensure we're authorizing access correctly.

https://trello.com/c/nb8N8Hk3

### Changes proposed in this pull request

Writing specs for each authorization case is time consuming and easily missed. Instead, use Pundit's built-in `verify_authorized` method in the PublishInterfaceController as an `after_action`. This raises an error if we forget to call authorize in any action. If we don't need authorization (eg—static content linked from the footer, cc: @defong ), we can call `skip_authorization`.

Paired with a very light feature spec, this should give us enough certainty that we're authorizing correctly, without the ongoing need to keep our specs up to date.

### Guidance to review
- Suitable approach?

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
