### PR TITLE
[591] Implement the courses index page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,7 @@ AllCops:
 
 RSpec/AnyInstance:
   Enabled: false
+
+# Remove after migration
+Naming/PredicateName:
+  Enabled: false

--- a/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
+++ b/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
@@ -1,0 +1,9 @@
+module PublishInterface
+  module Providers
+    class VacanciesController < PublishInterfaceController
+      def edit; end
+
+      def update; end
+    end
+  end
+end

--- a/app/controllers/publish_interface/providers/courses_controller.rb
+++ b/app/controllers/publish_interface/providers/courses_controller.rb
@@ -1,0 +1,32 @@
+module PublishInterface
+  module Providers
+    class CoursesController < PublishInterfaceController
+      def index
+        authorize :provider, :index?
+
+        courses_by_accrediting_provider
+        self_accredited_courses
+      end
+
+    private
+
+      def provider
+        @provider ||= Provider.find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+      end
+
+      def recruitment_cycle
+        cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+
+        @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
+      end
+
+      def courses_by_accrediting_provider
+        @courses_by_accrediting_provider ||= ::Courses::Fetch.by_accrediting_provider(provider)
+      end
+
+      def self_accredited_courses
+        @self_accredited_courses ||= courses_by_accrediting_provider.delete(provider.provider_name)
+      end
+    end
+  end
+end

--- a/app/controllers/publish_interface/providers/courses_controller.rb
+++ b/app/controllers/publish_interface/providers/courses_controller.rb
@@ -11,7 +11,9 @@ module PublishInterface
     private
 
       def provider
-        @provider ||= Provider.find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+        @provider ||= Provider
+          .includes(courses: %i[sites site_statuses enrichments provider])
+          .find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
       end
 
       def recruitment_cycle

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,4 +1,5 @@
 class ApplicationDecorator < Draper::Decorator
+  # TODO: Move this to a view component
   def status_tag
     tag = h.govuk_tag(text: status_text.html_safe, colour: status_colour)
     tag += unpublished_status_hint if object.has_unpublished_changes?

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -1,0 +1,36 @@
+class ApplicationDecorator < Draper::Decorator
+  def status_tag
+    tag = h.govuk_tag(text: status_text.html_safe, colour: status_colour)
+    tag += unpublished_status_hint if object.has_unpublished_changes?
+    tag.html_safe
+  end
+
+private
+
+  def status_text
+    return status_tags[:withdrawn][:text] if object.ucas_status == "not_running"
+
+    status_tags[object.content_status.to_sym][:text]
+  end
+
+  def status_colour
+    return status_tags[:withdrawn][:colour] if object.ucas_status == "not_running"
+
+    status_tags[object.content_status.to_sym][:colour]
+  end
+
+  def status_tags
+    {
+      published: { text: "Published", colour: "green" },
+      withdrawn: { text: "Withdrawn", colour: "red" },
+      empty: { text: "Empty", colour: "grey" },
+      draft: { text: "Draft", colour: "yellow" },
+      published_with_unpublished_changes: { text: "Published&nbsp;*", colour: "green" },
+      rolled_over: { text: "Rolled over", colour: "grey" },
+    }
+  end
+
+  def unpublished_status_hint
+    h.tag.span("*&nbsp;Unpublished&nbsp;changes".html_safe, class: "govuk-body-s govuk-!-display-block govuk-!-margin-bottom-0 govuk-!-margin-top-1")
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -1,0 +1,326 @@
+class CourseDecorator < ApplicationDecorator
+  delegate_all
+
+  def name_and_code
+    "#{object.name} (#{object.course_code})"
+  end
+
+  def vacancies
+    content = object.has_vacancies? ? "Yes" : "No"
+    content += " (#{edit_vacancy_link})" unless object.is_withdrawn?
+    content.html_safe
+  end
+
+  def find_url(provider = object.provider)
+    h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+  end
+
+  def on_find(provider = object.provider)
+    if object.findable?
+      if current_cycle_and_open?
+        h.govuk_link_to("Yes - view online", h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code))
+      else
+        "Yes – from #{Settings.next_cycle_open_date.to_s(:month)}"
+      end
+    else
+      not_on_find
+    end
+  end
+
+  def open_or_closed_for_applications
+    object.open_for_applications? ? "Open" : "Closed"
+  end
+
+  def outcome
+    I18n.t("edit_options.qualifications.#{object.qualification}.label")
+  end
+
+  def is_send?
+    object.is_send? ? "Yes" : "No"
+  end
+
+  def funding
+    {
+      "salary" => "Salaried",
+      "apprenticeship" => "Teaching apprenticeship (with salary)",
+      "fee" => "Fee paying (no salary)",
+    }[object.funding_type]
+  end
+
+  def subject_name
+    if object.subjects.count == 1
+      object.subjects.first.subject_name
+    else
+      object.name
+    end
+  end
+
+  def has_scholarship_and_bursary?
+    has_bursary? && has_scholarship?
+  end
+
+  def bursary_first_line_ending
+    if bursary_requirements.count > 1
+      ":"
+    else
+      "#{bursary_requirements.first}."
+    end
+  end
+
+  def bursary_requirements
+    requirements = ["a degree of 2:2 or above in any subject"]
+
+    if object.subjects.any? { |subject| subject.subject_name.downcase == "primary with mathematics" }
+      mathematics_requirement = "at least grade B in maths A-level (or an equivalent)"
+      requirements.push(mathematics_requirement)
+    end
+
+    requirements
+  end
+
+  def bursary_only?
+    has_bursary? && !has_scholarship?
+  end
+
+  def has_bursary?
+    object.subjects.present? &&
+      object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
+  end
+
+  def excluded_from_bursary?
+    object.subjects.present? &&
+      # incorrect bursary eligibility only shows up on courses with 2 subjects
+      object.subjects.count == 2 &&
+      has_excluded_course_name?
+  end
+
+  def has_scholarship?
+    object.subjects.present? &&
+      object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
+  end
+
+  def has_early_career_payments?
+    object.subjects.present? &&
+      object.subjects.any? { |subject| subject.attributes["early_career_payments"].present? }
+  end
+
+  def bursary_amount
+    find_max("bursary_amount")
+  end
+
+  def scholarship_amount
+    find_max("scholarship")
+  end
+
+  def salaried?
+    object.funding_type == "salary" || object.funding_type == "apprenticeship"
+  end
+
+  def apprenticeship?
+    object.funding_type == "apprenticeship" ? "Yes" : "No"
+  end
+
+  def sorted_subjects
+    object.subjects.map(&:subject_name).sort.join("<br>").html_safe
+  end
+
+  def length
+    case object.course_length
+    when "OneYear"
+      "1 year"
+    when "TwoYears"
+      "Up to 2 years"
+    else
+      object.course_length
+    end
+  end
+
+  def other_course_length?
+    %w[OneYear TwoYears].exclude?(course.course_length) && !course.course_length.nil?
+  end
+
+  def other_age_range?
+    options = object.meta["edit_options"]["age_range_in_years"]
+    options.exclude?(course.age_range_in_years)
+  end
+
+  def alphabetically_sorted_sites
+    object.sites.sort_by(&:location_name)
+  end
+
+  def preview_site_statuses
+    site_statuses.select(&:new_or_running?).sort_by { |status| status.site.location_name }
+  end
+
+  def has_site?(site)
+    !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
+  end
+
+  def funding_option
+    if salaried?
+      "Salary"
+    elsif excluded_from_bursary?
+      "Student finance if you’re eligible"
+    elsif has_scholarship_and_bursary?
+      "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
+    elsif has_bursary?
+      "Bursaries and student finance are available if you’re eligible"
+    else
+      "Student finance if you’re eligible"
+    end
+  end
+
+  def current_cycle?
+    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year
+  end
+
+  def current_cycle_and_open?
+    current_cycle? && FeatureService.enabled?("rollover.has_current_cycle_started?")
+  end
+
+  def next_cycle?
+    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
+  end
+
+  def use_financial_support_placeholder?
+    course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
+  end
+
+  def cycle_range
+    "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
+  end
+
+  def age_range
+    if object.age_range_in_years.present?
+      I18n.t("edit_options.age_range_in_years.#{object.age_range_in_years}.label", default: object.age_range_in_years.humanize)
+    else
+      "<span class='app-!-colour-muted'>Unknown</span>".html_safe
+    end
+  end
+
+  def applications_open_from_message_for(recruitment_cycle)
+    if current_cycle?
+      "As soon as the course is on Find (recommended)"
+    else
+      year = recruitment_cycle.year.to_i
+      day_month = Date.parse(recruitment_cycle.application_start_date).strftime("%-d %B")
+      "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
+    end
+  end
+
+  def selectable_subjects
+    meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
+  end
+
+  def selected_subject_ids
+    selectable_subject_ids = meta["edit_options"]["subjects"].map { |subject| subject["id"] }
+    selected_subject_ids = subjects.map(&:id)
+
+    selectable_subject_ids & selected_subject_ids
+  end
+
+  def subject_present?(subject_to_find)
+    subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
+  end
+
+  def return_start_date
+    if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
+      start_date.presence || "September #{Settings.current_recruitment_cycle_year + 1}"
+    else
+      start_date.presence || "September #{Settings.current_recruitment_cycle_year}"
+    end
+  end
+
+  def placements_heading
+    if is_further_education?
+      "How teaching placements work"
+    else
+      "How school placements work"
+    end
+  end
+
+  def listing_basic_details
+    if is_further_education?
+      ["outcome",
+       "full time or part time",
+       "fee or salary",
+       "application open date",
+       "course start date"]
+    else
+      ["age range",
+       "outcome",
+       "full time or part time",
+       "application open date",
+       "course start date",
+       "GCSE requirements"]
+    end
+  end
+
+  def subject_page_title
+    case level
+    when "primary"
+      "Pick a primary subject"
+    when "secondary"
+      "Pick a secondary subject"
+    else
+      "Pick a subject"
+    end
+  end
+
+  def subject_input_label
+    case level
+    when "primary"
+      "Primary subject"
+    when "secondary"
+      "Secondary subject"
+    else
+      "Pick a subject"
+    end
+  end
+
+  def accept_gcse_equivalency?
+    object.accept_gcse_equivalency
+  end
+
+private
+
+  def not_on_find
+    if object.new_and_not_running?
+      "No – still in draft"
+    elsif object.is_withdrawn?
+      "No – withdrawn"
+    else
+      "No"
+    end
+  end
+
+  def edit_vacancy_link
+    h.govuk_link_to(h.vacancies_publish_provider_recruitment_cycle_course_path(object.provider_code, object.recruitment_cycle.year, object.course_code)) do
+      h.raw("Edit<span class=\"govuk-visually-hidden\"> vacancies for #{name_and_code}</span>")
+    end
+  end
+
+  def find_max(attribute)
+    subject_attributes = object.subjects.map do |s|
+      if s.attributes[attribute].present?
+        s.__send__(attribute).to_i
+      end
+    end
+
+    subject_attributes.compact.max.to_s
+  end
+
+  def has_excluded_course_name?
+    exclusions = [
+      /^Drama/,
+      /^Media Studies/,
+      /^PE/,
+      /^Physical/,
+    ]
+    # We only care about course with a name matching the pattern 'Foo with bar'
+    # We don't care about courses matching the pattern 'Foo and bar'
+    return false unless /with/.match?(object.name)
+
+    exclusions.any? { |e| e.match?(object.name) }
+  end
+end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -157,6 +157,7 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def funding_option
+    # rubocop:disable Lint/DuplicateBranch
     if salaried?
       "Salary"
     elsif excluded_from_bursary?
