### PR TITLE
[576] Migrate the publish locations index

### DIFF
--- a/app/controllers/publish_interface/providers/locations_controller.rb
+++ b/app/controllers/publish_interface/providers/locations_controller.rb
@@ -2,6 +2,8 @@ module PublishInterface
   module Providers
     class LocationsController < PublishInterfaceController
       def index
+        authorize :provider, :index?
+
         @locations = provider.sites.sort_by(&:location_name)
       end
 

--- a/app/controllers/publish_interface/providers/locations_controller.rb
+++ b/app/controllers/publish_interface/providers/locations_controller.rb
@@ -1,0 +1,21 @@
+module PublishInterface
+  module Providers
+    class LocationsController < PublishInterfaceController
+      def index
+        @locations = provider.sites.sort_by(&:location_name)
+      end
+
+    private
+
+      def provider
+        @provider ||= Provider.find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+      end
+
+      def recruitment_cycle
+        cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+
+        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
+      end
+    end
+  end
+end

--- a/app/helpers/location_helper.rb
+++ b/app/helpers/location_helper.rb
@@ -1,0 +1,5 @@
+module LocationHelper
+  def urn_required?(recruitment_cycle_year)
+    recruitment_cycle_year >= Site::URN_2022_REQUIREMENTS_REQUIRED_FROM
+  end
+end

--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -38,7 +38,7 @@ private
       raw("<p class=\"govuk-heading-s app-inset-text__title\">Can you sponsor visas?</p>") +
         govuk_link_to(
           "Select if visas can be sponsored",
-          edit_publish_provider_recruitment_cycle_visas_path(
+          visas_publish_provider_recruitment_cycle_path(
             provider.provider_code,
             provider.recruitment_cycle_year,
           ),

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,5 +1,6 @@
 class Site < ApplicationRecord
   MAIN_SITE = "main site".freeze
+  URN_2022_REQUIREMENTS_REQUIRED_FROM = 2022
 
   include PostcodeNormalize
   include RegionCode

--- a/app/views/publish_interface/providers/locations/_location.html.erb
+++ b/app/views/publish_interface/providers/locations/_location.html.erb
@@ -1,0 +1,13 @@
+<tr class="govuk-table__row location-row">
+  <th class="govuk-table__header name" scope="row">
+    <%= govuk_link_to location.location_name, edit_publish_provider_recruitment_cycle_location_path(@provider.provider_code, location.recruitment_cycle.year, location.id) %>
+  </th>
+  <td class="govuk-table__cell code">
+    <%= location.code %> <%= location.code == "-" ? "(dash)" : "" %>
+  </td>
+  <% if urn_required?(@recruitment_cycle.year.to_i) %>
+    <td class="govuk-table__cell urn">
+      <%= location.urn.presence || "<strong class='govuk-error-message govuk-\!-display-inline'>(Missing)</strong>".html_safe %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/publish_interface/providers/locations/index.html.erb
+++ b/app/views/publish_interface/providers/locations/index.html.erb
@@ -1,0 +1,46 @@
+<% page_title = "Locations" %>
+
+<%= render PageTitle::View.new(title: page_title) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    old_publish_link_for(
+      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    )
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+      <%= page_title %>
+    </h1>
+
+    <p class="govuk-body">A location is a place that a candidate selects when making an application. They do this by choosing from a list on the course page in Find.</p>
+
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>edit location names and addresses</li>
+      <li>add locations</li>
+    </ul>
+
+    <p class="govuk-body">You can assign locations to a course from the ‘Basic details’ tab on the course page.</p>
+
+    <table class="govuk-table app-table--vertical-align-middle">
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Name</th>
+          <th class="govuk-table__header" scope="col">Location code</th>
+          <% if urn_required?(@recruitment_cycle.year.to_i) %>
+            <th class="govuk-table__header" scope="col">URN</th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <%= render partial: "location", collection: @locations %>
+      </tbody>
+    </table>
+    <%= govuk_button_link_to "Add a location", new_publish_provider_recruitment_cycle_location_path(@provider.provider_code) %>
+  </div>
+</div>

--- a/app/views/publish_interface/providers/visas/edit.html.erb
+++ b/app/views/publish_interface/providers/visas/edit.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with(
       model: @provider_visa_form,
-      url: publish_provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year),
+      url: visas_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year),
       method: :put,
       local: true,
       builder: GOVUKDesignSystemFormBuilder::FormBuilder,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,7 @@ Rails.application.routes.draw do
         get "/details", on: :member, to: "providers#details"
 
         scope module: :providers do
-          resource :visas, only: %i[edit update], path: "/visas"
+          resources :locations, except: %i[destroy show]
 
           get "/contact", on: :member, to: "contacts#edit"
           put "/contact", on: :member, to: "contacts#update"

--- a/spec/features/publish_interface/managing_locations_spec.rb
+++ b/spec/features/publish_interface/managing_locations_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Managing a provider's locations" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_locations_page
+  end
+
+  scenario "i can view a provider's locations" do
+    then_i_should_see_a_list_of_locations
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(:user, providers: [create(:provider, sites: [build(:site)])]),
+    )
+  end
+
+  def when_i_visit_the_locations_page
+    publish_provider_locations_index_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year,
+    )
+  end
+
+  def then_i_should_see_a_list_of_locations
+    expect(publish_provider_locations_index_page.locations.size).to eq(1)
+
+    expect(publish_provider_locations_index_page.locations.first.name).to have_text(site.location_name)
+    expect(publish_provider_locations_index_page.locations.first.code).to have_text(site.code)
+    expect(publish_provider_locations_index_page.locations.first.urn).to have_text(site.urn)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def site
+    @site ||= provider.sites.first
+  end
+end

--- a/spec/support/feature_helpers/publish_interface_pages.rb
+++ b/spec/support/feature_helpers/publish_interface_pages.rb
@@ -15,5 +15,9 @@ module FeatureHelpers
     def visa_sponsorships_page
       @visa_sponsorships_page ||= PageObjects::PublishInterface::ProviderVisaSponsorships.new
     end
+
+    def publish_provider_locations_index_page
+      @publish_provider_locations_index_page ||= PageObjects::PublishInterface::ProviderLocationsIndex.new
+    end
   end
 end

--- a/spec/support/page_objects/publish_interface/provider_locations_index.rb
+++ b/spec/support/page_objects/publish_interface/provider_locations_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "../sections/location"
+
+module PageObjects
+  module PublishInterface
+    class ProviderLocationsIndex < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/locations"
+
+      sections :locations, Sections::Location, ".location-row"
+
+      element :add_location, ".govuk-button", text: "Add location"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/giOu9OOk/576-migrate-locations-locations-list

### Changes proposed in this pull request

<img width="846" alt="Screenshot 2022-01-19 at 16 41 57" src="https://user-images.githubusercontent.com/616080/150175274-95094b16-8d9b-41e5-b4f3-f44d9c9a40d5.png">

- Migrate over locations index page from the locations section here https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2GU/2022
- Editing/Adding a location in a follow up ticket
- Clean up redundant visa routes

### Guidance to review

`publish/organisations/2AT/2022/locations`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
