### PR TITLE
Migrate to GitHub container registry

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/teacher-training-api
+      DOCKER_IMAGE: ghcr.io/dfe-digital/teacher-training-api
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      DOCKER_IMAGE: dfedigital/teacher-training-api
+      DOCKER_IMAGE: ghcr.io/dfe-digital/teacher-training-api
 
     steps:
     - name: Checkout
@@ -35,12 +35,13 @@ jobs:
         # This is the latest commit on the actual PR branch
         echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
-    - name: Login to DockerHub
+    - name: Login to GitHub Container Registry
       if: github.actor != 'dependabot[bot]'
-      uses: docker/login-action@v1
+      uses: docker/login-action@v1.12.0
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+        registry: ghcr.io
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -53,8 +54,8 @@ jobs:
         load: ${{ github.actor == 'dependabot[bot]' }}
         target: middleman
         cache-from: |
-          ${{ env.DOCKER_IMAGE}}-middleman:master
-          ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
         build-args: BUILDKIT_INLINE_CACHE=1
 
     - name: Build Teacher-Training-Api
@@ -66,10 +67,10 @@ jobs:
         push: ${{ github.actor != 'dependabot[bot]' }}
         load: ${{ github.actor == 'dependabot[bot]' }}
         cache-from: |
-          ${{ env.DOCKER_IMAGE}}:master
-          ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
-          ${{ env.DOCKER_IMAGE}}-middleman:master
-          ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
         build-args: |
           BUILDKIT_INLINE_CACHE=1
           COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ deploy-init:
 	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=master))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_cf_sso_passcode=$(PASSCODE))
-	$(eval export TF_VAR_paas_docker_image=dfedigital/teacher-training-api:$(IMAGE_TAG))
+	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/teacher-training-api:$(IMAGE_TAG))
 	$(eval export TF_VAR_paas_app_secrets_file=./workspace_variables/app_secrets.yml)
 	az account set -s ${AZ_SUBSCRIPTION} && az account show
 	cd terraform && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
     build:
       context: .
       cache_from:
-        - ${dockerHubUsername:-dfedigital}/teacher-training-api:${IMAGE_TAG:-latest}
-        - ${dockerHubUsername:-dfedigital}/teacher-training-api-middleman:master
-    image: ${dockerHubUsername:-dfedigital}/teacher-training-api:${IMAGE_TAG:-latest}
+        - ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
+        - ghcr.io/dfe-digital/teacher-training-api-middleman:master
+    image: ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
     command: ash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:
       - "3001:3001"
@@ -37,7 +37,7 @@ services:
       - RAILS_ENV=test
 
   bgJobs:
-    image: ${dockerHubUsername:-dfedigital}/teacher-training-api:${IMAGE_TAG:-latest}
+    image: ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
     command: bundle exec sidekiq -c 5 -C config/sidekiq.yml
     depends_on:
       - web

--- a/terraform/modules/paas/main.tf
+++ b/terraform/modules/paas/main.tf
@@ -11,7 +11,6 @@ resource cloudfoundry_app web_app {
   timeout                    = 300
   stopped                    = var.web_app_stopped
   environment                = local.app_environment_variables
-  docker_credentials         = var.docker_credentials
 
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id
@@ -43,7 +42,6 @@ resource cloudfoundry_app worker_app {
   health_check_timeout = 300
   stopped              = var.worker_app_stopped
   environment          = local.app_environment_variables
-  docker_credentials   = var.docker_credentials
 
   service_binding {
     service_instance = cloudfoundry_service_instance.redis.id

--- a/terraform/modules/paas/variables.tf
+++ b/terraform/modules/paas/variables.tf
@@ -20,8 +20,6 @@ variable redis_service_plan {}
 
 variable docker_image {}
 
-variable docker_credentials {}
-
 variable logstash_url {}
 
 variable app_environment {}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -47,7 +47,6 @@ module paas {
   cf_space                  = var.cf_space
   app_environment           = var.paas_app_environment
   docker_image              = var.paas_docker_image
-  docker_credentials        = local.docker_credentials
   logstash_url              = local.infra_secrets.LOGSTASH_URL
   web_app_host_name         = var.paas_web_app_host_name
   web_app_memory            = var.paas_web_app_memory

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,9 +52,5 @@ locals {
   app_secrets                    = yamldecode(data.azurerm_key_vault_secret.app_secrets.value)
   infra_secrets                  = yamldecode(data.azurerm_key_vault_secret.infra_secrets.value)
   paas_app_environment_variables = merge(local.app_secrets, local.app_config)
-  docker_credentials = {
-    username = local.infra_secrets.DOCKERHUB_USERNAME
-    password = local.infra_secrets.DOCKERHUB_PASSWORD
-  }
   azure_credentials = try(jsondecode(var.azure_credentials), null)
 }


### PR DESCRIPTION
### Context
Containers for this repo are currently published to Dockerhub. Publishing images to GitHub container registry is simpler and more secure.

### Changes proposed in this pull request
This commit migrates workflows from Dockerhub to the GitHub Container Packages registry.

### Guidance to review
- Confirm that image is being published as a GitHub Container Package
- Confirm that deployment is using the correct GitHub Container Package

### Trello card
https://trello.com/c/wVT0QcJ4

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
