### PR TITLE
Update docker base image to ruby:2.7.5-alpine3.15

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7.4
+      - name: Set up Ruby 2.7.5
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.4
+          ruby-version: 2.7.5
 
       - name: install bundler and gems
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-ruby 2.7.4
+ruby 2.7.5
 bundler 2.1.4
 yarn 1.22.4
-nodejs 12.18.3
+nodejs 16.14.0
 terraform 0.13.5
 adr-tools 3.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.4-alpine3.12 AS middleman
+FROM ruby:2.7.5-alpine3.15 AS middleman
 
 RUN apk add --update --no-cache npm git build-base
 
@@ -15,7 +15,7 @@ RUN bundle exec middleman build --build-dir=../public
 
 ###
 
-FROM ruby:2.7.4-alpine3.12
+FROM ruby:2.7.5-alpine3.15
 
 RUN apk add --update --no-cache tzdata && \
     cp /usr/share/zoneinfo/Europe/London /etc/localtime && \

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "2.7.4"
+ruby "2.7.5"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "6.1.4.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -742,7 +742,7 @@ DEPENDENCIES
   webpacker (~> 5.4)
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.1.4

--- a/docs/.tool-versions
+++ b/docs/.tool-versions
@@ -1,3 +1,3 @@
-nodejs 12.15.0
+nodejs 16.14.0
 bundler 2.1.4
-ruby 2.7.4
+ruby 2.7.5

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,7 +2,7 @@
 # the following line to use "http://"
 source "https://rubygems.org"
 
-ruby "2.7.4"
+ruby "2.7.5"
 
 # Include the tech docs gem
 gem "govuk_tech_docs", git: "https://github.com/DFE-Digital/tech-docs-gem"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -219,7 +219,7 @@ DEPENDENCIES
   rspec
 
 RUBY VERSION
-   ruby 2.7.4p191
+   ruby 2.7.5p203
 
 BUNDLED WITH
    2.1.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
 
   "engines": {
-    "node": "12.x"
+    "node": "16.x"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
### Context

https://trello.com/c/RjLvJulr/744-update-docker-base-image

This is to resolve security vulnerabilities in the base image
alpine, ruby and nodejs will be updated in this change

### Changes proposed in this pull request

ruby:2.7.4-alpine3.12 to ruby:2.7.5-alpine3.15
nodejs 12.18.3 to 16.14.0
ruby 2.7.4p191 to ruby 2.7.5p203

### Guidance to review

check locally
check review app

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