@@ -168,6 +169,7 @@ class CourseDecorator < ApplicationDecorator
     else
       "Student finance if you’re eligible"
     end
+    # rubocop:enable Lint/DuplicateBranch
   end
 
   def current_cycle?
@@ -286,9 +288,9 @@ private
 
   def not_on_find
     if object.new_and_not_running?
-      "No – still in draft"
+      "No - still in draft"
     elsif object.is_withdrawn?
-      "No – withdrawn"
+      "No - withdrawn"
     else
       "No"
     end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -11,9 +11,9 @@ class CourseDecorator < ApplicationDecorator
     content.html_safe
   end
 
-  def find_url(provider = object.provider)
-    h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
-  end
+  # def find_url(provider = object.provider)
+  #   h.search_ui_course_page_url(provider_code: provider.provider_code, course_code: object.course_code)
+  # end
 
   def on_find(provider = object.provider)
     if object.findable?
@@ -31,146 +31,144 @@ class CourseDecorator < ApplicationDecorator
     object.open_for_applications? ? "Open" : "Closed"
   end
 
-  def outcome
-    I18n.t("edit_options.qualifications.#{object.qualification}.label")
-  end
+  #   def outcome
+  #     I18n.t("edit_options.qualifications.#{object.qualification}.label")
+  #   end
 
-  def is_send?
-    object.is_send? ? "Yes" : "No"
-  end
+  #   def is_send?
+  #     object.is_send? ? "Yes" : "No"
+  #   end
 
-  def funding
-    {
-      "salary" => "Salaried",
-      "apprenticeship" => "Teaching apprenticeship (with salary)",
-      "fee" => "Fee paying (no salary)",
-    }[object.funding_type]
-  end
+  #   def funding
+  #     {
+  #       "salary" => "Salaried",
+  #       "apprenticeship" => "Teaching apprenticeship (with salary)",
+  #       "fee" => "Fee paying (no salary)",
+  #     }[object.funding_type]
+  #   end
 
-  def subject_name
-    if object.subjects.count == 1
-      object.subjects.first.subject_name
-    else
-      object.name
-    end
-  end
+  #   def subject_name
+  #     if object.subjects.count == 1
+  #       object.subjects.first.subject_name
+  #     else
+  #       object.name
+  #     end
+  #   end
 
-  def has_scholarship_and_bursary?
-    has_bursary? && has_scholarship?
-  end
+  #   def has_scholarship_and_bursary?
+  #     has_bursary? && has_scholarship?
+  #   end
 
-  def bursary_first_line_ending
-    if bursary_requirements.count > 1
-      ":"
-    else
-      "#{bursary_requirements.first}."
-    end
-  end
+  #   def bursary_first_line_ending
+  #     if bursary_requirements.count > 1
+  #       ":"
+  #     else
+  #       "#{bursary_requirements.first}."
+  #     end
+  #   end
 
-  def bursary_requirements
-    requirements = ["a degree of 2:2 or above in any subject"]
+  #   def bursary_requirements
+  #     requirements = ["a degree of 2:2 or above in any subject"]
 
-    if object.subjects.any? { |subject| subject.subject_name.downcase == "primary with mathematics" }
-      mathematics_requirement = "at least grade B in maths A-level (or an equivalent)"
-      requirements.push(mathematics_requirement)
-    end
+  #     if object.subjects.any? { |subject| subject.subject_name.downcase == "primary with mathematics" }
+  #       mathematics_requirement = "at least grade B in maths A-level (or an equivalent)"
+  #       requirements.push(mathematics_requirement)
+  #     end
 
-    requirements
-  end
+  #     requirements
+  #   end
 
-  def bursary_only?
-    has_bursary? && !has_scholarship?
-  end
+  #   def bursary_only?
+  #     has_bursary? && !has_scholarship?
+  #   end
 
-  def has_bursary?
-    object.subjects.present? &&
-      object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
-  end
+  #   def has_bursary?
+  #     object.subjects.present? &&
+  #       object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
+  #   end
 
-  def excluded_from_bursary?
-    object.subjects.present? &&
-      # incorrect bursary eligibility only shows up on courses with 2 subjects
-      object.subjects.count == 2 &&
-      has_excluded_course_name?
-  end
+  #   def excluded_from_bursary?
+  #     object.subjects.present? &&
+  #       # incorrect bursary eligibility only shows up on courses with 2 subjects
+  #       object.subjects.count == 2 &&
+  #       has_excluded_course_name?
+  #   end
 
-  def has_scholarship?
-    object.subjects.present? &&
-      object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
-  end
+  #   def has_scholarship?
+  #     object.subjects.present? &&
+  #       object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
+  #   end
 
-  def has_early_career_payments?
-    object.subjects.present? &&
-      object.subjects.any? { |subject| subject.attributes["early_career_payments"].present? }
-  end
+  #   def has_early_career_payments?
+  #     object.subjects.present? &&
+  #       object.subjects.any? { |subject| subject.attributes["early_career_payments"].present? }
+  #   end
 
-  def bursary_amount
-    find_max("bursary_amount")
-  end
+  #   def bursary_amount
+  #     find_max("bursary_amount")
+  #   end
 
-  def scholarship_amount
-    find_max("scholarship")
-  end
+  #   def scholarship_amount
+  #     find_max("scholarship")
+  #   end
 
-  def salaried?
-    object.funding_type == "salary" || object.funding_type == "apprenticeship"
-  end
+  #   def salaried?
+  #     object.funding_type == "salary" || object.funding_type == "apprenticeship"
+  #   end
 
-  def apprenticeship?
-    object.funding_type == "apprenticeship" ? "Yes" : "No"
-  end
+  #   def apprenticeship?
+  #     object.funding_type == "apprenticeship" ? "Yes" : "No"
+  #   end
 
-  def sorted_subjects
-    object.subjects.map(&:subject_name).sort.join("<br>").html_safe
-  end
+  #   def sorted_subjects
+  #     object.subjects.map(&:subject_name).sort.join("<br>").html_safe
+  #   end
 
-  def length
-    case object.course_length
-    when "OneYear"
-      "1 year"
-    when "TwoYears"
-      "Up to 2 years"
-    else
-      object.course_length
-    end
-  end
+  #   def length
+  #     case object.course_length
+  #     when "OneYear"
+  #       "1 year"
+  #     when "TwoYears"
+  #       "Up to 2 years"
+  #     else
+  #       object.course_length
+  #     end
+  #   end
 
