### PR TITLE
[593] Migrate and rework the entire vacancies editing functionality

### DIFF
--- a/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
+++ b/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
@@ -3,7 +3,7 @@ module PublishInterface
     module Courses
       class VacanciesController < PublishInterfaceController
         def edit
-          authorize(provider, :edit?)
+          authorize(provider)
 
           @course_vacancies_form = CourseVacanciesForm.new(course)
           @site_statuses = @course_vacancies_form.running_site_statuses

--- a/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
+++ b/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
@@ -10,7 +10,7 @@ module PublishInterface
         end
 
         def update
-          authorize(provider, :update?)
+          authorize(provider)
 
           @course_vacancies_form = CourseVacanciesForm.new(course, params: vacancy_params)
 
@@ -35,11 +35,11 @@ module PublishInterface
         end
 
         def provider
-          @provider ||= Provider.find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+          @provider ||= recruitment_cycle.providers.find_by(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
         end
 
         def recruitment_cycle
-          cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+          cycle_year = params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year
 
           @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
         end
@@ -51,8 +51,6 @@ module PublishInterface
             .require(:publish_interface_course_vacancies_form)
             .permit(
               CourseVacanciesForm::FIELDS,
-              :change_vacancies_confirmation,
-              :has_vacancies,
               site_statuses_attributes: %i[id vac_status full_time part_time],
             )
         end

--- a/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
+++ b/app/controllers/publish_interface/providers/courses/vacancies_controller.rb
@@ -1,9 +1,62 @@
 module PublishInterface
   module Providers
-    class VacanciesController < PublishInterfaceController
-      def edit; end
+    module Courses
+      class VacanciesController < PublishInterfaceController
+        def edit
+          authorize(provider, :edit?)
 
-      def update; end
+          @course_vacancies_form = CourseVacanciesForm.new(course)
+          @site_statuses = @course_vacancies_form.running_site_statuses
+        end
+
+        def update
+          authorize(provider, :update?)
+
+          @course_vacancies_form = CourseVacanciesForm.new(course, params: vacancy_params)
+
+          if @course_vacancies_form.save!
+            flash[:success] = I18n.t("success.published")
+
+            redirect_to publish_provider_recruitment_cycle_courses_path(
+              provider.provider_code,
+              recruitment_cycle.year,
+            )
+          else
+            @site_statuses = @course_vacancies_form.running_site_statuses
+
+            render :edit
+          end
+        end
+
+      private
+
+        def course
+          @course ||= provider.courses.find_by!(course_code: params[:id])
+        end
+
+        def provider
+          @provider ||= Provider.find_by!(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+        end
+
+        def recruitment_cycle
+          cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
+
+          @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
+        end
+
+        def vacancy_params
+          return { change_vacancies_confirmation: nil } if params[:publish_interface_course_vacancies_form].blank?
+
+          params
+            .require(:publish_interface_course_vacancies_form)
+            .permit(
+              CourseVacanciesForm::FIELDS,
+              :change_vacancies_confirmation,
+              :has_vacancies,
+              site_statuses_attributes: %i[id vac_status full_time part_time],
+            )
+        end
+      end
     end
   end
 end

--- a/app/forms/publish_interface/course_vacancies_form.rb
+++ b/app/forms/publish_interface/course_vacancies_form.rb
@@ -1,0 +1,107 @@
+module PublishInterface
+  class CourseVacanciesForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[
+      site_statuses
+      change_vacancies_confirmation
+      has_vacancies
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    delegate :recruitment_cycle_year, :provider_code, :running_site_statuses, :name, to: :course
+
+    validate :vacancies_confirmation
+
+    def initialize(*params)
+      @site_statuses = []
+      super
+    end
+
+    def site_statuses_attributes=(attributes)
+      attributes.each do |_i, site_status_params|
+        @site_statuses.push(site_status_params)
+      end
+    end
+
+  private
+
+    def compute_fields
+      course
+        .attributes
+        .symbolize_keys
+        .slice(*FIELDS)
+        .merge(new_attributes)
+        .merge(has_vacancies: course.has_vacancies?)
+    end
+
+    def assign_attributes_to_model
+      model.assign_attributes(
+        fields
+          .except(*fields_to_ignore_before_save, :has_vacancies)
+          .deep_merge(attributes_for_site_statuses),
+      )
+    end
+
+    def fields_to_ignore_before_save
+      %w[change_vacancies_confirmation has_vacancies]
+    end
+
+    def attributes_for_site_statuses
+      { site_statuses_attributes: statuses_attributes }.stringify_keys
+    end
+
+    def vacancies_confirmation
+      return if change_vacancies_confirmation.present? || params[:site_statuses_attributes].present?
+
+      errors.add(:change_vacancies_confirmation, vacancies_confirmation_error_message)
+    end
+
+    def vacancies_confirmation_error_message
+      if course.has_vacancies?
+        "Please confirm there are no vacancies to close applications"
+      else
+        "Please confirm there are vacancies to reopen applications"
+      end
+    end
+
+    def statuses_attributes
+      if course.has_multiple_running_sites_or_study_modes?
+        attributes_for_multiple_site_statuses
+      else
+        attributes_for_single_site_status
+      end
+    end
+
+    def attributes_for_single_site_status
+      running_site_statuses.first.attributes.merge(vac_status: single_site_status_vacancy)
+    end
+
+    def attributes_for_multiple_site_statuses
+      params[:site_statuses_attributes].transform_values do |site_status_params|
+        site_status_params.except("full_time", "part_time").merge(vac_status: site_status_vacancy(site_status_params))
+      end
+    end
+
+    def single_site_status_vacancy
+      case params[:change_vacancies_confirmation]
+
+      when "no_vacancies_confirmation"
+        "no_vacancies"
+      when "has_vacancies_confirmation"
+        course.full_time? ? "full_time_vacancies" : "part_time_vacancies"
+      end
+    end
+
+    def site_status_vacancy(site_status_params)
+      return "no_vacancies" if params[:has_vacancies] == "false"
+
+      VacancyStatusDeterminationService.call(
+        vacancy_status_full_time: site_status_params[:full_time],
+        vacancy_status_part_time: site_status_params[:part_time],
+        course: course,
+      )
+    end
+  end
+end

--- a/app/forms/publish_interface/course_vacancies_form.rb
+++ b/app/forms/publish_interface/course_vacancies_form.rb
@@ -39,17 +39,18 @@ module PublishInterface
     def assign_attributes_to_model
       model.assign_attributes(
         fields
-          .except(*fields_to_ignore_before_save, :has_vacancies)
+          .symbolize_keys
+          .except(*fields_to_ignore_before_save)
           .deep_merge(attributes_for_site_statuses),
       )
     end
 
     def fields_to_ignore_before_save
-      %w[change_vacancies_confirmation has_vacancies]
+      FIELDS
     end
 
     def attributes_for_site_statuses
-      { site_statuses_attributes: statuses_attributes }.stringify_keys
+      { site_statuses_attributes: statuses_attributes }
     end
 
     def vacancies_confirmation
@@ -80,7 +81,7 @@ module PublishInterface
 
     def attributes_for_multiple_site_statuses
       params[:site_statuses_attributes].transform_values do |site_status_params|
-        site_status_params.except("full_time", "part_time").merge(vac_status: site_status_vacancy(site_status_params))
+        site_status_params.except(:full_time, :part_time).merge(vac_status: site_status_vacancy(site_status_params))
       end
     end
 

--- a/app/forms/publish_interface/course_vacancies_form.rb
+++ b/app/forms/publish_interface/course_vacancies_form.rb
@@ -35,12 +35,14 @@ module PublishInterface
     end
 
     def assign_attributes_to_model
-      model.assign_attributes(
-        fields
-          .symbolize_keys
-          .except(*fields_to_ignore_before_save)
-          .deep_merge(attributes_for_site_statuses),
-      )
+      model.assign_attributes(model_attributes)
+    end
+
+    def model_attributes
+      fields
+        .symbolize_keys
+        .except(*fields_to_ignore_before_save)
+        .deep_merge(attributes_for_site_statuses)
     end
 
     def fields_to_ignore_before_save

--- a/app/forms/publish_interface/course_vacancies_form.rb
+++ b/app/forms/publish_interface/course_vacancies_form.rb
@@ -20,9 +20,7 @@ module PublishInterface
     end
 
     def site_statuses_attributes=(attributes)
-      attributes.each do |_i, site_status_params|
-        @site_statuses.push(site_status_params)
-      end
+      @site_statuses = attributes.values
     end
 
   private

--- a/app/helpers/vacancy_helper.rb
+++ b/app/helpers/vacancy_helper.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module VacancyHelper
+  def vacancy_available_for_course_site_status?(course, site_status, vacancy_study_mode = nil)
+    case course.study_mode
+    when "full_time"
+      site_status.full_time_vacancies?
+    when "part_time"
+      site_status.part_time_vacancies?
+    when "full_time_or_part_time"
+      vacancy_available_for_study_mode?(site_status, vacancy_study_mode)
+    else
+      false
+    end
+  end
+
+private
+
+  def vacancy_available_for_study_mode?(site_status, vacancy_study_mode)
+    return true if site_status.both_full_time_and_part_time_vacancies?
+
+    case vacancy_study_mode
+    when :part_time
+      site_status.part_time_vacancies?
+    when :full_time
+      site_status.full_time_vacancies?
+    else
+      false
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -395,11 +395,11 @@ class Course < ApplicationRecord
   end
 
   def has_multiple_running_sites_or_study_modes?
-    running_site_statuses.length > 1 || full_time_or_part_time?
+    running_site_statuses.count > 1 || full_time_or_part_time?
   end
 
   def running_site_statuses
-    site_statuses.select(&:running?)
+    site_statuses.where(status: :running)
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -104,6 +104,7 @@ class Course < ApplicationRecord
   has_many :subjects, through: :course_subjects
   has_many :financial_incentives, through: :subjects
   has_many :site_statuses
+  accepts_nested_attributes_for :site_statuses
   has_many :sites,
            -> { distinct.merge(SiteStatus.where(status: %i[new_status running])) },
            through: :site_statuses
@@ -391,6 +392,14 @@ class Course < ApplicationRecord
     else
       site_statuses.findable.with_vacancies.any?
     end
+  end
+
+  def has_multiple_running_sites_or_study_modes?
+    running_site_statuses.length > 1 || full_time_or_part_time?
+  end
+
+  def running_site_statuses
+    site_statuses.select(&:running?)
   end
 
   def update_changed_at(timestamp: Time.now.utc)

--- a/app/services/vacancy_status_determination_service.rb
+++ b/app/services/vacancy_status_determination_service.rb
@@ -1,0 +1,52 @@
+class VacancyStatusDeterminationService
+  attr_reader :vacancy_status_full_time,
+              :vacancy_status_part_time,
+              :course
+
+  def self.call(vacancy_status_full_time:, vacancy_status_part_time:, course:)
+    new(
+      vacancy_status_full_time: vacancy_status_full_time,
+      vacancy_status_part_time: vacancy_status_part_time,
+      course: course,
+    ).vacancy_status
+  end
+
+  def initialize(vacancy_status_full_time:, vacancy_status_part_time:, course:)
+    @vacancy_status_full_time = vacancy_status_full_time
+    @vacancy_status_part_time = vacancy_status_part_time
+    @course                   = course
+  end
+
+  def vacancy_status
+    return "both_full_time_and_part_time_vacancies" if full_or_part_time?
+    return "full_time_vacancies" if full_time?
+    return "part_time_vacancies" if part_time?
+
+    "no_vacancies"
+  end
+
+private
+
+  def part_time?
+    (course.full_time_or_part_time? && vacancy_status_part_time?) ||
+      (course.part_time? && vacancy_status_part_time?)
+  end
+
+  def full_time?
+    (course.full_time_or_part_time? && vacancy_status_full_time?) ||
+      (course.full_time? && vacancy_status_full_time?)
+  end
+
+  def full_or_part_time?
+    course.full_time_or_part_time? &&
+      (vacancy_status_full_time? && vacancy_status_part_time?)
+  end
+
+  def vacancy_status_full_time?
+    vacancy_status_full_time == "1"
+  end
+
+  def vacancy_status_part_time?
+    vacancy_status_part_time == "1"
+  end
+end

--- a/app/views/publish_interface/providers/courses/vacancies/_multiple_sites.html.erb
+++ b/app/views/publish_interface/providers/courses/vacancies/_multiple_sites.html.erb
@@ -1,0 +1,25 @@
+<%= f.govuk_radio_buttons_fieldset(:has_vacancies,  legend: nil) do %>
+  <%= f.govuk_radio_button :has_vacancies, false, label: { text: "There are no vacancies", size: "s" }, 
+    hint: { text: "Close this course to new applications.<br>You can reopen a course later.".html_safe },
+    link_errors: true 
+  %>
+
+  <%= f.govuk_radio_divider %>
+
+  <%= f.govuk_radio_button(:has_vacancies, true, label: { text: "There are some vacancies", size: "s" },
+    hint: { text: "Select the locations with vacancies" },
+    link_errors: true) do %>
+
+    <% @site_statuses.sort_by { |status| status.site.location_name }.each do |site_status| %>
+      <%= f.fields_for :site_statuses, site_status do |site_status| %>
+        <% if @course.full_time_or_part_time? %>
+          <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: :part_time, show_study_mode: true } %>
+          <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: :full_time, show_study_mode: true } %>
+        <% elsif @course.full_time? || @course.part_time? %>
+          <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: @course.study_mode } %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>
+

