### PR TITLE
[0580] Migrate users section request access form

### DIFF
--- a/app/controllers/publish_interface/providers/access_requests_controller.rb
+++ b/app/controllers/publish_interface/providers/access_requests_controller.rb
@@ -1,0 +1,34 @@
+module PublishInterface
+  module Providers
+    class AccessRequestsController < PublishInterfaceController
+      def new
+        authorize AccessRequest
+
+        @access_request = AccessRequestForm.new(user: current_user)
+      end
+
+      def create
+        authorize AccessRequest
+
+        @access_request = AccessRequestForm.new(params: access_request_params, user: current_user)
+
+        if @access_request.save!
+          redirect_to users_publish_provider_path(params[:code]),
+                      flash: { success: "Your request for access has been submitted" }
+        else
+          @errors = @access_request.errors.messages
+
+          render :new
+        end
+      end
+
+    private
+
+      def access_request_params
+        params.require(:publish_interface_access_request_form).permit(
+          *AccessRequestForm::FIELDS,
+        )
+      end
+    end
+  end
+end

--- a/app/forms/publish_interface/access_request_form.rb
+++ b/app/forms/publish_interface/access_request_form.rb
@@ -1,0 +1,39 @@
+module PublishInterface
+  class AccessRequestForm < BaseModelForm
+    alias_method :access_request, :model
+
+    validates :first_name, :last_name, :email_address,
+              :organisation, :reason,
+              presence: true
+
+    FIELDS = %i[
+      first_name
+      last_name
+      email_address
+      organisation
+      reason
+    ].freeze
+
+    attr_accessor(*FIELDS, :user)
+
+    def initialize(user:, params: {})
+      @user = user
+      super(AccessRequest.new, params: params)
+    end
+
+  private
+
+    def requester_email
+      @requester_email ||= user.email
+    end
+
+    def assign_attributes_to_model
+      access_request.assign_attributes(fields.except(*fields_to_ignore_before_save).merge(requester_email: requester_email))
+      access_request.add_additional_attributes(requester_email)
+    end
+
+    def compute_fields
+      access_request.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+  end
+end

--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -13,6 +13,7 @@ class AccessRequestPolicy
     @user.present?
   end
 
+  alias_method :new?, :create?
   alias_method :index?, :approve?
   alias_method :show?, :approve?
   alias_method :destroy?, :approve?

--- a/app/views/publish_interface/providers/access_requests/new.html.erb
+++ b/app/views/publish_interface/providers/access_requests/new.html.erb
@@ -1,0 +1,39 @@
+<% page_title = "Request access for someone else" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @access_request.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(users_publish_provider_path(params[:code])) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @access_request,
+      url: request_access_publish_provider_path(params[:code]),
+      method: :post
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <%= page_title %>
+      </h1>
+
+      <p class="govuk-body">You can request a DfE Sign-in account for others who manage your courses.</p>
+
+      <%= f.govuk_fieldset legend: { text: "Request an account for:", size: "m" } do %>
+        <%= f.govuk_text_field :first_name, label: { text: 'First name' }, width: "one-half" %>
+
+        <%= f.govuk_text_field :last_name, label: { text: 'Last name' }, width: "one-half" %>
+
+        <%= f.govuk_email_field :email_address, label: { text: "Email address" } %>
+
+        <%= f.govuk_text_field :organisation %>
+
+        <%= f.govuk_text_area :reason, width: "two-thirds" %>
+      <% end %>
+
+      <%= f.govuk_submit "Request access" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -230,6 +230,21 @@ en:
               blank: "^Enter their organisation"
             reason:
               blank: "^Enter why they need access"
+  activemodel:
+    errors:
+      models:
+        publish_interface/access_request_form:
+          attributes:
+            first_name:
+              blank: "Enter a first name"
+            last_name:
+              blank: "Enter a last name"
+            email_address:
+              blank: "Enter an email address"
+            organisation:
+              blank: "Enter their organisation"
+            reason:
+              blank: "Enter why they need access"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,8 @@ Rails.application.routes.draw do
 
     resources :providers, path: "organisations", param: :code, only: [] do
       get "/users", on: :member, to: "users#index"