-  def other_course_length?
-    %w[OneYear TwoYears].exclude?(course.course_length) && !course.course_length.nil?
-  end
+  #   def other_course_length?
+  #     %w[OneYear TwoYears].exclude?(course.course_length) && !course.course_length.nil?
+  #   end
 
-  def other_age_range?
-    options = object.meta["edit_options"]["age_range_in_years"]
-    options.exclude?(course.age_range_in_years)
-  end
+  #   def other_age_range?
+  #     options = object.meta["edit_options"]["age_range_in_years"]
+  #     options.exclude?(course.age_range_in_years)
+  #   end
 
-  def alphabetically_sorted_sites
-    object.sites.sort_by(&:location_name)
-  end
+  #   def alphabetically_sorted_sites
+  #     object.sites.sort_by(&:location_name)
+  #   end
 
-  def preview_site_statuses
-    site_statuses.select(&:new_or_running?).sort_by { |status| status.site.location_name }
-  end
+  # def preview_site_statuses
+  #   site_statuses.select(&:new_or_running?).sort_by { |status| status.site.location_name }
+  # end
 
-  def has_site?(site)
-    !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
-  end
+  # def has_site?(site)
+  #   !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
+  # end
 
-  def funding_option
-    # rubocop:disable Lint/DuplicateBranch
-    if salaried?
-      "Salary"
-    elsif excluded_from_bursary?
-      "Student finance if you’re eligible"
-    elsif has_scholarship_and_bursary?
-      "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
-    elsif has_bursary?
-      "Bursaries and student finance are available if you’re eligible"
-    else
-      "Student finance if you’re eligible"
-    end
-    # rubocop:enable Lint/DuplicateBranch
-  end
+  # def funding_option
+  #   if salaried?
+  #     "Salary"
+  #   elsif excluded_from_bursary?
+  #     "Student finance if you’re eligible"
+  #   elsif has_scholarship_and_bursary?
+  #     "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
+  #   elsif has_bursary?
+  #     "Bursaries and student finance are available if you’re eligible"
+  #   else
+  #     "Student finance if you’re eligible"
+  #   end
+  # end
 
   def current_cycle?
     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year
@@ -180,109 +178,109 @@ class CourseDecorator < ApplicationDecorator
     current_cycle? && FeatureService.enabled?("rollover.has_current_cycle_started?")
   end
 
-  def next_cycle?
-    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
-  end
+#   def next_cycle?
+#     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
+#   end
 
-  def use_financial_support_placeholder?
-    course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
-  end
+#   def use_financial_support_placeholder?
+#     course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
+#   end
 
-  def cycle_range
-    "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
-  end
+#   def cycle_range
+#     "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
+#   end
 
-  def age_range
-    if object.age_range_in_years.present?
-      I18n.t("edit_options.age_range_in_years.#{object.age_range_in_years}.label", default: object.age_range_in_years.humanize)
-    else
-      "<span class='app-!-colour-muted'>Unknown</span>".html_safe
-    end
-  end
+#   def age_range
+#     if object.age_range_in_years.present?
+#       I18n.t("edit_options.age_range_in_years.#{object.age_range_in_years}.label", default: object.age_range_in_years.humanize)
+#     else
+#       "<span class='app-!-colour-muted'>Unknown</span>".html_safe
+#     end
+#   end
 
-  def applications_open_from_message_for(recruitment_cycle)
-    if current_cycle?
-      "As soon as the course is on Find (recommended)"
-    else
-      year = recruitment_cycle.year.to_i
-      day_month = Date.parse(recruitment_cycle.application_start_date).strftime("%-d %B")
-      "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
-    end
-  end
+#   def applications_open_from_message_for(recruitment_cycle)
+#     if current_cycle?
+#       "As soon as the course is on Find (recommended)"
+#     else
+#       year = recruitment_cycle.year.to_i
+#       day_month = Date.parse(recruitment_cycle.application_start_date).strftime("%-d %B")
+#       "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
+#     end
+#   end
 
-  def selectable_subjects
-    meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
-  end
+#   def selectable_subjects
+#     meta["edit_options"]["subjects"].map { |subject| [subject["attributes"]["subject_name"], subject["id"]] }
+#   end
 
-  def selected_subject_ids
-    selectable_subject_ids = meta["edit_options"]["subjects"].map { |subject| subject["id"] }
-    selected_subject_ids = subjects.map(&:id)
+#   def selected_subject_ids
+#     selectable_subject_ids = meta["edit_options"]["subjects"].map { |subject| subject["id"] }
+#     selected_subject_ids = subjects.map(&:id)
 
-    selectable_subject_ids & selected_subject_ids
-  end
+#     selectable_subject_ids & selected_subject_ids
+#   end
 
-  def subject_present?(subject_to_find)
-    subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
-  end
+#   def subject_present?(subject_to_find)
+#     subjects.map { |subject| subject["id"] }.include?(subject_to_find["id"])
+#   end
 
-  def return_start_date
-    if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
-      start_date.presence || "September #{Settings.current_recruitment_cycle_year + 1}"
-    else
-      start_date.presence || "September #{Settings.current_recruitment_cycle_year}"
-    end
-  end
+#   def return_start_date
+#     if FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
+#       start_date.presence || "September #{Settings.current_recruitment_cycle_year + 1}"
+#     else
+#       start_date.presence || "September #{Settings.current_recruitment_cycle_year}"
+#     end
+#   end
 
-  def placements_heading
-    if is_further_education?
-      "How teaching placements work"
-    else
-      "How school placements work"
-    end
-  end
+#   def placements_heading
+#     if is_further_education?
+#       "How teaching placements work"
+#     else
+#       "How school placements work"
+#     end
+#   end
 
-  def listing_basic_details
-    if is_further_education?
-      ["outcome",
-       "full time or part time",
-       "fee or salary",
-       "application open date",
-       "course start date"]
-    else
-      ["age range",
-       "outcome",
-       "full time or part time",
-       "application open date",
-       "course start date",
-       "GCSE requirements"]
-    end
-  end
+#   def listing_basic_details
+#     if is_further_education?
+#       ["outcome",
+#        "full time or part time",
+#        "fee or salary",
+#        "application open date",
+#        "course start date"]
+#     else
+#       ["age range",
+#        "outcome",
+#        "full time or part time",
+#        "application open date",
+#        "course start date",
+#        "GCSE requirements"]
+#     end
+#   end
 
-  def subject_page_title
-    case level
-    when "primary"
-      "Pick a primary subject"
-    when "secondary"
-      "Pick a secondary subject"
-    else
-      "Pick a subject"
-    end
-  end
+#   def subject_page_title
+#     case level
+#     when "primary"
+#       "Pick a primary subject"
+#     when "secondary"
+#       "Pick a secondary subject"
+#     else
+#       "Pick a subject"
+#     end
+#   end
 
-  def subject_input_label
-    case level
-    when "primary"
-      "Primary subject"
-    when "secondary"
-      "Secondary subject"
-    else
-      "Pick a subject"
-    end
-  end
+#   def subject_input_label
+#     case level
+#     when "primary"
+#       "Primary subject"
+#     when "secondary"
+#       "Secondary subject"
+#     else
+#       "Pick a subject"
+#     end
+#   end
 
-  def accept_gcse_equivalency?
-    object.accept_gcse_equivalency
-  end
+#   def accept_gcse_equivalency?
+#     object.accept_gcse_equivalency
+#   end
 
 private
 
@@ -302,27 +300,27 @@ private
     end
   end
 
-  def find_max(attribute)
-    subject_attributes = object.subjects.map do |s|
-      if s.attributes[attribute].present?
-        s.__send__(attribute).to_i
-      end
-    end
+  # def find_max(attribute)
+  #   subject_attributes = object.subjects.map do |s|
+  #     if s.attributes[attribute].present?
+  #       s.__send__(attribute).to_i
+  #     end
+  #   end
 
-    subject_attributes.compact.max.to_s
-  end
+  #   subject_attributes.compact.max.to_s
+  # end
 
-  def has_excluded_course_name?
-    exclusions = [
-      /^Drama/,
-      /^Media Studies/,
-      /^PE/,
-      /^Physical/,
-    ]
-    # We only care about course with a name matching the pattern 'Foo with bar'
-    # We don't care about courses matching the pattern 'Foo and bar'
-    return false unless /with/.match?(object.name)
+  # def has_excluded_course_name?
+  #   exclusions = [
+  #     /^Drama/,
+  #     /^Media Studies/,
+  #     /^PE/,
+  #     /^Physical/,
+  #   ]
+  #   # We only care about course with a name matching the pattern 'Foo with bar'
+  #   # We don't care about courses matching the pattern 'Foo and bar'
+  #   return false unless /with/.match?(object.name)
 