--- a/app/views/publish_interface/providers/courses/vacancies/_multiple_sites.html.erb
+++ b/app/views/publish_interface/providers/courses/vacancies/_multiple_sites.html.erb
@@ -15,7 +15,7 @@
         <% if @course.full_time_or_part_time? %>
           <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: :part_time, show_study_mode: true } %>
           <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: :full_time, show_study_mode: true } %>
-        <% elsif @course.full_time? || @course.part_time? %>
+        <% else %>
           <%= render partial: "site_status_checkbox", locals: { f: site_status, course: @course, study_mode: @course.study_mode } %>
         <% end %>
       <% end %>

--- a/app/views/publish_interface/providers/courses/vacancies/_single_site.html.erb
+++ b/app/views/publish_interface/providers/courses/vacancies/_single_site.html.erb
@@ -1,0 +1,13 @@
+<%= f.govuk_check_boxes_fieldset :change_vacancies_confirmation, multiple: false, legend: nil do %>
+  <% if @course.has_vacancies? %>
+    <%= f.govuk_check_box :change_vacancies_confirmation, :no_vacancies_confirmation, multiple: false, link_errors: true, 
+      label: { text: 'I confirm there are no vacancies', size: 's' },
+      hint: { text: 'Close this course to new applications.<br>You can reopen a course later.'.html_safe }
+    %>
+  <% else %>
+    <%= f.govuk_check_box :change_vacancies_confirmation, :has_vacancies_confirmation, multiple: false, link_errors: true, 
+      label: { text: 'I confirm there are vacancies', size: 's' },
+      hint: { text: 'Reopen this course to new applications.' }
+    %>
+  <% end %>
+<% end %>