-      get "/request-access", on: :member, to: "access_requests#new"
+      get "/request-access", on: :member, to: "providers/access_requests#new"
+      post "/request-access", on: :member, to: "providers/access_requests#create"
 
       resources :recruitment_cycles, param: :year, constraints: { year: /#{Settings.current_recruitment_cycle_year}|#{Settings.current_recruitment_cycle_year + 1}/ }, path: "", only: [:show] do
         get "/about", on: :member, to: "providers#about"

--- a/spec/features/publish_interface/creating_request_access.rb
+++ b/spec/features/publish_interface/creating_request_access.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Creating request access" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    and_i_visit_the_request_access_new_page
+  end
+
+  scenario "creating request access with invalid data" do
+    and_i_submit_with_invalid_data
+    then_i_should_see_an_error_message
+  end
+
+  scenario "creating request access with valid data" do
+    and_i_submit_with_valid_data
+    then_i_should_see_a_success_message
+  end
+
+private
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/users")
+    expect(page).to have_content("Your request for access has been submitted")
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    user = create(:user, :with_provider)
+    given_i_am_authenticated(user: user)
+  end
+
+  def and_i_visit_the_request_access_new_page
+    request_access_new_page.load(provider_code: provider.provider_code)
+  end
+
+  def and_i_click_on_request_access
+    request_access_new_page.request_access.click
+  end
+
+  def and_i_submit_with_valid_data
+    request_access_new_page.first_name.set("first_name")
+    request_access_new_page.last_name.set("last_name")
+    request_access_new_page.email_address.set("email@address")
+    request_access_new_page.organisation.set("organisation")
+    request_access_new_page.reason.set("reason")
+    and_i_click_on_request_access
+  end
+
+  def and_i_submit_with_invalid_data
+    request_access_new_page.first_name.set("")
+    request_access_new_page.last_name.set("")
+    request_access_new_page.email_address.set("")
+    request_access_new_page.organisation.set("")
+    request_access_new_page.reason.set("")
+    and_i_click_on_request_access
+  end
+
+  def then_i_should_see_an_error_message
+    expect(request_access_new_page.error_messages).to eq(["Enter a first name", "Enter a last name", "Enter an email address", "Enter their organisation", "Enter why they need access"])
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish_interface/creating_request_access.rb
+++ b/spec/features/publish_interface/creating_request_access.rb
@@ -57,7 +57,8 @@ private
   end
 
   def then_i_should_see_an_error_message
-    expect(request_access_new_page.error_messages).to eq(["Enter a first name", "Enter a last name", "Enter an email address", "Enter their organisation", "Enter why they need access"])
+    expected_error_messages = ["Enter a first name", "Enter a last name", "Enter an email address", "Enter their organisation", "Enter why they need access"]
+    expect(request_access_new_page.error_messages).to eq(expected_error_messages)
   end
 
   def provider

--- a/spec/features/publish_interface/viewing_provider_users.rb
+++ b/spec/features/publish_interface/viewing_provider_users.rb
@@ -3,13 +3,29 @@
 require "rails_helper"
 
 feature "Viewing provider users" do
-  scenario "i can view associated users" do
+  before do
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_provider_users_page
+  end
+
+  scenario "i can view associated users" do
     then_i_can_view_users_associated_with_the_provider
   end
 
+  scenario "i can view request access form" do
+    and_i_click_on_request_access_for_someone_else
+    then_i_see_the_request_access_form
+  end
+
 private
+
+  def then_i_see_the_request_access_form
+    expect(page).to have_current_path("/publish/organisations/#{provider.provider_code}/request-access")
+  end
+
+  def and_i_click_on_request_access_for_someone_else
+    provider_users_page.request_access.click
+  end
 
   def given_i_am_authenticated_as_a_provider_user
     @user = create(:user, :with_provider)

--- a/spec/policies/access_request_policy_spec.rb
+++ b/spec/policies/access_request_policy_spec.rb
@@ -19,7 +19,7 @@ describe AccessRequestPolicy do
     end
   end
 
-  permissions :create? do
+  permissions :create?, :new? do
     context "non-admin user" do
       let(:user) { build(:user) }
 

--- a/spec/support/feature_helpers/publish_interface_pages.rb
+++ b/spec/support/feature_helpers/publish_interface_pages.rb
@@ -31,5 +31,9 @@ module FeatureHelpers
     def provider_users_page
       @provider_users_page ||= PageObjects::PublishInterface::ProviderUsers.new
     end
+
+    def request_access_new_page
+      @request_access_new_page ||= PageObjects::PublishInterface::RequestAccessNew.new
+    end
   end
 end

--- a/spec/support/page_objects/publish_interface/provider_users.rb
+++ b/spec/support/page_objects/publish_interface/provider_users.rb
@@ -5,7 +5,7 @@ module PageObjects
     class ProviderUsers < PageObjects::Base
       set_url "/publish/organisations/{provider_code}/users"
 
-      element :request_access, "#govuk-button"
+      element :request_access, ".govuk-button"
       element :heading, "h1"
       element :user_name, "h2", match: :first
     end

--- a/spec/support/page_objects/publish_interface/request_access_new.rb
+++ b/spec/support/page_objects/publish_interface/request_access_new.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module PublishInterface
+    class RequestAccessNew < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/request-access"
+
+      element :request_access, ".govuk-button"
+      element :heading, "h1"
+
+      element :first_name, "#publish-interface-access-request-form-first-name-field"
+      element :last_name, "#publish-interface-access-request-form-last-name-field"
+      element :email_address, "#publish-interface-access-request-form-email-address-field"
+      element :organisation, "#publish-interface-access-request-form-organisation-field"
+      element :reason, "#publish-interface-access-request-form-reason-field"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/sections/errorlink.rb
+++ b/spec/support/page_objects/sections/errorlink.rb
@@ -1,0 +1,7 @@
+module PageObjects
+  module Sections
+    class ErrorLink < PageObjects::Sections::Base
+      element :link
+    end
+  end
+end


### PR DESCRIPTION
### Context
Users section request access form

### Changes proposed in this pull request
Migrate users section request access form

### Guidance to review

There's one change in behaviour needed here — rather than redirect to the provider show page after form submission (which is what Old Publish does currently), let's redirect to the users index page.

Start from
`https://teacher-training-api-pr-2477.london.cloudapps.digital/publish/organisations/{provider_code}/users`

![request-access](https://user-images.githubusercontent.com/470137/151565306-2963f935-b1b8-4f1c-b017-97f36e25b42f.gif)



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