-    exclusions.any? { |e| e.match?(object.name) }
-  end
+  #   exclusions.any? { |e| e.match?(object.name) }
+  # end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -178,9 +178,9 @@ class CourseDecorator < ApplicationDecorator
     current_cycle? && FeatureService.enabled?("rollover.has_current_cycle_started?")
   end
 
-#   def next_cycle?
-#     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
-#   end
+  def next_cycle?
+    course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
+  end
 
 #   def use_financial_support_placeholder?
 #     course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -12,13 +12,13 @@ module ViewHelper
     )
   end
 
-  # def search_ui_url(relative_path)
-  #   URI.join(Settings.search_ui.base_url, relative_path).to_s
-  # end
+  def search_ui_url(relative_path)
+    URI.join(Settings.search_ui.base_url, relative_path).to_s
+  end
 
-  # def search_ui_course_page_url(provider_code:, course_code:)
-  #   search_ui_url("/course/#{provider_code}/#{course_code}")
-  # end
+  def search_ui_course_page_url(provider_code:, course_code:)
+    search_ui_url("/course/#{provider_code}/#{course_code}")
+  end
 
   def bat_contact_email_address
     Settings.support_email

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -556,6 +556,26 @@ class Course < ApplicationRecord
     %i[published published_with_unpublished_changes].include? content_status
   end
 
+  def has_unpublished_changes?
+    content_status == "published_with_unpublished_changes"
+  end
+
+  def is_running?
+    ucas_status == :running
+  end
+
+  def is_withdrawn?
+    content_status == "withdrawn" || not_running?
+  end
+
+  def not_running?
+    ucas_status == :not_running
+  end
+
+  def new_and_not_running?
+    ucas_status == :new
+  end
+
   def funding_type=(funding_type)
     assign_program_type_service = Courses::AssignProgramTypeService.new
     assign_program_type_service.execute(funding_type, self)

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -78,6 +78,10 @@ class Provider < ApplicationRecord
     rollable_courses? || rollable_accredited_courses?
   end
 
+  def rolled_over?
+    FeatureService.enabled?("rollover.can_edit_current_and_next_cycles")
+  end
+
   # the providers that this provider is an accredited_provider for
   def training_providers
     Provider.where(id: current_accredited_courses.pluck(:provider_id))

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -15,26 +15,23 @@ module Courses
 
       def by_accrediting_provider(provider)
         # rubocop:disable Style/MultilineBlockChain
+        # rubocop:disable Style/HashTransformValues
         provider
           .courses
-          .group_by { |course|
+          .group_by do |course|
             # HOTFIX: A courses API response no included hash seems to cause issues with the
             # .accrediting_provider relationship lookup. To be investigated, for now,
             # if this throws, it's self-accredited.
-            begin
-              course.accrediting_provider&.provider_name || provider.provider_name
-            rescue StandardError
-              provider.provider_name
-            end
-          }
+            course.accrediting_provider&.provider_name || provider.provider_name
+          rescue StandardError
+            provider.provider_name
+          end
           .sort_by { |accrediting_provider, _| accrediting_provider.downcase }
-          .map { |provider_name, courses|
-          [provider_name,
-           courses.sort_by { |course| [course.name, course.course_code] }
-                                         .map(&:decorate)]
-        }
-          .to_h
+          .to_h do |provider_name, courses|
+            [provider_name, courses.sort_by { |course| [course.name, course.course_code] }.map(&:decorate)]
+          end
         # rubocop:enable Style/MultilineBlockChain
+        # rubocop:enable Style/HashTransformValues
       end
     end
   end

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -1,17 +1,17 @@
 module Courses
   class Fetch
     class << self
-      def by_code(provider_code:, course_code:, cycle_year: Settings.current_recruitment_cycle_year)
-        Course
-          .includes(:subjects)
-          .includes(:sites)
-          .includes(provider: [:sites])
-          .includes(:accrediting_provider)
-          .where(recruitment_cycle_year: cycle_year)
-          .where(provider_code: provider_code)
-          .find(course_code)
-          .first
-      end
+      # def by_code(provider_code:, course_code:, cycle_year: Settings.current_recruitment_cycle_year)
+      #   Course
+      #     .includes(:subjects)
+      #     .includes(:sites)
+      #     .includes(provider: [:sites])
+      #     .includes(:accrediting_provider)
+      #     .where(recruitment_cycle_year: cycle_year)
+      #     .where(provider_code: provider_code)
+      #     .find(course_code)
+      #     .first
+      # end
 
       def by_accrediting_provider(provider)
         # rubocop:disable Style/MultilineBlockChain
@@ -19,9 +19,6 @@ module Courses
         provider
           .courses
           .group_by do |course|
-            # HOTFIX: A courses API response no included hash seems to cause issues with the
-            # .accrediting_provider relationship lookup. To be investigated, for now,
-            # if this throws, it's self-accredited.
             course.accrediting_provider&.provider_name || provider.provider_name
           rescue StandardError
             provider.provider_name

--- a/app/services/courses/fetch.rb
+++ b/app/services/courses/fetch.rb
@@ -1,0 +1,41 @@
+module Courses
+  class Fetch
+    class << self
+      def by_code(provider_code:, course_code:, cycle_year: Settings.current_recruitment_cycle_year)
+        Course
+          .includes(:subjects)
+          .includes(:sites)
+          .includes(provider: [:sites])
+          .includes(:accrediting_provider)
+          .where(recruitment_cycle_year: cycle_year)
+          .where(provider_code: provider_code)
+          .find(course_code)
+          .first
+      end
+
+      def by_accrediting_provider(provider)
+        # rubocop:disable Style/MultilineBlockChain
+        provider
+          .courses
+          .group_by { |course|
+            # HOTFIX: A courses API response no included hash seems to cause issues with the
+            # .accrediting_provider relationship lookup. To be investigated, for now,
+            # if this throws, it's self-accredited.
+            begin
+              course.accrediting_provider&.provider_name || provider.provider_name
+            rescue StandardError
+              provider.provider_name
+            end
+          }
+          .sort_by { |accrediting_provider, _| accrediting_provider.downcase }
+          .map { |provider_name, courses|
+          [provider_name,
+           courses.sort_by { |course| [course.name, course.course_code] }
+                                         .map(&:decorate)]
+        }
+          .to_h
+        # rubocop:enable Style/MultilineBlockChain
+      end
+    end
+  end
+end

--- a/app/views/publish_interface/providers/courses/_course_abilities_blurb.html.erb
+++ b/app/views/publish_interface/providers/courses/_course_abilities_blurb.html.erb
@@ -1,0 +1,8 @@
+<p class="govuk-body">Use this section to:</p>
+
+<ul class="govuk-list govuk-list--bullet <%= classes %>">
+  <li>add and remove courses</li>
+  <li>edit, preview and publish courses</li>
+  <li>assign locations to a course</li>
+  <li>copy content between courses</li>
+</ul>

--- a/app/views/publish_interface/providers/courses/_course_table.html.erb
+++ b/app/views/publish_interface/providers/courses/_course_table.html.erb
@@ -1,0 +1,18 @@
+<table class="govuk-table app-table--vertical-align-middle app-table--courses">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header">Course</th>
+      <th class="govuk-table__header">Status</th>
+      <th class="govuk-table__header">
+        <% if @recruitment_cycle.current_and_open? %>Is it<% else %>Will it be<% end %> on <abbr class="app-!-text-decoration-underline-dotted" title="Find postgraduate teacher training">Find</abbr>?
+      </th>
+      <th class="govuk-table__header">Applications</th>
+      <% if @recruitment_cycle.current_and_open? %>
+        <th class="govuk-table__header">Vacancies</th>
+      <% end %>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+    <%= render partial: "course_table_row", collection: courses, as: :course %>
+  </tbody>
+</table>

