### PR TITLE
[621] Port over locations editing from course page

### DIFF
--- a/app/components/notification_banner/view.rb
+++ b/app/components/notification_banner/view.rb
@@ -68,7 +68,7 @@ module NotificationBanner
     end
 
     def success_banner?
-      type == :success
+      type&.to_sym == :success
     end
   end
 end

--- a/app/forms/publish/course_location_form.rb
+++ b/app/forms/publish/course_location_form.rb
@@ -1,0 +1,23 @@
+module Publish
+  class CourseLocationForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[site_ids].freeze
+
+    attr_accessor(*FIELDS)
+
+    validate :no_locations_selected
+
+  private
+
+    def compute_fields
+      { site_ids: course.site_ids }.merge(new_attributes)
+    end
+
+    def no_locations_selected
+      return unless site_ids.nil?
+
+      errors.add(:site_ids, :no_locations)
+    end
+  end
+end

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -104,8 +104,8 @@
           <% end %>
         <% end %>
         <% row.action({
-          # href: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-          # visually_hidden_text: "locations",
+          href: locations_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          visually_hidden_text: "locations",
         }) %>
       <% end %>
 

--- a/app/views/publish/courses/show.html.erb
+++ b/app/views/publish/courses/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
 <%= content_for :before_content do %>
   <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+      publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
   ) %>
 <% end %>
 

--- a/app/views/publish/courses/sites/edit.html.erb
+++ b/app/views/publish/courses/sites/edit.html.erb
@@ -1,19 +1,19 @@
-<% content_for :page_title, title_with_error_prefix("Select the locations for this course – #{course.name_and_code}", @errors.present?) %>
+<% content_for :page_title, title_with_error_prefix("Select the locations for this course – #{course.name_and_code}", @course_location_form.errors.present?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)) %>
 <% end %>
 
-<% if @errors.present? %>
+<% if @course_location_form.errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">
     <h2 class="govuk-error-summary__title" id="error-summary-title">
-      <%= @errors.first %>
+      <%= @course_location_form.errors[:site_ids].first %>
     </h2>
     <div class="govuk-error-summary__body">
       <p class="govuk-body" data-error-message="Removing all locations would prevent people from applying to this course">
         Removing all locations would prevent people from applying to this course.
         If you want to close applications, you can
-        <%= govuk_link_to "edit the vacancies for this course", vacancies_provider_recruitment_cycle_course_path(code: course.course_code) %>.
+        <%= govuk_link_to "edit the vacancies for this course", vacancies_publish_provider_recruitment_cycle_course_path(code: course.course_code) %>.
       </p>
     </div>
   </div>
@@ -26,28 +26,26 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= govuk_link_to "Manage all your locations", provider_recruitment_cycle_sites_path(@provider.provider_code), data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
+    <p class="govuk-body govuk-body govuk-!-margin-bottom-6"><%= govuk_link_to "Manage all your locations", publish_provider_recruitment_cycle_locations_path(@provider.provider_code), data: { qa: "course__manage_provider_locations_link" } %> to add to or edit this list.</p>
 
-    <%= form_for course, url: locations_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), method: :put do |form| %>
-      <div class="govuk-form-group">
-        <div class="govuk-checkboxes">
-          <%= form.fields_for :site_statuses, @provider.sites.sort_by(&:location_name) do |sf| %>
-            <% site = sf.object %>
-            <div class="govuk-checkboxes__item">
-              <%= sf.check_box "selected", checked: course.has_site?(site), class: "govuk-checkboxes__input" %>
-              <%= sf.label "selected", class: "govuk-label govuk-checkboxes__label"  do %>
-                <strong><%= site.location_name %></strong>
-              <% end %>
-              <span class="govuk-hint govuk-checkboxes__hint">
-                <%= site.full_address %>
-              </span>
-            </div>
-          <% end %>
-        </div>
-      </div>
+    <%= form_with(
+      model: @course_location_form, 
+      url: locations_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), 
+      method: :put,
+      local: true
+    ) do |f| %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
-        class: "govuk-button", data: { qa: "course__save" } %>
+      <%= f.govuk_check_boxes_fieldset :site_ids, legend: nil do %>
+       <% @provider.sites.sort_by(&:location_name).each_with_index do |site, index| %>
+          <%= f.govuk_check_box :site_ids, 
+              site.id, 
+              label: { text: site.location_name, size: "s" },
+              hint: { text: site.full_address },
+              link_errors: index.zero? %>
+       <% end %>
+      <% end %>
+
+      <%= f.govuk_submit course.is_running? ? "Save and publish changes" : "Save" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -345,6 +345,10 @@ en:
               too_long: "Reduce the word count for fee details"
             financial_support:
               too_long: "Reduce the word count for financial support"
