### PR TITLE
Send course enrichment data to big query

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -70,6 +70,16 @@ shared:
     - created_at
     - updated_at
     - position
+  course_enrichment:
+    - id
+    - course_id
+    - created_at
+    - created_by_user_id
+    - json_data
+    - last_published_timestamp_utc
+    - status
+    - updated_at
+    - updated_by_user_id
   financial_incentive:
     - id
     - subject_id

--- a/lib/tasks/big_query.rake
+++ b/lib/tasks/big_query.rake
@@ -8,14 +8,15 @@ namespace :big_query do
     Send import events for configured entities
   DESC
 
-  task send_import_events: :environment do
+  task send_import_events: :environment do |_task, args|
     Object.const_set("CourseSite", Class.new(ApplicationRecord))
     Object.const_set("OrganisationProvider", Class.new(ApplicationRecord))
     Object.const_set("Session", Class.new(ApplicationRecord))
 
     conf = Rails.configuration.analytics
 
-    classes = conf.keys.map { |k| k.to_s.camelize.constantize }
+    provided_models = *args
+    classes = (provided_models.presence || conf.keys).map { |k| k.to_s.camelize.constantize }
 
     classes.each do |c|
       puts "Queueing: #{c.count} #{c} entities"


### PR DESCRIPTION
### Context

- https://trello.com/c/YO6vJnOA/638-get-courseenrichment-attributes-into-big-query-for-publish

### Changes proposed in this pull request

- Add course_enrichment model to the analytics list
- Update rake task to allow importing individual tables, eg:

```ruby
bundle exec rails big_query:send_import_events["course_enrichment, course"]
```

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