--- a/app/views/publish_interface/providers/courses/vacancies/_site_status_checkbox.html.erb
+++ b/app/views/publish_interface/providers/courses/vacancies/_site_status_checkbox.html.erb
@@ -1,0 +1,6 @@
+<% show_study_mode ||= false %>
+
+<div class="govuk-checkboxes__item">
+  <%= f.check_box(study_mode, checked: vacancy_available_for_course_site_status?(course, f.object, study_mode), class: "govuk-checkboxes__input") %>
+  <%= f.label(study_mode, "#{f.object.site.location_name}#{show_study_mode ? " (#{study_mode.to_s.humanize})" : ''}", class: "govuk-label govuk-checkboxes__label") %>
+</div>

--- a/app/views/publish_interface/providers/courses/vacancies/edit.html.erb
+++ b/app/views/publish_interface/providers/courses/vacancies/edit.html.erb
@@ -1,0 +1,40 @@
+<% content_for :page_title do %>
+  <% title_with_error_prefix("Edit vacancies – #{@course.name} (#{@course.course_code})", @course_vacancies_form.errors.any?)  %> 
+ <% end %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle.year)) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @course_vacancies_form,
+      url: vacancies_publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle.year, @course.course_code),
+      method: :put
+    ) do |form| %>
+      
+      <%= form.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @course.name %> (<%= @course.course_code %>)</span>
+        Edit vacancies
+      </h1>
+
+      <% if @course.has_multiple_running_sites_or_study_modes? %>
+        <%= render partial: "multiple_sites", locals: { f: form } %>
+      <% else %>
+        <%= render partial: "single_site", locals: { f: form } %>
+      <% end %>
+
+      <% if @course.has_multiple_running_sites_or_study_modes? %>
+        <%= form.govuk_submit "Publish changes"%>
+      <% elsif @course.has_vacancies? %>
+        <%= form.govuk_submit "Close applications", class: "govuk-button--warning" %>
+      <% else %>
+        <%= form.govuk_submit "Reopen applications"%>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/rubocop/naming.yml
+++ b/config/rubocop/naming.yml
@@ -1,2 +1,4 @@
 Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