--- a/app/views/publish_interface/providers/courses/_course_table_row.html.erb
+++ b/app/views/publish_interface/providers/courses/_course_table_row.html.erb
@@ -1,0 +1,40 @@
+<tr class="govuk-table__row">
+  <td class="govuk-table__cell app-table--courses__course-name" data-qa="courses-table__course-name">
+    <% if current_page?(publish_provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle.year)) %>
+      <%= govuk_link_to course.name_and_code,
+        publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle.year, course.course_code),
+        class: "govuk-heading-s govuk-!-margin-bottom-0" %>
+    <% else %>
+      <span class="govuk-heading-s govuk-!-margin-0">
+        <%= course.name_and_code %><br>
+      </span>
+    <% end %>
+    <span class="govuk-body-s"><%= course.description %></span>
+  </td>
+  <td class="govuk-table__cell" data-qa="courses-table__status">
+    <%= course.status_tag %>
+  </td>
+  <td class="govuk-table__cell" data-qa="courses-table__findable">
+    <% if @training_provider.present? %>
+      <%= course.on_find(@training_provider) %>
+    <% else %>
+      <%= course.on_find(@provider) %>
+    <% end %>
+  </td>
+  <td class="govuk-table__cell" data-qa="courses-table__applications">
+    <% if course.is_running? || course.is_withdrawn? %>
+      <%= course.open_or_closed_for_applications %>
+    <% end %>
+  </td>
+  <% if @recruitment_cycle.current_and_open? %>
+    <td class="govuk-table__cell" data-qa="courses-table__vacancies">
+      <% if course.is_running? || course.is_withdrawn? %>
+        <% if current_page?(publish_provider_recruitment_cycle_courses_path(@provider.provider_code, course.recruitment_cycle.year)) %>
+          <%= course.vacancies %>
+        <% else %>
+          <%= course.has_vacancies? ? "Yes" : "No" %>
+        <% end %>
+      <% end %>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/publish_interface/providers/courses/index.html.erb
+++ b/app/views/publish_interface/providers/courses/index.html.erb
@@ -1,0 +1,53 @@
+<% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    old_publish_link_for(
+      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    )
+  ) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  Courses
+</h1>
+
+<%= render partial: "course_abilities_blurb", locals: { classes: "govuk-!-margin-bottom-6" } %>
+
+<% if @provider.courses.count > 10 %>
+  <%= govuk_button_link_to(
+    "Add a new course",
+    new_publish_provider_recruitment_cycle_course_path(
+      provider_code: @provider.provider_code,
+      recruitment_cycle_year: @provider.recruitment_cycle_year,
+    ),
+    class: "govuk-!-margin-bottom-6",
+  ) %>
+<% end %>
+
+<% if @self_accredited_courses %>
+  <section data-qa="courses__table-section">
+    <%= render partial: "course_table", locals: { courses: @self_accredited_courses } %>
+  </section>
+<% end %>
+
+<% @courses_by_accrediting_provider.each do |accrediting_provider, courses| %>
+  <section data-qa="courses__table-section">
+    <h2 class="govuk-heading-m">
+      <span class="govuk-caption-m">Accredited body</span>
+      <%= accrediting_provider %>
+    </h2>
+
+    <%= render partial: "course_table", locals: { courses: courses } %>
+  </section>
+<% end %>
+
+<%= govuk_button_link_to(
+  "Add a new course",
+  new_publish_provider_recruitment_cycle_course_path(
+    provider_code: @provider.provider_code,
+    recruitment_cycle_year: @provider.recruitment_cycle_year,
+  ),
+  class: "govuk-!-margin-bottom-2",
+) %>

