### PR TITLE
Replaced service binding with service key

### DIFF
--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -14,9 +14,6 @@ resource cloudfoundry_app web_app {
   docker_credentials         = var.docker_credentials
 
   service_binding {
-    service_instance = cloudfoundry_service_instance.postgres.id
-  }
-  service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
   }
   service_binding {
@@ -48,9 +45,6 @@ resource cloudfoundry_app worker_app {
   environment          = local.app_environment_variables
   docker_credentials   = var.docker_credentials
 
-  service_binding {
-    service_instance = cloudfoundry_service_instance.postgres.id
-  }
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
   }
@@ -118,6 +112,11 @@ resource cloudfoundry_user_provided_service logging {
   name             = local.logging_service_name
   space            = data.cloudfoundry_space.space.id
   syslog_drain_url = var.logstash_url
+}
+
+resource cloudfoundry_service_key postgres_key {
+  name             = "${local.postgres_service_name}-app-key"
+  service_instance = cloudfoundry_service_instance.postgres.id
 }
 
 resource cloudfoundry_service_key redis_cache_key {

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -48,6 +48,7 @@ locals {
 
   app_environment_variables = merge(var.app_environment_variables,
     {
+      DATABASE_URL     = cloudfoundry_service_key.postgres_key.credentials.uri
       REDIS_CACHE_URL  = cloudfoundry_service_key.redis_cache_key.credentials.uri
       REDIS_WORKER_URL = cloudfoundry_service_key.redis_worker_key.credentials.uri
     }


### PR DESCRIPTION
### Context

Service binding is causing interruption in database connection after deployment as new service binding replaces old. 

### Changes proposed in this pull request

Replacing with service key that defines a persistent set of credentials.

https://trello.com/c/LAQXxy4y/2042-site-reliability-engineering-issue

### Guidance to review

Ensure database connection still works in review app

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