+  Exclude:
+  - "spec/**/*"

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -198,14 +198,6 @@ FactoryBot.define do
       to_create { |instance| instance.save(validate: false) }
     end
 
-    trait :full_time_or_part_time do
-      study_mode { :full_time_or_part_time }
-    end
-
-    trait :part_time do
-      study_mode { "part_time" }
-    end
-
     trait :unpublished do
       transient do
         identifier { "unpublished" }

--- a/spec/factories/courses.rb
+++ b/spec/factories/courses.rb
@@ -198,6 +198,14 @@ FactoryBot.define do
       to_create { |instance| instance.save(validate: false) }
     end
 
+    trait :full_time_or_part_time do
+      study_mode { :full_time_or_part_time }
+    end
+
+    trait :part_time do
+      study_mode { "part_time" }
+    end
+
     trait :unpublished do
       transient do
         identifier { "unpublished" }

--- a/spec/features/publish_interface/editing_vacancies_spec.rb
+++ b/spec/features/publish_interface/editing_vacancies_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing vacancies" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  context "a full time course with one running site" do
+    scenario "presents a checkbox to turn off all vacancies" do
+      and_there_is_a_full_time_course_with_one_running_site
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      then_i_should_see_a_checkbox_to_turn_off_all_vacancies
+      when_i_check_the_checkbox_to_turn_off_all_vacancies
+      and_i_submit
+      then_the_vacancies_are_turned_off
+    end
+
+    scenario "shows an error if the form is submitted without confirming" do
+      and_there_is_a_full_time_course_with_one_running_site
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_submit_with_invalid_data
+      then_i_should_see_a_an_error_message
+    end
+  end
+
+  context "a full time or part time course with one running site but no vacancies" do
+    scenario "full time course presents a checkbox to turn on all vacancies" do
+      and_there_is_a_full_time_course_with_one_site_and_no_vacancies
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      then_i_should_see_a_checkbox_to_turn_on_all_vacancies
+      when_i_check_the_checkbox_to_turn_on_all_vacancies
+      and_i_submit
+      then_the_vacancies_are_turned_on("full_time_vacancies")
+    end
+
+    scenario "part time course presents a checkbox to turn on all vacancies" do
+      and_there_is_a_part_time_course_with_one_site_and_no_vacancies
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      then_i_should_see_a_checkbox_to_turn_on_all_vacancies
+      when_i_check_the_checkbox_to_turn_on_all_vacancies
+      and_i_submit
+      then_the_vacancies_are_turned_on("part_time_vacancies")
+    end
+
+    scenario "shows an error if the form is submitted without confirming" do
+      and_there_is_a_full_time_course_with_one_site_and_no_vacancies
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_submit_with_invalid_data
+      then_i_should_see_a_an_error_message
+    end
+  end
+
+  scenario "a full time course with multiple running sites only render site statuses that are running" do
+    and_there_is_a_full_time_course_with_multiple_sites
+    when_i_visit_the_vacancy_edit_page_for_a_course
+    then_i_should_see_a_checkbox_for_each_running_site
+  end
+
+  scenario "a full time course with multiple running sites but no vacancies shows course as having no vacancies" do
+    and_there_is_a_full_time_course_with_sites_and_no_vacancies
+    when_i_visit_the_vacancy_edit_page_for_a_course
+    then_i_should_see_the_course_as_having_no_vacancies
+  end
+
+  scenario "a full time or part time course with one site presents a radio button choice and shows both study modes for the site" do
+    and_there_is_a_full_or_part_time_course_with_one_full_and_part_time_site
+    when_i_visit_the_vacancy_edit_page_for_a_course
+    then_i_should_see_a_checkbox_for_each_study_mode
+  end
+
+  scenario "a full time or part time course with multiple running sites shows both study modes for each site" do
+    and_there_is_a_full_or_part_time_course_with_multiple_sites
+    when_i_visit_the_vacancy_edit_page_for_a_course
+    then_i_should_see_a_checkbox_for_each_study_mode_per_site
+  end
+
+  context "removing vacancies for a course" do
+    scenario "removing a full time vacancy with no vacancies remaining" do
+      and_there_is_a_full_time_course_with_multiple_sites
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_uncheck_the_sites
+      and_i_submit
+      then_the_vacancies_are_turned_off
+    end
+
+    scenario "removing all vacancies" do
+      and_there_is_a_full_time_course_with_multiple_sites
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_choose_to_remove_all_vacancies
+      and_i_submit
+      then_the_vacancies_are_turned_off
+    end
+
+    scenario "removing a full time vacancy with one remaining" do
+      and_there_is_a_full_time_course_with_multiple_sites
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_uncheck_some_sites
+      and_i_submit
+      then_the_vacancies_are_updated_with(%w[no_vacancies full_time_vacancies])
+    end
+  end
+
+  context "adding vacancies for a course" do
+    scenario "all locations have vacancies" do
+      and_there_is_a_full_time_course_with_sites_and_no_vacancies
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_check_all_the_sites
+      and_i_submit
+      then_the_vacancies_are_turned_on("full_time_vacancies")
+    end
+
+    scenario "some locations have vacancies" do
+      and_there_is_a_full_time_course_with_sites_and_no_vacancies
+      when_i_visit_the_vacancy_edit_page_for_a_course
+      and_i_check_some_sites
+      and_i_submit
+      then_the_vacancies_are_updated_with(%w[full_time_vacancies no_vacancies])
+    end
+  end
+
+  scenario "adding a part time vacancy for a course thats full or part time" do
+    and_there_is_a_full_or_part_time_course_with_one_full_time_site
+    when_i_visit_the_vacancy_edit_page_for_a_course
+    and_i_check_the_part_time_site
+    and_i_submit
+    then_the_vacancies_are_updated_with(%w[both_full_time_and_part_time_vacancies])
+  end
+
+private
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_full_time_course_with_one_running_site
+    given_a_course_exists
+    given_a_site_exists(:full_time_vacancies, :findable)
+  end
+
+  def and_there_is_a_full_time_course_with_one_site_and_no_vacancies
+    given_a_course_exists
+    given_a_site_exists(:no_vacancies, :findable)
+  end
+
+  def and_there_is_a_part_time_course_with_one_site_and_no_vacancies
+    given_a_course_exists(:part_time)
+    given_a_site_exists(:no_vacancies, :findable)
+  end
+
+  def and_there_is_a_full_time_course_with_multiple_sites
+    given_a_course_exists
+    given_a_site_exists(:full_time_vacancies, :findable, site: build(:site, location_name: "Site 1"))
+    given_a_site_exists(:full_time_vacancies, :findable, site: build(:site, location_name: "Site 2"))
+  end
+
+  def and_there_is_a_full_time_course_with_sites_and_no_vacancies
+    given_a_course_exists
+    given_a_site_exists(:no_vacancies, :findable, site: build(:site, location_name: "Site 1"))
+    given_a_site_exists(:no_vacancies, :findable, site: build(:site, location_name: "Site 2"))
+  end
+
+  def and_there_is_a_full_or_part_time_course_with_one_full_and_part_time_site
+    given_a_course_exists(:full_time_or_part_time)
+    given_a_site_exists(
+      :both_full_time_and_part_time_vacancies,
+      :findable,
+      site: build(:site, location_name: "Uni full and part time 1"),
+    )
+  end
+
+  def and_there_is_a_full_or_part_time_course_with_one_full_time_site
+    given_a_course_exists(:full_time_or_part_time)
+    given_a_site_exists(
+      :full_time_vacancies,
+      :findable,
+      site: build(:site, location_name: "Uni 1"),
+    )
+  end
+
+  def and_there_is_a_full_or_part_time_course_with_multiple_sites
+    given_a_course_exists(:full_time_or_part_time)
+    given_a_site_exists(:full_time_vacancies, :findable, site: build(:site, location_name: "Uni 1"))
+    given_a_site_exists(:part_time_vacancies, :findable, site: build(:site, location_name: "Uni 2"))
+    given_a_site_exists(:both_full_time_and_part_time_vacancies, :findable, site: build(:site, location_name: "Uni 3"))
+    given_a_site_exists(:full_time_vacancies, :suspended, site: build(:site, location_name: "Not running Uni"))
+  end
+
+  def given_a_site_exists(*traits, **overrides)
+    course.site_statuses << build(:site_status, *traits, **overrides)
+  end
+
+  def when_i_visit_the_vacancy_edit_page_for_a_course
+    publish_provider_vacancies_edit_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_submit_with_invalid_data
+    publish_provider_vacancies_edit_page.submit.click
+  end
+
+  def then_i_should_see_a_an_error_message
+    expect(publish_provider_vacancies_edit_page.errors).to include(vacancies_confirmation_error_message)
+  end
+
+  def then_i_should_see_a_checkbox_to_turn_off_all_vacancies
+    expect(publish_provider_vacancies_edit_page).to have_content("I confirm there are no vacancies")
+    expect(publish_provider_vacancies_edit_page).to have_content("Close this course")
+    expect(publish_provider_vacancies_edit_page).to have_confirm_no_vacancies
+    expect(publish_provider_vacancies_edit_page.confirm_no_vacancies).not_to be_checked
+  end
+
+  def then_i_should_see_a_checkbox_to_turn_on_all_vacancies
+    expect(publish_provider_vacancies_edit_page).to have_content("I confirm there are vacancies")
+    expect(publish_provider_vacancies_edit_page).to have_content("Reopen this course")
+    expect(publish_provider_vacancies_edit_page).to have_confirm_has_vacancies
+    expect(publish_provider_vacancies_edit_page.confirm_has_vacancies).not_to be_checked
+  end
+
+  def then_i_should_see_a_checkbox_for_each_running_site
+    expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+  end
+
+  def then_i_should_see_the_course_as_having_no_vacancies
+    expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_no_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
+    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to all(be_falsey)
+  end
+
+  def then_i_should_see_a_checkbox_for_each_study_mode
+    expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(
+      ["Uni full and part time 1 (Full time)", "Uni full and part time 1 (Part time)"],
+    )
+    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to all(be_truthy)
+  end
+
+  def then_i_should_see_a_checkbox_for_each_study_mode_per_site
+    expected_checkbox_state = {
+      "Uni 1 (Full time)" => true,
+      "Uni 1 (Part time)" => false,
+      "Uni 2 (Full time)" => false,
+      "Uni 2 (Part time)" => true,
+      "Uni 3 (Full time)" => true,
+      "Uni 3 (Part time)" => true,
+    }
+
+    expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(expected_checkbox_state.keys)
+    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to match_array(expected_checkbox_state.values)
+  end
+
+  def when_i_check_the_checkbox_to_turn_off_all_vacancies
+    publish_provider_vacancies_edit_page.confirm_no_vacancies.check
+  end
+
+  def when_i_check_the_checkbox_to_turn_on_all_vacancies
+    publish_provider_vacancies_edit_page.confirm_has_vacancies.check
+  end
+
+  def and_i_uncheck_the_sites
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+
+    publish_provider_vacancies_edit_page.site_checkboxes.each(&:uncheck)
+  end
+
+  def and_i_check_all_the_sites
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
+
+    publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies.choose
+    publish_provider_vacancies_edit_page.site_checkboxes.each(&:check)
+  end
+
+  def and_i_uncheck_some_sites
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+
+    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Site 1" }.uncheck
+  end
+
+  def and_i_check_some_sites
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
+    publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies.choose
+
+    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Site 1" }.check
+  end
+
+  def and_i_check_the_part_time_site
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+
+    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Uni 1 (Part time)" }.check
+  end
+
+  def and_i_choose_to_remove_all_vacancies
+    expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
+    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+
+    publish_provider_vacancies_edit_page.vacancies_radio_no_vacancies.choose
+  end
+
+  def and_i_submit
+    publish_provider_vacancies_edit_page.submit.click
+  end
+
+  def then_the_vacancies_are_turned_off
+    expect(course.site_statuses.pluck(:vac_status)).to all(eq("no_vacancies"))
+  end
+
+  def then_the_vacancies_are_turned_on(status)
+    expect(course.site_statuses.pluck(:vac_status)).to all(eq(status))
+  end
+
+  def then_the_vacancies_are_updated_with(expected_array)
+    expect(course.site_statuses.pluck(:vac_status)).to match_array(expected_array)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def vacancies_confirmation_error_message
+    if course.has_vacancies?
+      "Please confirm there are no vacancies to close applications"
+    else
+      "Please confirm there are vacancies to reopen applications"
+    end
+  end
+end

