### PR TITLE
Update StatusCake contact groups

### DIFF
--- a/terraform/workspace_variables/qa.tfvars
+++ b/terraform/workspace_variables/qa.tfvars
@@ -20,7 +20,7 @@ statuscake_alerts = {
     website_url    = "https://qa.api.publish-teacher-training-courses.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [188603]
+    contact_group  = [151103]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }

--- a/terraform/workspace_variables/staging.tfvars
+++ b/terraform/workspace_variables/staging.tfvars
@@ -20,7 +20,7 @@ statuscake_alerts = {
     website_url    = "https://staging.api.publish-teacher-training-courses.service.gov.uk/ping"
     test_type      = "HTTP"
     check_rate     = 60
-    contact_group  = [188603]
+    contact_group  = [151103]
     trigger_rate   = 0
     node_locations = ["UKINT", "UK1", "MAN1", "MAN5", "DUB2"]
   }


### PR DESCRIPTION
### Context

QA and Staging alerts are currently routed to StatusCake Contact group BAT-DevOps-Slack-All which only forwards to email.

### Changes proposed in this pull request

The contact group will be changed to BAT-DevOps-Slack-Prod which will be routed to Slack, email and mobile alerts instead of just email. Email and mobile alerts are a limited subset of users. Updated contact groups in workspace variable files for qa and staging to match production and sandbox.

https://trello.com/c/q3F2WvuS

### Guidance to review

Do the channels match the expected channels.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