+        publish/course_location_form:
+          attributes:
+            site_ids:
+              no_locations: "Select at least one location"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,6 +110,8 @@ Rails.application.routes.draw do
           patch "/about", on: :member, to: "courses/course_information#update"
           get "/fees", on: :member, to: "courses/fees#edit"
           patch "/fees", on: :member, to: "courses/fees#update"
+          get "/locations", on: :member, to: "courses/sites#edit"
+          put "/locations", on: :member, to: "courses/sites#update"
         end
 
         scope module: :providers do

--- a/spec/features/publish/courses/editing_course_locations_spec.rb
+++ b/spec/features/publish/courses/editing_course_locations_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing course locations" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+    and_there_is_a_course_i_want_to_edit
+    when_i_visit_the_course_locations_page
+  end
+
+  scenario "i can update the course locations" do
+    then_i_should_see_a_list_of_locations
+    when_i_update_the_course_locations
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_locations_are_updated
+  end
+
+  scenario "updating with invalid data" do
+    and_i_submit
+    then_i_should_see_an_error_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(
+      user: create(
+        :user,
+        providers: [
+          build(
+            :provider,
+            sites: [
+              build(:site, location_name: "Site 1"),
+              build(:site, location_name: "Site 2"),
+            ],
+          ),
+        ],
+      ),
+    )
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists(sites: [])
+  end
+
+  def when_i_visit_the_course_locations_page
+    publish_course_location_page.load(
+      provider_code: provider.provider_code,
+      recruitment_cycle_year: provider.recruitment_cycle_year,
+      course_code: course.course_code,
+    )
+  end
+
+  def then_i_should_see_a_list_of_locations
+    expect(publish_course_location_page.vacancy_names).to match_array(["Site 1", "Site 2"])
+  end
+
+  def when_i_update_the_course_locations
+    publish_course_location_page.vacancies.find do |el|
+      el.find(".govuk-label").text == "Site 1"
+    end.check
+  end
+
+  def and_i_submit
+    publish_course_location_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content("Course locations saved")
+  end
+
+  def and_the_course_locations_are_updated
+    expect(course.reload.sites.map(&:location_name)).to match_array(["Site 1"])
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_location_page).to have_content(
+      I18n.t("activemodel.errors.models.publish/course_location_form.attributes.site_ids.no_locations"),
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -115,5 +115,9 @@ module FeatureHelpers
     def publish_course_fee_page
       @publish_course_fee_page ||= PageObjects::Publish::CourseFeeEdit.new
     end
+
+    def publish_course_location_page
+      @publish_course_location_page ||= PageObjects::Publish::CourseLocationEdit.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/course_location_edit.rb
+++ b/spec/support/page_objects/publish/course_location_edit.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../sections/vacancy"
+
+module PageObjects
+  module Publish
+    class CourseLocationEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/locations"
+
+      sections :vacancies, Sections::Vacancy, ".govuk-checkboxes__item"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def vacancy_names
+        vacancies.map { |el| el.find(".govuk-label").text }
+      end
+
+      def vacancy_checked_values
+        vacancies.map(&:checked?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/ZNQzq1dZ/621-migrate-courses-course-show-page-updating-locations

### Changes proposed in this pull request

- Port over and simplify locations selection logic for the course
- Refactor markup to use govuk form builder
- Add test coverage with feature spec

### Guidance to review

Original implementation here: https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2022/courses/AK12/locations

Ported version: https://teacher-training-api-pr-2526.london.cloudapps.digital/publish/organisations/2AT/2022/courses/AK12/locations

Check:

- You can update locations
- Error message is triggered if you try to remove all locations

FYI the full address is shown in the hint for the location in new publish which includes the location name but is excluded in old publish. Not sure which is right, @mbocc or Adam to confirm?

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