--- a/spec/features/publish_interface/editing_vacancies_spec.rb
+++ b/spec/features/publish_interface/editing_vacancies_spec.rb
@@ -202,7 +202,7 @@ private
   end
 
   def then_i_should_see_a_an_error_message
-    expect(publish_provider_vacancies_edit_page.errors).to include(vacancies_confirmation_error_message)
+    expect(publish_provider_vacancies_edit_page.error_messages).to include(vacancies_confirmation_error_message)
   end
 
   def then_i_should_see_a_checkbox_to_turn_off_all_vacancies
@@ -222,23 +222,23 @@ private
   def then_i_should_see_a_checkbox_for_each_running_site
     expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
-    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+    expect(publish_provider_vacancies_edit_page.vacancy_names).to match_array(["Site 1", "Site 2"])
   end
 
   def then_i_should_see_the_course_as_having_no_vacancies
     expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
     expect(publish_provider_vacancies_edit_page.vacancies_radio_no_vacancies).to be_checked
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
-    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to all(be_falsey)
+    expect(publish_provider_vacancies_edit_page.vacancy_checked_values).to all(be_falsey)
   end
 
   def then_i_should_see_a_checkbox_for_each_study_mode
     expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
-    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(
+    expect(publish_provider_vacancies_edit_page.vacancy_names).to match_array(
       ["Uni full and part time 1 (Full time)", "Uni full and part time 1 (Part time)"],
     )
-    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to all(be_truthy)
+    expect(publish_provider_vacancies_edit_page.vacancy_checked_values).to all(be_truthy)
   end
 
   def then_i_should_see_a_checkbox_for_each_study_mode_per_site
@@ -253,8 +253,8 @@ private
 
     expect(publish_provider_vacancies_edit_page).to have_vacancies_radio_choice
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
-    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(expected_checkbox_state.keys)
-    expect(publish_provider_vacancies_edit_page.site_checkboxes.map(&:checked?)).to match_array(expected_checkbox_state.values)
+    expect(publish_provider_vacancies_edit_page.vacancy_names).to match_array(expected_checkbox_state.keys)
+    expect(publish_provider_vacancies_edit_page.vacancy_checked_values).to match_array(expected_checkbox_state.values)
   end
 
   def when_i_check_the_checkbox_to_turn_off_all_vacancies
@@ -267,40 +267,40 @@ private
 
   def and_i_uncheck_the_sites
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
-    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+    expect(publish_provider_vacancies_edit_page.vacancy_names).to match_array(["Site 1", "Site 2"])
 
-    publish_provider_vacancies_edit_page.site_checkboxes.each(&:uncheck)
+    publish_provider_vacancies_edit_page.vacancies.each(&:uncheck)
   end
 
   def and_i_check_all_the_sites
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
 
     publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies.choose
-    publish_provider_vacancies_edit_page.site_checkboxes.each(&:check)
+    publish_provider_vacancies_edit_page.vacancies.each(&:check)
   end
 
   def and_i_uncheck_some_sites
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
 
-    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Site 1" }.uncheck
+    publish_provider_vacancies_edit_page.vacancies.find { |el| el.text == "Site 1" }.uncheck
   end
 
   def and_i_check_some_sites
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).not_to be_checked
     publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies.choose
 