--- a/app/webpacker/styles/_table.scss
+++ b/app/webpacker/styles/_table.scss
@@ -1,0 +1,13 @@
+// Required since govuk-frontend 3.0.0
+.app-table--vertical-align-middle {
+  .govuk-table__header,
+  .govuk-table__cell {
+    vertical-align: middle;
+  }
+}
+
+.app-table--courses {
+  &__course-name {
+    width: 33%;
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -4,3 +4,4 @@
 
 @import "status-box";
 @import "summary-list";
+@import "table";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,6 +39,10 @@ Rails.application.routes.draw do
 
         scope module: :providers do
           resources :locations, except: %i[destroy show]
+          resources :courses, only: %i[index new create show] do
+            get "/vacancies", on: :member, to: "courses/vacancies#edit"
+            put "/vacancies", on: :member, to: "courses/vacancies#update"
+          end
 
           get "/contact", on: :member, to: "contacts#edit"
           put "/contact", on: :member, to: "contacts#update"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -3,6 +3,10 @@ environment:
   label: "Beta"
 support_email: becomingateacher@digital.education.gov.uk
 
+search_ui:
+  # URL of the C# search ui app (search-and-compare-ui)
+  base_url: https://localhost:5000
+
 # URL of this app for the callback after sigining in
 base_url: https://localhost:3001
 
@@ -30,6 +34,7 @@ authentication:
   subject: "access"
 
 current_recruitment_cycle_year: 2022
+next_cycle_open_date: 2022-10-5
 allocation_cycle_year: 2021
 govuk_notify:
   api_key: please_change_me
@@ -76,3 +81,5 @@ features:
     # Normally a short period of time between rollover and the next cycle
     # actually starting when it would be set to false
     has_current_cycle_started?: true
+    # During rollover providers should be able to edit current & next recruitment cycle courses
+    can_edit_current_and_next_cycles: false

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -4,7 +4,6 @@ environment:
 support_email: becomingateacher@digital.education.gov.uk
 
 search_ui:
-  # URL of the C# search ui app (search-and-compare-ui)
   base_url: https://localhost:5000
 
 # URL of this app for the callback after sigining in

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -3,6 +3,9 @@ publish_api_url: https://api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://www.publish-teacher-training-courses.service.gov.uk
 find_url: https://www.find-postgraduate-teacher-training.service.gov.uk
 
+search_ui:
+  base_url: https://www.find-postgraduate-teacher-training.service.gov.uk
+
 base_url: https://www2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -2,6 +2,8 @@ gcp_api_key: please_change_me
 publish_api_url: https://qa.api.publish-teacher-training-courses.service.gov.uk
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+search_ui:
+  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
 
 # URL of this app for the callback after sigining in
 base_url: https://qa2.publish-teacher-training-courses.service.gov.uk

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -1,10 +1,15 @@
 skylight:
   enable: false
+
 environment:
   label: "Review"
   name: "review"
+
 publish_url: https://qa.publish-teacher-training-courses.service.gov.uk
 find_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+search_ui:
+  base_url: https://qa.find-postgraduate-teacher-training.service.gov.uk
+
 authentication:
   secret: secret
   mode: persona

--- a/config/settings/sandbox.yml
+++ b/config/settings/sandbox.yml
@@ -6,6 +6,9 @@ environment:
   label: "Sandbox"
   name: "sandbox"
 
+search_ui:
+  base_url: https://sandbox.find-postgraduate-teacher-training.service.gov.uk
+
 base_url: https://sandbox2.publish-teacher-training-courses.service.gov.uk
 
 dfe_signin:

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -3,6 +3,9 @@ publish_api_url: https://staging.api.publish-teacher-training-courses.service.go
 publish_url: https://staging.publish-teacher-training-courses.service.gov.uk
 find_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
 
+search_ui:
+  base_url: https://staging.find-postgraduate-teacher-training.service.gov.uk
+
 # URL of this app for the callback after sigining in
 base_url: https://staging2.publish-teacher-training-courses.service.gov.uk
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -1,0 +1,808 @@
+require "rails_helper"
+
+describe CourseDecorator do
+  let(:current_recruitment_cycle) { build :recruitment_cycle }
+  let(:next_recruitment_cycle) { build :recruitment_cycle, :next }
+  let(:provider) { build(:provider, recruitment_cycle: current_recruitment_cycle) }
+  let(:english) { build(:secondary_subject, :english) }
+  let(:biology) { build(:secondary_subject, :biology) }
+  let(:mathematics) { build(:secondary_subject, :mathematics) }
+  let(:subjects) { [english, mathematics] }
+  let(:has_vacancies) { false }
+  let(:is_withdrawn) { false }
+
+  let(:content_status) do
+    is_withdrawn ? "withdrawn" : ""
+  end
+
+  let(:course_enrichment) do
+    build(
+      :course_enrichment,
+      course_length: "OneYear",
+    )
+  end
+
+  let(:course) do
+    build(
+      :course,
+      course_code: "A1",
+      name: "Mathematics",
+      qualification: "pgce_with_qts",
+      study_mode: "full_time",
+      start_date: start_date,
+      site_statuses: [site_status],
+      provider: provider,
+      accrediting_provider: provider,
+      subjects: subjects,
+      enrichments: [course_enrichment],
+    )
+  end
+
+  let(:start_date) { Time.zone.local(2019) }
+  let(:site) { build(:site) }
+  let(:site_status) do
+    build(:site_status, :both_full_time_and_part_time_vacancies, site: site)
+  end
+
+  let(:decorated_course) { course.decorate }
+
+  it "returns the course name and code in brackets" do
+    expect(decorated_course.name_and_code).to eq("Mathematics (A1)")
+  end
+
+  # it "returns a list of subjects in alphabetical order" do
+  #   expect(decorated_course.sorted_subjects).to eq("English<br>Mathematics")
+  # end
+
+  it "returns if applications are open or closed" do
+    allow(course).to receive(:open_for_applications?).and_return(true)
+
+    expect(decorated_course.open_or_closed_for_applications).to eq("Open")
+  end
+
+  # it "returns if course is an apprenticeship" do
+  #   expect(decorated_course.apprenticeship?).to eq("No")
+  # end
+
+  # it "returns if course is SEND?" do
+  #   expect(decorated_course.is_send?).to eq("No")
+  # end
+
+  # it "returns the Find URL" do
+  #   expect(decorated_course.find_url).to eq("#{Settings.search_ui.base_url}/course/#{provider.provider_code}/#{course.course_code}")
+  # end
+
+  # it "returns course length" do
+  #   expect(decorated_course.length).to eq("1 year")
+  # end
+
+  context "recruitment cycles" do
+    before do
+      allow(Settings).to receive(:current_recruitment_cycle_year).and_return(2019)
+    end
+
+    context "for a course in the current cycle" do
+      it "knows which cycle it’s in" do
+        expect(decorated_course.next_cycle?).to eq(false)
+        expect(decorated_course.current_cycle?).to eq(true)
+      end
+    end
+
+    context "for a course in the next cycle" do
+      let(:provider) { build(:provider, recruitment_cycle: next_recruitment_cycle) }
+
+      it "knows which cycle it’s in" do
+        expect(decorated_course.next_cycle?).to eq(true)
+        expect(decorated_course.current_cycle?).to eq(false)
+      end
+    end
+  end
+
+  # context "status tag" do
+  #   let(:status_tag) { course.decorate.status_tag }
+
+  #   context "A non running course" do
+  #     let(:course) { build(:course, ucas_status: "not_running") }
+
+  #     it "Returns red tag" do
+  #       expect(status_tag).to include("govuk-tag--red")
+  #     end
+
+  #     it "Returns text withdrawn" do
+  #       expect(status_tag).to include("Withdrawn")
+  #     end
+  #   end
+
+  #   context "An empty course" do
+  #     let(:course) { build(:course, content_status: "empty") }
+
+  #     it "Returns grey tag" do
+  #       expect(status_tag).to include("govuk-tag--grey")
+  #     end
+
+  #     it "Returns text empty" do
+  #       expect(status_tag).to include("Empty")
+  #     end
+  #   end
+
+  #   context "A draft course" do
+  #     let(:course) { build(:course, content_status: "draft") }
+
+  #     it "Returns yellow tag" do
+  #       expect(status_tag).to include("govuk-tag--yellow")
+  #     end
+
+  #     it "Returns text draft" do
+  #       expect(status_tag).to include("Draft")
+  #     end
+  #   end
+
+  #   context "A published with unpublished changes course" do
+  #     let(:course) { build(:course, content_status: "published_with_unpublished_changes") }
+
+  #     it "Returns green tag" do
+  #       expect(status_tag).to include("govuk-tag--green")
+  #     end
+
+  #     it "Returns text published*" do
+  #       expect(status_tag).to include("Published&nbsp;*")
+  #     end
+
+  #     it "Returns unpublished status hint" do
+  #       expect(status_tag).to include("*&nbsp;Unpublished&nbsp;changes")
+  #     end
+  #   end
+
+  #   context "A rolled over course" do
+  #     let(:course) { build(:course, content_status: "rolled_over") }
+
+  #     it "Returns grey tag" do
+  #       expect(status_tag).to include("govuk-tag--grey")
+  #     end
+
+  #     it "Returns text rolled over" do
+  #       expect(status_tag).to include("Rolled over")
+  #     end
+  #   end
+
+  #   context "A withdrawn course" do
+  #     let(:course) { build(:course, content_status: "withdrawn") }
+
+  #     it "Returns red tag" do
+  #       expect(status_tag).to include("govuk-tag--red")
+  #     end
+
+  #     it "Returns text withdrawn" do
+  #       expect(status_tag).to include("Withdrawn")
+  #     end
+  #   end
+  # end
+
+  # describe "#selectable_subjects" do
+  #   let(:course) do
+  #     build(
+  #       :course,
+  #       edit_options: {
+  #         subjects: subjects.map do |subject|
+  #           subject.to_jsonapi[:data]
+  #         end,
+  #       },
+  #     )
+  #   end
+
+  #   it "gets the name and id" do
+  #     expect(decorated_course.selectable_subjects).to eq([
+  #       [english.subject_name, english.id],
+  #       [mathematics.subject_name, mathematics.id],
+  #     ])
+  #   end
+  # end
+
+  # describe "#selected_subject_ids" do
+  #   let(:selectable_subjects) { [english, mathematics] }
+  #   let(:subjects) { [biology, mathematics] }
+
+  #   let(:course) do
+  #     build(
+  #       :course,
+  #       subjects: subjects,
+  #       edit_options: {
+  #         subjects: subjects.map do |subject|
+  #           subject.to_jsonapi[:data]
+  #         end,
+  #       },
+  #     )
+  #   end
+
+  #   it "returns ids for only subjects that are selectable" do
+  #     expect(decorated_course.selected_subject_ids).to match_array([biology.id, mathematics.id])
+  #   end
+  # end
+
+  # describe "#subject_present?" do
+  #   it "returns true when the subject id exists" do
+  #     expect(decorated_course.subject_present?(english)).to eq(true)
+  #   end
+
+  #   it "returns true when the subject id does not exists" do
+  #     expect(decorated_course.subject_present?(biology)).to eq(false)
+  #   end
+  # end
+
+  # context "financial incentives" do
+  #   describe "#salaried?" do
+  #     let(:subject) { decorated_course }
+
+  #     context "course is salaried" do
+  #       let(:course) { build :course, funding_type: "salary" }
+
+  #       it { is_expected.to be_salaried }
+  #     end
+
+  #     context "course is an apprenticeship with salary" do
+  #       let(:course) { build :course, funding_type: "apprenticeship" }
+
+  #       it { is_expected.to be_salaried }
+  #     end
+
+  #     context "course is not salaried" do
+  #       let(:course) { build :course, :with_fees }
+
+  #       it { is_expected.to_not be_salaried }
+  #     end
+  #   end
+
+  #   describe "#funding_option" do
+  #     let(:subject) { decorated_course.funding_option }
+
+  #     context "Salary" do
+  #       let(:course) { build :course, funding_type: "salary" }
+
+  #       it { is_expected.to eq("Salary") }
+  #     end
+
+  #     context "Apprenticeship" do
+  #       let(:course) { build :course, funding_type: "apprenticeship" }
+
+  #       it { is_expected.to eq("Salary") }
+  #     end
+
+  #     context "Bursary and Scholarship" do
+  #       let(:mathematics) { build(:subject, :mathematics, scholarship: "2000", bursary_amount: "3000") }
+  #       let(:course) { build :course, subjects: [mathematics] }
+
+  #       it { is_expected.to eq("Scholarships or bursaries, as well as student finance, are available if you’re eligible") }
+  #     end
+
+  #     context "Bursary" do
+  #       let(:mathematics) { build(:subject, :mathematics, bursary_amount: "3000") }
+  #       let(:course) { build :course, subjects: [mathematics] }
+
+  #       it { is_expected.to eq("Bursaries and student finance are available if you’re eligible") }
+  #     end
+
+  #     context "Student finance" do
+  #       let(:course) { build :course }
+
+  #       it { is_expected.to eq("Student finance if you’re eligible") }
+  #     end
+
+  #     context "Courses excluded from bursaries" do
+  #       let(:pe) { build(:subject) }
+  #       let(:english) { build(:subject, :english, bursary_amount: "3000") }
+
+  #       let(:course) { build :course, name: "Drama with English", subjects: [pe, english] }
+
+  #       it { is_expected.to eq("Student finance if you’re eligible") }
+  #     end
+  #   end
+
+  #   describe "#subject_name" do
+  #     context "course has more than one subject" do
+  #       it "returns the course name" do
+  #         expect(decorated_course.subject_name).to eq("Mathematics")
+  #       end
+  #     end
+
+  #     context "course has one subject" do
+  #       let(:subject) { build :subject, subject_name: "Computer Science" }
+  #       let(:course) { build :course, subjects: [subject] }
+
+  #       it "return the subject name" do
+  #         expect(decorated_course.subject_name).to eq("Computer Science")
+  #       end
+  #     end
+  #   end
+
+  #   describe "#bursary_requirements" do
+  #     let(:subject) { decorated_course.bursary_requirements }
+
+  #     context "Course with mathematics as a subject" do
+  #       let(:mathematics) { build :subject, :mathematics, subject_name: "Primary with Mathematics" }
+  #       let(:english) { build :subject, :english }
+  #       let(:subjects) { [mathematics, english] }
+
+  #       expected_requirements = [
+  #         "a degree of 2:2 or above in any subject",
+  #         "at least grade B in maths A-level (or an equivalent)",
+  #       ]
+
+  #       it { is_expected.to eq(expected_requirements) }
+  #     end
+
+  #     context "Course without mathematics as a subject" do
+  #       let(:english) { build :subject, :english }
+  #       let(:subjects) { [biology, english] }
+
+  #       expected_requirements = [
+  #         "a degree of 2:2 or above in any subject",
+  #       ]
+
+  #       it { is_expected.to eq(expected_requirements) }
+  #     end
+  #   end
+
+  #   describe "#bursary_first_line_ending" do
+  #     let(:subject) { decorated_course.bursary_first_line_ending }
+
+  #     context "More than one requirement" do
+  #       let(:mathematics) { build :subject, :mathematics, subject_name: "Primary with Mathematics" }
+  #       let(:english) { build :subject, :english }
+  #       let(:subjects) { [mathematics, english] }
+
+  #       expected_line_ending = ":"
+
+  #       it { is_expected.to eq(expected_line_ending) }
+  #     end
+
+  #     context "Course without mathematics as a subject" do
+  #       let(:english) { build :subject, :english }
+  #       let(:subjects) { [biology, english] }
+
+  #       expected_line_ending = "a degree of 2:2 or above in any subject."
+
+  #       it { is_expected.to eq(expected_line_ending) }
+  #     end
+  #   end
+
+  #   describe "#bursary_only" do
+  #     let(:subject) { decorated_course }
+
+  #     context "course only has bursary financial incentives" do
+  #       let(:mathematics) { build :subject, bursary_amount: "2000" }
+  #       let(:english) { build :subject, bursary_amount: "4000" }
+  #       let(:subjects) { [mathematics, english] }
+
+  #       it { is_expected.to be_bursary_only }
+  #     end
+
+  #     context "course has other financial incentives apart from bursaries" do
+  #       let(:mathematics) { build :subject, bursary_amount: "2000" }
+  #       let(:english) { build :subject, scholarship: "4000" }
+  #       let(:subjects) { [mathematics, english] }
+
+  #       it { is_expected.to_not be_bursary_only }
+  #     end
+  #   end
+
+  #   describe "#has_bursary" do
+  #     context "course has no bursary" do
+  #       it "returns false" do
+  #         expect(decorated_course.has_bursary?).to eq(false)
+  #       end
+  #     end
+
+  #     context "course has bursary" do
+  #       let(:mathematics) { build :subject, bursary_amount: "2000" }
+  #       let(:english) { build :subject, bursary_amount: "4000" }
+  #       let(:subjects) { [biology, mathematics, english] }
+
+  #       it "returns true" do
+  #         expect(decorated_course.has_bursary?).to eq(true)
+  #       end
+  #     end
+  #   end
+
+  #   describe "#bursary_amount" do
+  #     context "course has bursary" do
+  #       let(:mathematics) { build :subject, bursary_amount: "2000" }
+  #       let(:english) { build :subject, bursary_amount: "4000" }
+  #       let(:subjects) { [biology, mathematics, english] }
+
+  #       it "returns the maximum bursary amount" do
+  #         expect(decorated_course.bursary_amount).to eq("4000")
+  #       end
+  #     end
+  #   end
+
+  #   describe "#excluded_from_bursary?" do
+  #     let(:subject) { decorated_course }
+
+  #     context "course name does not qualify for exclusion" do
+  #       let(:course) { build(:course, name: "Mathematics") }
+
+  #       it { is_expected.to_not be_excluded_from_bursary }
+  #     end
+
+  #     context "course name contains 'with'" do
+  #       context "Drama" do
+  #         let(:english) { build :subject, bursary_amount: "30000" }
+  #         let(:drama) { build :subject, subject_name: "Drama" }
+  #         let(:subjects) { [english, drama] }
+
+  #         context "Drama with English" do
+  #           let(:course) { build(:course, name: "Drama with English", subjects: subjects) }
+
+  #           it { is_expected.to be_excluded_from_bursary }
+  #         end
+
+  #         context "English with Drama" do
+  #           let(:course) { build(:course, name: "English with Drama", subjects: subjects) }
+
+  #           it { is_expected.to_not be_excluded_from_bursary }
+  #         end
+  #       end
+
+  #       context "PE" do
+  #         let(:english) { build :subject, bursary_amount: "30000" }
+  #         let(:pe) { build :subject, subject_name: "PE" }
+  #         let(:subjects) { [english, pe] }
+
+  #         context "PE with English" do
+  #           let(:course) { build(:course, name: "PE with English", subjects: subjects) }
+
+  #           it { is_expected.to be_excluded_from_bursary }
+  #         end
+
+  #         context "English with PE" do
+  #           let(:course) { build(:course, name: "English with PE", subjects: subjects) }
+
+  #           it { is_expected.to_not be_excluded_from_bursary }
+  #         end
+  #       end
+
+  #       context "Physical Education" do
+  #         let(:english) { build :subject, bursary_amount: "30000" }
+  #         let(:physical_education) { build :subject, subject_name: "Physical Education" }
+  #         let(:subjects) { [english, physical_education] }
+
+  #         context "Physical Education with English" do
+  #           let(:course) { build(:course, name: "Physical Education with English", subjects: subjects) }
+
+  #           it { is_expected.to be_excluded_from_bursary }
+  #         end
+
+  #         context "English with Physical Education" do
+  #           let(:course) { build(:course, name: "English with Physical Education", subjects: subjects) }
+
+  #           it { is_expected.to_not be_excluded_from_bursary }
+  #         end
+  #       end
+
+  #       context "Media Studies" do
+  #         let(:english) { build :subject, bursary_amount: "30000" }
+  #         let(:media_studies) { build :subject, subject_name: "Media Studies" }
+  #         let(:subjects) { [english, media_studies] }
+
+  #         context "Media Studies with English" do
+  #           let(:course) { build(:course, name: "Media Studies with English", subjects: subjects) }
+
+  #           it { is_expected.to be_excluded_from_bursary }
+  #         end
+
+  #         context "English with Media Studies" do
+  #           let(:course) { build(:course, name: "English with Media Studies", subjects: subjects) }
+
+  #           it { is_expected.to_not be_excluded_from_bursary }
+  #         end
+  #       end
+  #     end
+
+  #     context "course name contains 'and'" do
+  #       let(:english) { build :subject, bursary_amount: "30000" }
+  #       let(:drama) { build :subject, subject_name: "Drama" }
+  #       let(:subjects) { [english, drama] }
+
+  #       context "Drama and English" do
+  #         let(:course) { build(:course, name: "Drama and English", subjects: subjects) }
+
+  #         it { is_expected.to_not be_excluded_from_bursary }
+  #       end
+
+  #       context "English and Drama" do
+  #         let(:course) { build(:course, name: "English and Drama", subjects: subjects) }
+
+  #         it { is_expected.to_not be_excluded_from_bursary }
+  #       end
+  #     end
+  #   end
+
+  #   describe "#scholarship_amount" do
+  #     context "course has scholarship" do
+  #       let(:mathematics) { build :subject, scholarship: "2000" }
+  #       let(:english) { build :subject, scholarship: "4000" }
+  #       let(:subjects) { [biology, mathematics, english] }
+
+  #       it "returns the maximum scholarship amount" do
+  #         expect(decorated_course.scholarship_amount).to eq("4000")
+  #       end
+  #     end
+  #   end
+
+  #   context "#has_scholarship?" do
+  #     context "course has no scholarship" do
+  #       it "returns false" do
+  #         expect(decorated_course.has_scholarship?).to eq(false)
+  #       end
+  #     end
+
+  #     context "course has scholarship" do
+  #       let(:mathematics) { build :subject, scholarship: "6000" }
+  #       let(:english) { build :subject, scholarship: "8000" }
+  #       let(:subjects) { [biology, mathematics, english] }
+
+  #       it "returns true" do
+  #         expect(decorated_course.has_scholarship?).to eq(true)
+  #       end
+  #     end
+  #   end
+
+  #   context "early careers payment option" do
+  #     context "course has no early career payment option" do
+  #       it "returns false" do
+  #         expect(decorated_course.has_early_career_payments?).to eq(false)
+  #       end
+  #     end
+
+  #     context "course has early career payment option" do
+  #       let(:english) { build :subject, early_career_payments: "2000" }
+  #       let(:subjects) { [biology, mathematics, english] }
+
+  #       it "returns true" do
+  #         expect(decorated_course.has_early_career_payments?).to eq(true)
+  #       end
+  #     end
+  #   end
+  # end
+
+  # describe "return_start_date" do
+  #   context "when the course has a start date" do
+  #     it "should return the course's start date" do
+  #       expect(decorated_course.return_start_date).to eq(course.start_date)
+  #     end
+  #   end
+
+  #   context "when the course has no start date" do
+  #     let(:start_date) { nil }
+
+  #     it "should return the September of the current cycle" do
+  #       expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle}")
+  #     end
+  #   end
+
+  #   context "during rollover" do
+  #     let(:start_date) { nil }
+
+  #     before { allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(true) }
+
+  #     it "should return the September of the next cycle" do
+  #       expect(decorated_course.return_start_date).to eq("September #{Settings.current_cycle + 1}")
+  #     end
+  #   end
+  # end
+
+  # describe "#other_course_length?" do
+  #   context "when course_length is a pre-defined value" do
+  #     let(:course) { build(:course, course_length: "OneYear") }
+
+  #     it "returns false" do
+  #       expect(decorated_course.other_course_length?).to be_falsey
+  #     end
+  #   end
+
+  #   context "when course_length is nil" do
+  #     let(:course) { build(:course, course_length: nil) }
+
+  #     it "returns false so there is no default value" do
+  #       expect(decorated_course.other_course_length?).to be_falsey
+  #     end
+  #   end
+
+  #   context "when course_length is user set" do
+  #     let(:course) { build(:course, course_length: "3 months") }
+
+  #     it "returns true" do
+  #       expect(decorated_course.other_course_length?).to be_truthy
+  #     end
+  #   end
+  # end
+
+  # describe "#placements_heading" do
+  #   context "when the subject is not further education" do
+  #     let(:course) { build(:course) }
+
+  #     it "returns school placements" do
+  #       expect(decorated_course.placements_heading).to eq("How school placements work")
+  #     end
+  #   end
+
+  #   context "when the subject is further education" do
+  #     let(:course) { build(:course, level: "further_education") }
+
+  #     it "returns teaching placements" do
+  #       expect(decorated_course.placements_heading).to eq("How teaching placements work")
+  #     end
+  #   end
+  # end
+
+  # describe "#subject_page_title" do
+  #   let(:subject_page_title) { course.decorate.subject_page_title }
+
+  #   context "a primary course" do
+  #     let(:course) { build :course, level: "primary" }
+
+  #     it "returns the correct page title" do
+  #       expect(subject_page_title).to eq("Pick a primary subject")
+  #     end
+  #   end
+
+  #   context "a secondary course" do
+  #     let(:course) { build :course, level: "secondary" }
+
+  #     it "returns the correct page title" do
+  #       expect(subject_page_title).to eq("Pick a secondary subject")
+  #     end
+  #   end
+
+  #   context "a further education course" do
+  #     let(:course) { build :course, level: "further_education" }
+
+  #     it "returns the correct page title" do
+  #       expect(subject_page_title).to eq("Pick a subject")
+  #     end
+  #   end
+  # end
+
+  # describe "#changing_basic_details" do
+  #   context "basic details when course is further education" do
+  #     let(:course) { build :course, level: "further_education" }
+
+  #     it "returns the correct details under 'changing your basic details'" do
+  #       expect(decorated_course.listing_basic_details).to eq(["outcome",
+  #                                                             "full time or part time",
+  #                                                             "fee or salary",
+  #                                                             "application open date",
+  #                                                             "course start date"])
+  #     end
+  #   end
+
+  #   context "basic details when course is primary or secondary" do
+  #     let(:course) { build :course }
+
+  #     it "returns the correct details under 'changing your basic details'" do
+  #       expect(decorated_course.listing_basic_details).to eq(["age range",
+  #                                                             "outcome",
+  #                                                             "full time or part time",
+  #                                                             "application open date",
+  #                                                             "course start date",
+  #                                                             "GCSE requirements"])
+  #     end
+  #   end
+  # end
+
+  # describe "#subject_input_label" do
+  #   let(:subject_input_label) { course.decorate.subject_input_label }
+
+  #   context "a primary course" do
+  #     let(:course) { build :course, level: "primary" }
+
+  #     it "returns the correct input label" do
+  #       expect(subject_input_label).to eq("Primary subject")
+  #     end
+  #   end
+
+  #   context "a secondary course" do
+  #     let(:course) { build :course, level: "secondary" }
+
+  #     it "returns the correct input label" do
+  #       expect(subject_input_label).to eq("Secondary subject")
+  #     end
+  #   end
+
+  #   context "a further education course" do
+  #     let(:course) { build :course, level: "further_education" }
+
+  #     it "returns the correct input label" do
+  #       expect(subject_input_label).to eq("Pick a subject")
+  #     end
+  #   end
+  # end
+
+  # describe "#cycle_range" do
+  #   let(:expected_cycle_range) do
+  #     "#{current_recruitment_cycle.year} to #{current_recruitment_cycle.year.to_i + 1}"
+  #   end
+
+  #   subject { course.decorate.cycle_range }
+
+  #   it "should state the correct cycle range" do
+  #     expect(subject).to eq(expected_cycle_range)
+  #   end
+  # end
+
+  # describe "#use_financial_support_placeholder?" do
+  #   before do
+  #     allow(Settings).to receive(:financial_support_placeholder_cycle)
+  #       .and_return(financial_support_placeholder_cycle)
+  #   end
+
+  #   subject { course.decorate.use_financial_support_placeholder? }
+  #   context "financial_support_placeholder_cycle is nil" do
+  #     let(:financial_support_placeholder_cycle) { nil }
+
+  #     it "should be false" do
+  #       expect(subject).to be_falsey
+  #     end
+  #   end
+  #   context "financial_support_placeholder_cycle not the same as course recruitment_cycle_year" do
+  #     let(:financial_support_placeholder_cycle) do
+  #       course.recruitment_cycle_year.to_i + 1
+  #     end
+  #     it "should be false" do
+  #       expect(subject).to be_falsey
+  #     end
+  #   end
+
+  #   context "financial_support_placeholder_cycle same as course recruitment_cycle_year" do
+  #     let(:financial_support_placeholder_cycle) do
+  #       course.recruitment_cycle_year.to_i
+  #     end
+  #     it "should be true" do
+  #       expect(subject).to be_truthy
+  #     end
+  #   end
+  # end
+
+  describe "#vacancies" do
+    subject { course.decorate.vacancies }
+
+    let(:link) do
+      "/publish/organisations/#{provider.provider_code}/#{current_recruitment_cycle.year}/courses/#{course.course_code}/vacancies"
+    end
+
+    before do
+      allow(course).to receive(:has_vacancies?).and_return(has_vacancies)
+      allow(course).to receive(:is_withdrawn?).and_return(is_withdrawn)
+    end
+
+    context "has no vacancies" do
+      it "has link" do
+        expect(subject).to eq "No (<a class=\"govuk-link\" href=\"#{link}\">Edit<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
+      end
+
+      context "has been withdrawn" do
+        let(:is_withdrawn) { true }
+
+        it "does not have link" do
+          expect(subject).to eq "No"
+        end
+      end
+    end
+
+    context "has vacancies" do
+      let(:has_vacancies) { true }
+
+      it "has link" do
+        expect(subject).to eq "Yes (<a class=\"govuk-link\" href=\"#{link}\">Edit<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
+      end
+
+      context "has been withdrawn" do
+        let(:is_withdrawn) { true }
+
+        it "does not have link" do
+          expect(subject).to eq "Yes"
+        end
+      end
+    end
+  end
+end

--- a/spec/features/publish_interface/viewing_courses_spec.rb
+++ b/spec/features/publish_interface/viewing_courses_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Managing a provider's courses" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    when_i_visit_the_courses_page
+  end
+
+  scenario "i can view a provider's courses" do
+    then_i_should_see_a_list_of_courses
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          create(:provider, sites: [build(:site)], courses: [build(:course)]),
+        ],
+      ),
+    )
+  end
+
+  def when_i_visit_the_courses_page
+    publish_provider_courses_index_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year,
+    )
+  end
+
+  def then_i_should_see_a_list_of_courses
+    expect(publish_provider_courses_index_page.courses.size).to eq(1)
+
+    expect(publish_provider_courses_index_page.courses.first.name).to have_text(course.name)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course
+    @course ||= provider.courses.first
+  end
+end

