### PR TITLE
[0698] Added missing cross cutting flash

### DIFF
--- a/app/components/flash_banner/view.html.erb
+++ b/app/components/flash_banner/view.html.erb
@@ -1,7 +1,27 @@
 <% if display? %>
-  <% FLASH_TYPES.each do |type| %>
-    <% if flash[type] %>
-      <%= render(NotificationBanner::View.new(text: flash[type], type: type)) %>
+  <% flash.each do |key, value| %>
+    <% if FLASH_TYPES.include?(key.to_s) %>
+      <%= render(NotificationBanner::View.new(text: flash[key], type: key)) %>
+    <% end %>
+
+    <% if key == "error" %>
+      <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
+        <h2 class="govuk-error-summary__title" id="error-summary-title" data-qa="error__heading">
+          There is a problem
+        </h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <li>
+              <a href="#<%= value["id"] %>" data-qa="error__text"><%= value["message"] %></a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    <% elsif key == "success_with_body" %>
+      <%= govuk_notification_banner(title_text: t("notification_banner.success"), success: true, html_attributes: { role: "alert" }) do |notification_banner| %>
+        <% notification_banner.heading(text: value["title"]) %>
+        <p class="govuk-body" data-qa="flash__success__body"><%= value["body"] %></p>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/components/flash_banner/view.rb
+++ b/app/components/flash_banner/view.rb
@@ -4,7 +4,7 @@ module FlashBanner
   class View < GovukComponent::Base
     attr_reader :flash
 
-    FLASH_TYPES = %i[success warning info].freeze
+    FLASH_TYPES = %w[success warning info].freeze
 
     def initialize(flash:)
       super(classes: classes, html_attributes: html_attributes)

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -44,7 +44,7 @@ module Publish
     def redirect_to_contact_page_with_ukprn_error
       flash[:error] = { id: "provider-error", message: "Please enter a UKPRN before continuing" }
 
-      redirect_to contact_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
+      redirect_to contact_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
     end
 
     def provider_params

--- a/app/controllers/publish/providers_controller.rb
+++ b/app/controllers/publish/providers_controller.rb
@@ -42,7 +42,7 @@ module Publish
   private
 
     def redirect_to_contact_page_with_ukprn_error
-      flash[:error] = { id: "provider-error", message: "Please enter a UKPRN before continuing" }
+      flash[:error] = { id: "publish-provider-contact-form-ukprn-field", message: "Please enter a UKPRN before continuing" }
 
       redirect_to contact_publish_provider_recruitment_cycle_path(provider.provider_code, provider.recruitment_cycle_year)
     end

--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -7,7 +7,7 @@ module Publish
   private
 
     def provider
-      @provider ||= recruitment_cycle.providers.find_by(recruitment_cycle: recruitment_cycle, provider_code: params[:provider_code])
+      @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
     end
 
     def recruitment_cycle

--- a/spec/components/flash_banner/view_preview.rb
+++ b/spec/components/flash_banner/view_preview.rb
@@ -2,6 +2,14 @@
 
 module FlashBanner
   class ViewPreview < ViewComponent::Preview
+    def with_error
+      render(FlashBanner::View.new(flash: flash(:error, flash_value: { id: "some-id", message: "some message" }.with_indifferent_access)))
+    end
+
+    def with_success_with_body
+      render(FlashBanner::View.new(flash: flash(:success_with_body, flash_value: { title: "some title", body: "some body" }.with_indifferent_access)))
+    end
+
     def with_success
       render(FlashBanner::View.new(flash: flash(:success)))
     end
@@ -16,9 +24,9 @@ module FlashBanner
 
   private
 
-    def flash(type)
+    def flash(type, flash_value: "Provider #{type}")
       flash = ActionDispatch::Flash::FlashHash.new
-      flash[type] = "Provider #{type}"
+      flash[type] = flash_value
       flash
     end
   end


### PR DESCRIPTION
### Context
Cross cutting flash

### Changes proposed in this pull request
There are cross cutting messages that is displayed when the intended user action can not be commerced as prior data input is required.

### Guidance to review

Go to 
https://teacher-training-api-pr-2520.london.cloudapps.digital/publish/organisations/B1T/2022/details

then you will be redirected to 

https://teacher-training-api-pr-2520.london.cloudapps.digital/publish/organisations/B1T/2022/contacts



### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