-    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Site 1" }.check
+    publish_provider_vacancies_edit_page.vacancies.find { |el| el.text == "Site 1" }.check
   end
 
   def and_i_check_the_part_time_site
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
 
-    publish_provider_vacancies_edit_page.sites.find { |el| el.text == "Uni 1 (Part time)" }.check
+    publish_provider_vacancies_edit_page.vacancies.find { |el| el.text == "Uni 1 (Part time)" }.check
   end
 
   def and_i_choose_to_remove_all_vacancies
     expect(publish_provider_vacancies_edit_page.vacancies_radio_has_some_vacancies).to be_checked
-    expect(publish_provider_vacancies_edit_page.sites.map(&:text)).to match_array(["Site 1", "Site 2"])
+    expect(publish_provider_vacancies_edit_page.vacancy_names).to match_array(["Site 1", "Site 2"])
 
     publish_provider_vacancies_edit_page.vacancies_radio_no_vacancies.choose
   end

--- a/spec/helpers/vacancy_helper_spec.rb
+++ b/spec/helpers/vacancy_helper_spec.rb
@@ -1,0 +1,249 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe VacancyHelper do
+  include VacancyHelper
+
+  describe "#vacancy_available_for_course_site_status" do
+    let(:vacancy_study_mode) { nil }
+
+    subject do
+      vacancy_available_for_course_site_status?(
+        course,
+        site_status,
+        vacancy_study_mode,
+      )
+    end
+
+    context "with a full time or part time course" do
+      let(:course) { double(:course, study_mode: "full_time_or_part_time") }
+
+      context "when the vacancy study mode is full time" do
+        let(:vacancy_study_mode) { :full_time }
+
+        context "with a full and part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: true,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq true }
+        end
+
+        context "with a full time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: true,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq true }
+        end
+
+        context "with a part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: true,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+
+        context "with no vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+      end
+
+      context "when the vacancy study mode is part time" do
+        let(:vacancy_study_mode) { :part_time }
+
+        context "with a full and part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: true,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq true }
+        end
+
+        context "with a full time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: true,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+
+        context "with a part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: true,
+            )
+          end
+
+          it { is_expected.to eq true }
+        end
+
+        context "with no vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+      end
+
+      context "without a vacancy study mode set" do
+        context "with a full and part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: true,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq true }
+        end
+
+        context "with a full time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: true,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+
+        context "with a part time vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: true,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+
+        context "with no vacancy" do
+          let(:site_status) do
+            double(
+              :site_status,
+              both_full_time_and_part_time_vacancies?: false,
+              full_time_vacancies?: false,
+              part_time_vacancies?: false,
+            )
+          end
+
+          it { is_expected.to eq false }
+        end
+      end
+    end
+
+    context "with a full time course and vacancy" do
+      let(:course) { double(:course, study_mode: "full_time") }
+
+      context "with a full time vacancy" do
+        let(:site_status) do
+          double(
+            :site_status,
+            both_full_time_and_part_time_vacancies?: false,
+            full_time_vacancies?: true,
+            part_time_vacancies?: false,
+          )
+        end
+
+        it { is_expected.to eq true }
+      end
+
+      context "with no vacancy" do
+        let(:site_status) do
+          double(
+            :site_status,
+            both_full_time_and_part_time_vacancies?: false,
+            full_time_vacancies?: false,
+            part_time_vacancies?: false,
+          )
+        end
+
+        it { is_expected.to eq false }
+      end
+    end
+
+    context "with a part time course" do
+      let(:course) { double(:course, study_mode: "part_time") }
+
+      context "with a part time vacancy" do
+        let(:site_status) do
+          double(
+            :site_status,
+            both_full_time_and_part_time_vacancies?: false,
+            full_time_vacancies?: false,
+            part_time_vacancies?: true,
+          )
+        end
+
+        it { is_expected.to eq true }
+      end
+
+      context "with no vacancy" do
+        let(:site_status) do
+          double(
+            :site_status,
+            both_full_time_and_part_time_vacancies?: false,
+            full_time_vacancies?: false,
+            part_time_vacancies?: false,
+          )
+        end
+
+        it { is_expected.to eq false }
+      end
+    end
+  end
+end