--- a/spec/support/feature_helpers/publish_interface_pages.rb
+++ b/spec/support/feature_helpers/publish_interface_pages.rb
@@ -19,5 +19,9 @@ module FeatureHelpers
     def publish_provider_locations_index_page
       @publish_provider_locations_index_page ||= PageObjects::PublishInterface::ProviderLocationsIndex.new
     end
+
+    def publish_provider_courses_index_page
+      @publish_provider_courses_index_page ||= PageObjects::PublishInterface::ProviderCoursesIndex.new
+    end
   end
 end

--- a/spec/support/page_objects/publish_interface/provider_courses_index.rb
+++ b/spec/support/page_objects/publish_interface/provider_courses_index.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative "../sections/course"
+
+module PageObjects
+  module PublishInterface
+    class ProviderCoursesIndex < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses"
+
+      sections :courses, '[data-qa="courses__table-section"]' do
+        element :subheading, "h2"
+        element :name, '[data-qa="courses-table__course-name"]'
+        element :link, '[data-qa="courses-table__course-name"] a'
+        element :status, '[data-qa="courses-table__status"]'
+        element :on_find, '[data-qa="courses-table__findable"]'
+        element :find_link, '[data-qa="courses-table__findable"] a'
+        element :applications, '[data-qa="courses-table__applications"]'
+        element :vacancies, '[data-qa="courses-table__vacancies"]'
+      end
+
+      element :add_course, ".govuk-button", text: "Add a new course"
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/T5fMViQB/591-migrate-courses-courses-index-page

### Changes proposed in this pull request

- Migrate the courses index page to new publish
- Bring over supporting code and fix where things are broken

### Guidance to review

https://teacher-training-api-pr-2460.london.cloudapps.digital/publish/organisations/2AT/2022/courses

Assert the current list of courses (and information) matches the same view in old publish.

Note: Course adding/editing (and vacancies editing) will be handled in upcoming tickets

I've also temporarily disabled a couple of Rubocop rules in two methods as they'll probably require refactoring which is outside the scope of this ticket/work. We'll remove these and sort out post migration.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