--- a/spec/services/vacancy_status_determination_service_spec.rb
+++ b/spec/services/vacancy_status_determination_service_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+describe VacancyStatusDeterminationService do
+  describe ".call" do
+    let(:vacancy_status_full_time) { "0" }
+    let(:vacancy_status_part_time) { "0" }
+
+    subject do
+      described_class.call(
+        vacancy_status_full_time: vacancy_status_full_time,
+        vacancy_status_part_time: vacancy_status_part_time,
+        course: course,
+      )
+    end
+
+    context "with a full time or part time course" do
+      let(:course) { build_stubbed(:course, :full_time_or_part_time) }
+
+      context "with a full time and part time vacancies" do
+        let(:vacancy_status_full_time) { "1" }
+        let(:vacancy_status_part_time) { "1" }
+
+        it { is_expected.to eq "both_full_time_and_part_time_vacancies" }
+      end
+
+      context "with a full time vacancy" do
+        let(:vacancy_status_full_time) { "1" }
+
+        it { is_expected.to eq "full_time_vacancies" }
+      end
+
+      context "with a part time vacancy" do
+        let(:vacancy_status_part_time) { "1" }
+
+        it { is_expected.to eq "part_time_vacancies" }
+      end
+
+      context "with no vacancies" do
+        it { is_expected.to eq "no_vacancies" }
+      end
+    end
+
+    context "with a full time course" do
+      let(:course) { build_stubbed(:course, :full_time) }
+
+      context "with a full time vacancy" do
+        let(:vacancy_status_full_time) { "1" }
+
+        it { is_expected.to eq "full_time_vacancies" }
+      end
+
+      context "with no vacancy" do
+        it { is_expected.to eq "no_vacancies" }
+      end
+    end
+
+    context "with a part time course" do
+      let(:course) { build_stubbed(:course, :part_time) }
+
+      context "with a part time vacancy" do
+        let(:vacancy_status_part_time) { "1" }
+
+        it { is_expected.to eq "part_time_vacancies" }
+      end
+
+      context "with no vacancies" do
+        it { is_expected.to eq "no_vacancies" }
+      end
+    end
+  end
+end

--- a/spec/support/feature_helpers/course_steps.rb
+++ b/spec/support/feature_helpers/course_steps.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module FeatureHelpers
+  module CourseSteps
+    attr_reader :course
+
+    def given_a_course_exists(*traits, **overrides)
+      @course ||= create(:course, *traits, **overrides, provider: current_user.providers.first)
+    end
+  end
+end

--- a/spec/support/feature_helpers/publish_interface_pages.rb
+++ b/spec/support/feature_helpers/publish_interface_pages.rb
@@ -39,5 +39,9 @@ module FeatureHelpers
     def publish_provider_courses_index_page
       @publish_provider_courses_index_page ||= PageObjects::PublishInterface::ProviderCoursesIndex.new
     end
+
+    def publish_provider_vacancies_edit_page
+      @publish_provider_vacancies_edit_page ||= PageObjects::PublishInterface::CourseVacanciesEdit.new
+    end
   end
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "feature_helpers/authentication"
+require_relative "feature_helpers/course_steps"
 require_relative "feature_helpers/support_pages"
 require_relative "feature_helpers/publish_interface_pages"
 require_relative "dfe_sign_in_user_helper"
@@ -10,5 +11,6 @@ RSpec.configure do |config|
   config.include FeatureHelpers::GovukComponents, type: :feature
   config.include FeatureHelpers::SupportPages, type: :feature
   config.include FeatureHelpers::PublishInterfacePages, type: :feature
+  config.include FeatureHelpers::CourseSteps, type: :feature
   config.include DfESignInUserHelper, type: :feature
 end

--- a/spec/support/page_objects/publish_interface/course_vacancies_edit.rb
+++ b/spec/support/page_objects/publish_interface/course_vacancies_edit.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module PublishInterface
+    class CourseVacanciesEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/vacancies"
+
+      element :error_summary, ".govuk-error-summary"
+
+      element :confirm_no_vacancies, "#publish-interface-course-vacancies-form-change-vacancies-confirmation-no-vacancies-confirmation-field"
+      element :confirm_has_vacancies, "#publish-interface-course-vacancies-form-change-vacancies-confirmation-has-vacancies-confirmation-field"
+
+      element :confirm_no_vacancies_for_sites, "#publish-interface-course-vacancies-form-has-vacancies-field"
+
+      element :vacancies_radio_choice, ".govuk-radios"
+      element :vacancies_radio_no_vacancies, "#publish-interface-course-vacancies-form-has-vacancies-field"
+      element :vacancies_radio_has_some_vacancies, "#publish-interface-course-vacancies-form-has-vacancies-true-field"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def errors
+        within(error_summary) do
+          all(".govuk-error-summary__list li").map(&:text)
+        end
+      end
+
+      def sites
+        within("#publish-interface-course-vacancies-form-has-vacancies-true-conditional") do
+          all(".govuk-checkboxes__item")
+        end
+      end
+
+      def site_checkboxes
+        within("#publish-interface-course-vacancies-form-has-vacancies-true-conditional") do
+          all(".govuk-checkboxes__input")
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish_interface/course_vacancies_edit.rb
+++ b/spec/support/page_objects/publish_interface/course_vacancies_edit.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
+require_relative "../sections/errorlink"
+require_relative "../sections/vacancy"
+
 module PageObjects
   module PublishInterface
     class CourseVacanciesEdit < PageObjects::Base
       set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/vacancies"
 
-      element :error_summary, ".govuk-error-summary"
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
 
       element :confirm_no_vacancies, "#publish-interface-course-vacancies-form-change-vacancies-confirmation-no-vacancies-confirmation-field"
       element :confirm_has_vacancies, "#publish-interface-course-vacancies-form-change-vacancies-confirmation-has-vacancies-confirmation-field"
@@ -16,24 +19,20 @@ module PageObjects
       element :vacancies_radio_no_vacancies, "#publish-interface-course-vacancies-form-has-vacancies-field"
       element :vacancies_radio_has_some_vacancies, "#publish-interface-course-vacancies-form-has-vacancies-true-field"
 
+      sections :vacancies, Sections::Vacancy, ".govuk-checkboxes__item"
+
       element :submit, 'button.govuk-button[type="submit"]'
 
-      def errors
-        within(error_summary) do
-          all(".govuk-error-summary__list li").map(&:text)
-        end
+      def error_messages
+        errors.map(&:text)
       end
 
-      def sites
-        within("#publish-interface-course-vacancies-form-has-vacancies-true-conditional") do
-          all(".govuk-checkboxes__item")
-        end
+      def vacancy_names
+        vacancies.map(&:text)
       end
 
-      def site_checkboxes
-        within("#publish-interface-course-vacancies-form-has-vacancies-true-conditional") do
-          all(".govuk-checkboxes__input")
-        end
+      def vacancy_checked_values
+        vacancies.map(&:checked?)
       end
     end
   end

--- a/spec/support/page_objects/sections/errorlink.rb
+++ b/spec/support/page_objects/sections/errorlink.rb
@@ -1,3 +1,7 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
 module PageObjects
   module Sections
     class ErrorLink < PageObjects::Sections::Base

--- a/spec/support/page_objects/sections/vacancy.rb
+++ b/spec/support/page_objects/sections/vacancy.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require "forwardable"
+
+module PageObjects
+  module Sections
+    class Vacancy < PageObjects::Sections::Base
+      extend Forwardable
+
+      element :name, ".govuk-checkboxes__label"
+      element :checkbox, ".govuk-checkboxes__input"
+
+      def_delegators :checkbox, :checked?
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/OC8lv6IK/593-migrate-courses-edit-vacancies

### Changes proposed in this pull request

- Refactor and simplify entire editing vacancies flow
- Use govuk formbuilder for views over manual markup
- Move logic over to form object pattern
- Increase test coverage with feature spec

### Guidance to review

Edit vacancies for a course with one site https://teacher-training-api-pr-2490.london.cloudapps.digital/publish/organisations/2AT/2022/courses

Edit vacancies for a course with a site and multiple study modes https://teacher-training-api-pr-2490.london.cloudapps.digital/publish/organisations/2EZ/2022/courses (33PY)

Edit vacancies for a course with multiple sites https://teacher-training-api-pr-2490.london.cloudapps.digital/publish/organisations/2CJ/2022/courses (M444)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
