### PR TITLE
[0629] Migrate courses course show page preview content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,6 +92,10 @@ gem "sidekiq-cron"
 # Semantic Logger makes logs pretty
 gem "rails_semantic_logger"
 
+# Render nice markdown
+gem "redcarpet"
+gem "rubypants"
+
 # Thread-safe global state
 gem "request_store"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,6 +484,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rb-readline (0.5.5)
+    redcarpet (3.5.1)
     redis (4.6.0)
     regexp_parser (2.2.1)
     representable (3.1.1)
@@ -541,6 +542,7 @@ GEM
       rexml
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    rubypants (0.7.1)
     schema_to_scaffold (0.8.0)
       activesupport (>= 3.2.1)
     semantic_logger (4.10.0)
@@ -712,6 +714,7 @@ DEPENDENCIES
   rails-erd
   rails_semantic_logger
   rb-readline
+  redcarpet
   request_store
   rspec-its
   rspec-rails
@@ -719,6 +722,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
+  rubypants
   schema_to_scaffold
   sentry-rails
   sentry-ruby

--- a/app/components/degree_preview_component/view.html.erb
+++ b/app/components/degree_preview_component/view.html.erb
@@ -1,0 +1,23 @@
+<% if course.degree_section_complete? %>
+  <p class="govuk-body">
+    <%= degree_grade_content(course) %>
+  </p>
+
+  <% if course.level == "secondary" %>
+    <p class="govuk-body">Your degree subject should be in <%= subject_name(course) %> or a similar subject. Otherwise you’ll need to prove your subject knowledge in some other way.</p>
+  <% end %>
+
+  <% if course.degree_subject_requirements.present? %>
+    <p class="govuk-body">
+      <%= markdown(course.degree_subject_requirements) %>
+    </p>
+  <% end %>
+<% else %>
+  <%= govuk_inset_text(classes: "app-inset-text--important") do %>
+    <p class="govuk-body">
+      Please add details <%= govuk_link_to "about degree requirements",
+        nil #degrees_start_provider_recruitment_cycle_course_path(course.provider.provider_code, course.provider.recruitment_cycle_year, course.course_code,) 
+        %>.
+    </p>
+  <% end %>
+<% end %>

--- a/app/components/degree_preview_component/view.rb
+++ b/app/components/degree_preview_component/view.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module DegreePreviewComponent
+  class View < ViewComponent::Base
+    include PublishHelper
+
+    attr_reader :course
+
+    def initialize(course:)
+      super
+      @course = course
+    end
+
+  private
+
+    def subject_name(course)
+      case course.subjects.count
+      when 1
+        course.subjects.first.subject_name
+      when 2
+        "#{course.subjects.first.subject_name} or #{course.subjects.last.subject_name}"
+      else
+        course.name
+      end
+    end
+
+    def degree_grade_content(course)
+      {
+        "two_one" => "An undergraduate degree at class 2:1 or above, or equivalent.",
+        "two_two" => "An undergraduate degree at class 2:2 or above, or equivalent.",
+        "third_class" => "An undergraduate degree, or equivalent. This should be an honours degree (Third or above), or equivalent.",
+        "not_required" => "An undergraduate degree, or equivalent.",
+      }[course.degree_grade]
+    end
+  end
+end

--- a/app/components/gcse_preview_component/view.html.erb
+++ b/app/components/gcse_preview_component/view.html.erb
@@ -1,0 +1,29 @@
+<% if course.gcse_section_complete? %>
+  <p class="govuk-body">
+    <%= required_gcse_content(course) %>
+  </p>
+
+  <p class="govuk-body">
+    <%= pending_gcse_content(course) %>
+  </p>
+
+  <p class="govuk-body">
+    <%= gcse_equivalency_content(course) %>
+  </p>
+
+  <% if course.additional_gcse_equivalencies %>
+    <%= markdown(course.additional_gcse_equivalencies) %>
+  <% end %>
+<% else %>
+  <%= govuk_inset_text(classes: "app-inset-text--important") do %>
+    <p class="govuk-body">
+      Please add details <%= govuk_link_to "about GCSE requirements", "#"
+        # gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(
+        #   course.provider.provider_code,
+        #   course.provider.recruitment_cycle_year,
+        #   course.course_code,
+        # ) 
+        %>.
+    </p>
+  <% end %>
+<% end %>

--- a/app/components/gcse_preview_component/view.rb
+++ b/app/components/gcse_preview_component/view.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module GcsePreviewComponent
+  class View < GcseRequirementsComponent::View
+    include PublishHelper
+  end
+end

--- a/app/controllers/publish/courses_controller.rb
+++ b/app/controllers/publish/courses_controller.rb
@@ -58,6 +58,12 @@ module Publish
       @course = ::Courses::CreationService.call(course_params: course_params, provider: provider)
     end
 
+    def preview
+      fetch_course
+
+      authorize @course
+    end
+
   private
 
     def course_params

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -149,16 +149,12 @@ class CourseDecorator < ApplicationDecorator
   end
 
   def preview_site_statuses
-    site_statuses.new_or_running.sort_by { |status| status.site.location_name }
+    object.site_statuses.new_or_running.sort_by { |status| status.site.location_name }
   end
 
   def has_site?(site)
     !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
   end
-
-  # def sites
-  #   alphabetically_sorted_sites.pluck(:id)
-  # end
 
   # rubocop:disable Lint/DuplicateBranch: Duplicate branch body detected
   def funding_option
@@ -195,9 +191,9 @@ class CourseDecorator < ApplicationDecorator
     course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
   end
 
-  #   def cycle_range
-  #     "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
-  #   end
+  def cycle_range
+    "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
+  end
 
   def age_range
     if object.age_range_in_years.present?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -148,7 +148,6 @@ class CourseDecorator < ApplicationDecorator
 
   # rubocop:disable Lint/DuplicateBranch: Duplicate branch body detected
   def funding_option
-    # TODO: Fix this typical railsy rubbish
     if salaried?
       "Salary"
     elsif excluded_from_bursary?

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -160,19 +160,24 @@ class CourseDecorator < ApplicationDecorator
   #   alphabetically_sorted_sites.pluck(:id)
   # end
 
+  # rubocop:disable Lint/DuplicateBranch: Duplicate branch body detected
   def funding_option
+    # TODO: Fix this typical railsy rubbish
     if salaried?
       "Salary"
     elsif excluded_from_bursary?
+      # Duplicate branch body detected
       "Student finance if you’re eligible"
     elsif has_scholarship_and_bursary?
       "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
     elsif has_bursary?
       "Bursaries and student finance are available if you’re eligible"
     else
+      # Duplicate branch body detected
       "Student finance if you’re eligible"
     end
   end
+  # rubocop:enable Lint/DuplicateBranch: Duplicate branch body detected
 
   def current_cycle?
     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -55,9 +55,9 @@ class CourseDecorator < ApplicationDecorator
   #     end
   #   end
 
-  #   def has_scholarship_and_bursary?
-  #     has_bursary? && has_scholarship?
-  #   end
+  def has_scholarship_and_bursary?
+    has_bursary? && has_scholarship?
+  end
 
   #   def bursary_first_line_ending
   #     if bursary_requirements.count > 1
@@ -78,26 +78,26 @@ class CourseDecorator < ApplicationDecorator
   #     requirements
   #   end
 
-  #   def bursary_only?
-  #     has_bursary? && !has_scholarship?
-  #   end
+  def bursary_only?
+    has_bursary? && !has_scholarship?
+  end
 
-  #   def has_bursary?
-  #     object.subjects.present? &&
-  #       object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
-  #   end
+  def has_bursary?
+    object.subjects.present? &&
+      object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
+  end
 
-  #   def excluded_from_bursary?
-  #     object.subjects.present? &&
-  #       # incorrect bursary eligibility only shows up on courses with 2 subjects
-  #       object.subjects.count == 2 &&
-  #       has_excluded_course_name?
-  #   end
+  def excluded_from_bursary?
+    object.subjects.present? &&
+      # incorrect bursary eligibility only shows up on courses with 2 subjects
+      object.subjects.count == 2 &&
+      has_excluded_course_name?
+  end
 
-  #   def has_scholarship?
-  #     object.subjects.present? &&
-  #       object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
-  #   end
+  def has_scholarship?
+    object.subjects.present? &&
+      object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
+  end
 
   #   def has_early_career_payments?
   #     object.subjects.present? &&
@@ -112,9 +112,9 @@ class CourseDecorator < ApplicationDecorator
   #     find_max("scholarship")
   #   end
 
-  #   def salaried?
-  #     object.funding_type == "salary" || object.funding_type == "apprenticeship"
-  #   end
+  def salaried?
+    object.funding_type == "salary" || object.funding_type == "apprenticeship"
+  end
 
   def apprenticeship?
     object.funding_type.to_s == "apprenticeship" ? "Yes" : "No"
@@ -148,9 +148,9 @@ class CourseDecorator < ApplicationDecorator
     object.sites.sort_by(&:location_name)
   end
 
-  # def preview_site_statuses
-  #   site_statuses.select(&:new_or_running?).sort_by { |status| status.site.location_name }
-  # end
+  def preview_site_statuses
+    site_statuses.new_or_running.sort_by { |status| status.site.location_name }
+  end
 
   def has_site?(site)
     !course.sites.nil? && object.sites.any? { |s| s.id == site.id }
@@ -160,19 +160,19 @@ class CourseDecorator < ApplicationDecorator
   #   alphabetically_sorted_sites.pluck(:id)
   # end
 
-  # def funding_option
-  #   if salaried?
-  #     "Salary"
-  #   elsif excluded_from_bursary?
-  #     "Student finance if you’re eligible"
-  #   elsif has_scholarship_and_bursary?
-  #     "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
-  #   elsif has_bursary?
-  #     "Bursaries and student finance are available if you’re eligible"
-  #   else
-  #     "Student finance if you’re eligible"
-  #   end
-  # end
+  def funding_option
+    if salaried?
+      "Salary"
+    elsif excluded_from_bursary?
+      "Student finance if you’re eligible"
+    elsif has_scholarship_and_bursary?
+      "Scholarships or bursaries, as well as student finance, are available if you’re eligible"
+    elsif has_bursary?
+      "Bursaries and student finance are available if you’re eligible"
+    else
+      "Student finance if you’re eligible"
+    end
+  end
 
   def current_cycle?
     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year
@@ -186,9 +186,9 @@ class CourseDecorator < ApplicationDecorator
     course.recruitment_cycle.year.to_i == Settings.current_recruitment_cycle_year + 1
   end
 
-  #   def use_financial_support_placeholder?
-  #     course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
-  #   end
+  def use_financial_support_placeholder?
+    course.recruitment_cycle.year.to_i == Settings.financial_support_placeholder_cycle
+  end
 
   #   def cycle_range
   #     "#{course.recruitment_cycle.year} to #{course.recruitment_cycle.year.to_i + 1}"
@@ -346,6 +346,10 @@ class CourseDecorator < ApplicationDecorator
     object.enrichment_attribute(:course_length)
   end
 
+  def about_accrediting_body
+    object.accrediting_provider_description
+  end
+
 private
 
   def not_on_find
@@ -374,17 +378,17 @@ private
   #   subject_attributes.compact.max.to_s
   # end
 
-  # def has_excluded_course_name?
-  #   exclusions = [
-  #     /^Drama/,
-  #     /^Media Studies/,
-  #     /^PE/,
-  #     /^Physical/,
-  #   ]
-  #   # We only care about course with a name matching the pattern 'Foo with bar'
-  #   # We don't care about courses matching the pattern 'Foo and bar'
-  #   return false unless /with/.match?(object.name)
+  def has_excluded_course_name?
+    exclusions = [
+      /^Drama/,
+      /^Media Studies/,
+      /^PE/,
+      /^Physical/,
+    ]
+    # We only care about course with a name matching the pattern 'Foo with bar'
+    # We don't care about courses matching the pattern 'Foo and bar'
+    return false unless /with/.match?(object.name)
 
-  #   exclusions.any? { |e| e.match?(object.name) }
-  # end
+    exclusions.any? { |e| e.match?(object.name) }
+  end
 end

--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -47,25 +47,25 @@ class CourseDecorator < ApplicationDecorator
     }[object.funding_type]
   end
 
-  #   def subject_name
-  #     if object.subjects.count == 1
-  #       object.subjects.first.subject_name
-  #     else
-  #       object.name
-  #     end
-  #   end
-
-  def has_scholarship_and_bursary?
-    has_bursary? && has_scholarship?
+  def subject_name
+    if object.subjects.size == 1
+      object.subjects.first.subject_name
+    else
+      object.name
+    end
   end
 
-  #   def bursary_first_line_ending
-  #     if bursary_requirements.count > 1
-  #       ":"
-  #     else
-  #       "#{bursary_requirements.first}."
-  #     end
-  #   end
+  def has_scholarship_and_bursary?
+    object.has_bursary? && object.has_scholarship?
+  end
+
+  def bursary_first_line_ending
+    if bursary_requirements.count > 1
+      ":"
+    else
+      "#{bursary_requirements.first}."
+    end
+  end
 
   #   def bursary_requirements
   #     requirements = ["a degree of 2:2 or above in any subject"]
@@ -79,12 +79,7 @@ class CourseDecorator < ApplicationDecorator
   #   end
 
   def bursary_only?
-    has_bursary? && !has_scholarship?
-  end
-
-  def has_bursary?
-    object.subjects.present? &&
-      object.subjects.any? { |subject| subject.attributes["bursary_amount"].present? }
+    object.has_bursary? && !object.has_scholarship?
   end
 
   def excluded_from_bursary?
@@ -92,11 +87,6 @@ class CourseDecorator < ApplicationDecorator
       # incorrect bursary eligibility only shows up on courses with 2 subjects
       object.subjects.count == 2 &&
       has_excluded_course_name?
-  end
-
-  def has_scholarship?
-    object.subjects.present? &&
-      object.subjects.any? { |subject| subject.attributes["scholarship"].present? }
   end
 
   #   def has_early_career_payments?

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,26 +12,6 @@ module ApplicationHelper
   #   render "pagy/paginator", pagy: pagy
   # end
 
-  # def markdown(source)
-  #   render = Govuk::MarkdownRenderer
-  #   # Options: https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
-  #   # lax_spacing: HTML blocks do not require to be surrounded by an empty line as in the Markdown standard.
-  #   # autolink: parse links even when they are not enclosed in <> characters
-  #   options = { autolink: true, lax_spacing: true }
-  #   markdown = Redcarpet::Markdown.new(render, options)
-  #   markdown.render(source).html_safe
-
-  #   # Convert quotes to smart quotes
-  #   source_with_smart_quotes = smart_quotes(source)
-  #   markdown.render(source_with_smart_quotes).html_safe
-  # end
-
-  # def smart_quotes(string)
-  #   return "" if string.blank?
-
-  #   RubyPants.new(string, [2, :dashes], ruby_pants_options).to_html
-  # end
-
   # def enrichment_error_link(model, field, error)
   #   href = case model
   #          when :course
@@ -95,20 +75,4 @@ private
       visually_hidden_text: action_visually_hidden_text,
     }
   end
-
-  # Use characters rather than HTML entities for smart quotes this matches how
-  # we write smart quotes in templates and allows us to use them in <title>
-  # elements
-  # https://github.com/jmcnevin/rubypants/blob/master/lib/rubypants.rb
-  # def ruby_pants_options
-  #   {
-  #     double_left_quote: "“",
-  #     double_right_quote: "”",
-  #     single_left_quote: "‘",
-  #     single_right_quote: "’",
-  #     ellipsis: "…",
-  #     em_dash: "—",
-  #     en_dash: "–",
-  #   }
-  # end
 end

--- a/app/helpers/publish_helper.rb
+++ b/app/helpers/publish_helper.rb
@@ -4,4 +4,42 @@ module PublishHelper
   def old_publish_link_for(path)
     "#{Settings.publish_url}#{path.sub(/\/publish\//, '/')}"
   end
+
+  def markdown(source)
+    render = Govuk::MarkdownRenderer
+    # Options: https://github.com/vmg/redcarpet#and-its-like-really-simple-to-use
+    # lax_spacing: HTML blocks do not require to be surrounded by an empty line as in the Markdown standard.
+    # autolink: parse links even when they are not enclosed in <> characters
+    options = { autolink: true, lax_spacing: true }
+    markdown = Redcarpet::Markdown.new(render, options)
+    markdown.render(source).html_safe
+
+    # Convert quotes to smart quotes
+    source_with_smart_quotes = smart_quotes(source)
+    markdown.render(source_with_smart_quotes).html_safe
+  end
+
+  def smart_quotes(string)
+    return "" if string.blank?
+
+    RubyPants.new(string, [2, :dashes], ruby_pants_options).to_html
+  end
+
+private
+
+  # Use characters rather than HTML entities for smart quotes this matches how
+  # we write smart quotes in templates and allows us to use them in <title>
+  # elements
+  # https://github.com/jmcnevin/rubypants/blob/master/lib/rubypants.rb
+  def ruby_pants_options
+    {
+      double_left_quote: "“",
+      double_right_quote: "”",
+      single_left_quote: "‘",
+      single_right_quote: "’",
+      ellipsis: "…",
+      em_dash: "—",
+      en_dash: "–",
+    }
+  end
 end

--- a/app/lib/govuk/markdown_renderer.rb
+++ b/app/lib/govuk/markdown_renderer.rb
@@ -1,0 +1,61 @@
+module Govuk
+  class MarkdownRenderer < ::Redcarpet::Render::Safe
+    def block_html(raw_html)
+      # No user input HTML please
+    end
+
+    def raw_html(raw_html)
+      # No user input HTML please
+    end
+
+    def emphasis(text)
+      # Disable feature
+    end
+
+    def double_emphasis(text)
+      # Disable feature
+    end
+
+    def triple_emphasis(text)
+      # Disable feature
+    end
+
+    def list(content, list_type)
+      case list_type
+      when :ordered
+        <<~HTML
+          <ol class="govuk-list govuk-list--number">
+            #{content}
+          </ol>
+        HTML
+      when :unordered
+        <<~HTML
+          <ul class="govuk-list govuk-list--bullet">
+            #{content}
+          </ul>
+        HTML
+      end
+    end
+
+    def link(link, _title, content)
+      %(<a href="#{link}" class="govuk-link">#{content}</a>)
+    end
+
+    def autolink(link, _link_type)
+      %(<a href="#{link}" class="govuk-link">#{link}</a>)
+    end
+
+    def paragraph(text)
+      %(<p class="govuk-body">#{text}</p>)
+    end
+
+    # Force all headers to <h3> to maintain semantic markup
+    def header(text, _heading_level)
+      %(<h3 class="govuk-heading-m">#{text}</h3>)
+    end
+
+    def self.render(content)
+      Redcarpet::Markdown.new(self).render(content)
+    end
+  end
+end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -324,6 +324,10 @@ class Provider < ApplicationRecord
     !can_sponsor_student_visa && can_sponsor_skilled_worker_visa
   end
 
+  def cannot_sponsor_visas?
+    can_sponsor_student_visa == false && can_sponsor_skilled_worker_visa == false
+  end
+
 private
 
   scope :course_code_search, ->(course_code) { joins(:courses).merge(Course.case_insensitive_search(course_code)) }

--- a/app/models/site_status.rb
+++ b/app/models/site_status.rb
@@ -63,6 +63,7 @@ class SiteStatus < ApplicationRecord
   end
 
   scope :with_vacancies, -> { where.not(vac_status: :no_vacancies).findable }
+  scope :new_or_running, -> { where(status: %i[running new_status]) }
 
   def with_vacancies?
     !no_vacancies? && findable?

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -37,6 +37,7 @@ class CoursePolicy
     user.present?
   end
 
+  alias_method :preview?, :show?
   alias_method :details?, :show?
   alias_method :update?, :show?
   alias_method :destroy?, :show?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,5 +56,6 @@
     </div>
 
     <%= render partial: "layouts/footer" %>
+    <%= yield(:before_body_close) %>
   </body>
 </html>

--- a/app/views/publish/courses/preview.html.erb
+++ b/app/views/publish/courses/preview.html.erb
@@ -1,0 +1,95 @@
+<% content_for :page_title, "Preview: #{course.name_and_code} with #{@provider.provider_name}" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_courses_path(@course.provider_code, @course.recruitment_cycle.year)) %>
+<% end %>
+
+<%= govuk_notification_banner(title_text: t("notification_banner.info")) do |notification_banner| %>
+  <% notification_banner.heading(text: "This is a preview of the ‘#{course.name_and_code}’ course.") %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  <span class="govuk-heading-l govuk-!-margin-bottom-0" data-qa="course__provider_name"><%= course.provider.provider_name %></span>
+  <%= course.name_and_code %>
+</h1>
+
+<p class="govuk-body-l" data-qa="course__description"><%= course.description %></p>
+
+<dl class="app-description-list govuk-!-margin-bottom-8">
+  <% if course.accrediting_provider.present? %>
+    <dt class="app-description-list__label">Accredited body</dt>
+    <dd data-qa="course__accredited_body"><%= course.accrediting_provider.provider_name %></dd>
+  <% end %>
+  <dt class="app-description-list__label">Financial support</dt>
+  <dd data-qa="course__funding_option"><%= course.funding_option %></dd>
+  <dt class="app-description-list__label">Qualification</dt>
+  <dd data-qa="course__qualifications">
+    <%= render partial: "publish/courses/preview/qualification" %>
+  </dd>
+
+  <% if course.age_range_in_years.present? %>
+    <dt class="app-description-list__label">Age range</dt>
+    <dd data-qa="course__age_range_in_years"><%= course.age_range_in_years.humanize %></dd>
+  <% end %>
+
+  <% if course.length.present? %>
+    <dt class="app-description-list__label">Course length</dt>
+    <dd data-qa="course__length"><%= course.length %></dd>
+  <% end %>
+  <% if course.applications_open_from.present? %>
+    <dt class="app-description-list__label">Date you can apply from</dt>
+    <dd data-qa="course__applications_open"><%= l(course.applications_open_from&.to_date) %></dd>
+  <% end %>
+  <% if course.start_date.present? %>
+    <dt class="app-description-list__label">Date course starts</dt>
+    <dd data-qa="course__start_date"><%= l(course.start_date&.to_date, format: :short) %></dd>
+  <% end %>
+  <% if @provider.website.present? %>
+    <dt class="app-description-list__label">Website</dt>
+    <dd data-qa="course__provider_website">
+      <%= govuk_link_to @provider.website, @provider.website %>
+    </dd>
+  <% end %>
+</dl>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Contents</h2>
+    <ul class="govuk-list app-list--dash govuk-!-margin-bottom-8">
+      <li><%= govuk_link_to "About the course", "#section-about" %></li>
+      <li><%= govuk_link_to course.placements_heading, "#section-schools" %></li>
+      <li><%= govuk_link_to "Entry requirements", "#section-entry" %></li>
+      <li><%= govuk_link_to "About the training provider", "#section-about-provider" %></li>
+      <% if course.salaried? %>
+        <li><%= govuk_link_to "Salary", "#section-salary" %></li>
+      <% end %>
+      <li><%= govuk_link_to "Fees and financial support", "#section-fees-and-financial-support" %></li>
+      <% if course.interview_process.present? %>
+        <li><%= govuk_link_to "Interview process", "#section-interviews" %></li>
+      <% end %>
+      <li><%= govuk_link_to "Training with disabilities and other needs", "#section-train-with-disabilities" %></li>
+      <li><%= govuk_link_to "Contact details", "#section-contact" %></li>
+      <li><%= govuk_link_to "Support and advice", "#section-advice" %></li>
+      <li><%= govuk_link_to "Apply", "#section-apply" %></li>
+    </ul>
+
+    <%= render partial: "publish/courses/preview/about_course" %>
+    <%= render partial: "publish/courses/preview/about_schools" %>
+    <%= render partial: "publish/courses/preview/entry_requirements_qualifications" %>
+    <% if course.salaried? %>
+      <%= render partial: "publish/courses/preview/salary" %>
+    <% end %>
+    <%= render partial: "publish/courses/preview/fees_and_financial_support" %>
+    <%= render partial: "publish/courses/preview/about_the_provider" %>
+    <% if course.interview_process.present? %>
+      <%= render partial: "publish/courses/preview/interview_process" %>
+    <% end %>
+    <% if Providers::VisaSponsorshipService.new(@provider).visa_sponsorship_enabled? %>
+      <%= render partial: "publish/courses/preview/international_students" %>
+    <% end %>
+    <%= render partial: "publish/courses/preview/train_with_disabilities" %>
+    <%= render partial: "publish/courses/preview/contact_details" %>
+    <%= render partial: "publish/courses/preview/advice" %>
+    <%= render partial: "publish/courses/preview/apply" %>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/_about_course.html.erb
+++ b/app/views/publish/courses/preview/_about_course.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-about">About the course</h2>
+  <div data-qa="course__about_course">
+    <% if course.about_course.present? %>
+      <%= markdown(course.about_course) %>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details for this section.</p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/_about_schools.html.erb
+++ b/app/views/publish/courses/preview/_about_schools.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-schools"><%= course.placements_heading %></h2>
+  <div data-qa="course__about_schools">
+    <div class="app-advice__body">
+      <% if course.provider.provider_type == "university" && course.provider.provider_code != 'B31' %>
+        <%= render partial: "publish/courses/preview/placement/hei", locals: { course: course } %>
+      <% elsif course.program_type == 'scitt_programme' && course.provider.provider_code != 'E65' %>
+        <%= render partial: "publish/courses/preview/placement/scitt", locals: { course: course } %>
+      <% end %>
+    </div>
+    <% if course.how_school_placements_work.present? %>
+      <%= markdown(course.how_school_placements_work) %>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details for this section.</p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/_about_the_provider.html.erb
+++ b/app/views/publish/courses/preview/_about_the_provider.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-about-provider">About the training provider</h2>
+  <div data-qa="course__about_provider">
+    <% if @provider.train_with_us.present? %>
+      <%= markdown(@provider.train_with_us) %>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details <%= govuk_link_to "about your organisation", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
+      <% end %>
+    <% end %>
+  </div>
+
+  <% if course.about_accrediting_body.present? %>
+    <div data-qa="course__about_accrediting_body">
+      <h3 class="govuk-heading-m">About the accredited body</h3>
+      <%= markdown(course.about_accrediting_body) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/publish/courses/preview/_advice.html.erb
+++ b/app/views/publish/courses/preview/_advice.html.erb
@@ -1,0 +1,11 @@
+<h3 class="govuk-heading-l" id="section-advice">Support and advice</h3>
+<p class="govuk-body">For questions about this course you should contact the training provider using <%= govuk_link_to "the contact details above", "#contact_section" %>.</p>
+
+<h4 class="govuk-heading-m">Get support and advice about teaching</h4>
+<p class="govuk-body">Register with <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/user/register" %>, the Department for Education’s free support and advice service, for personalised guidance from teaching experts. They can help you to prepare your application, book school experience, and access exclusive teaching events. You can also call them free of charge on 0800 389 2500, or speak to an adviser using their <%= govuk_link_to "online chat service", "https://getintoteaching.education.gov.uk/lp/live-chat" %>, from 8am to 8pm, Monday to Friday.</p>
+
+<h4 class="govuk-heading-m">Website support</h4>
+<p class="govuk-body">If you have feedback or have had a problem using Find postgraduate teacher training you can <%= bat_contact_mail_to "contact us by email" %>.</p>
+
+<h4 class="govuk-heading-m">Is there something wrong with this page?</h4>
+<p class="govuk-body">If there is something wrong with this course listing, <%= bat_contact_mail_to "contact us by email", subject: "Edit #{course.name} (#{course.provider_code}/#{course.course_code})" %>.</p>

--- a/app/views/publish/courses/preview/_apply.html.erb
+++ b/app/views/publish/courses/preview/_apply.html.erb
@@ -1,0 +1,68 @@
+<%= content_for :before_body_close do %>
+  <script src="https://maps.googleapis.com/maps/api/js?key=<%= Settings.google.maps_api_key %>&callback=initLocationsMap" async defer></script>
+<% end %>
+
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-apply">Apply</h2>
+
+  <% if @course.content_status == "rolled_over" || @course.has_vacancies? %>
+    <p class="govuk-body">
+      <%= govuk_start_button(
+        text: "Apply for this course",
+        href: "#",
+        html_attributes: {
+          data: { qa: "course__apply_link" },
+          rel: "nofollow",
+        },
+      ) %>
+    </p>
+
+    <h3 class="govuk-heading-m">Choose a training location</h3>
+    <p class="govuk-body">You’ll also need to choose a training location – select the relevant location name on the application form.</p>
+
+    <div id="locations-map" class="app-map" data-qa="course__locations_map"></div>
+
+    <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
+      <caption class="govuk-visually-hidden">Choose a training location - List of locations, vacancies and codes</caption>
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="col">Location</th>
+          <th class="govuk-table__header" scope="col">Vacancies</th>
+          <th class="govuk-table__header" scope="col">Code</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% course.preview_site_statuses.each do |site_status| %>
+          <tr class="govuk-table__row">
+            <td class="govuk-table__cell">
+              <strong><%= smart_quotes(site_status.site.location_name) %></strong>
+              <br>
+              <%= smart_quotes(site_status.site.full_address) %>
+            </td>
+            <td class="govuk-table__cell">
+              <%= site_status.has_vacancies? ? "Yes" : "No" %>
+            </td>
+            <td class="govuk-table__cell"><%= site_status.site.code %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% else %>
+    <%= govuk_warning_text(text: "You cannot apply for this course because it currently has no vacancies. To find courses with vacancies, change your search settings to ‘Only courses with vacancies’.") %>
+  <% end %>
+</div>
+
+<script>
+  window.trainingLocations = [
+    <% course.preview_site_statuses.each do |site_status| %>
+      {
+        "code": "<%= site_status.site.code %>",
+        "name": "<%= smart_quotes(site_status.site.location_name) %>",
+        "lat": "<%= site_status.site.latitude.presence ? site_status.site.latitude : course.provider.latitude %>",
+        "lng": "<%= site_status.site.longitude.presence ? site_status.site.longitude : course.provider.longitude %>",
+        "address": "<%= smart_quotes(site_status.site.full_address) %>",
+        "vacancies": "<%= site_status.has_vacancies? ? "" : "No vacancies" %>"
+      },
+    <% end %>
+  ]
+</script>

--- a/app/views/publish/courses/preview/_apply.html.erb
+++ b/app/views/publish/courses/preview/_apply.html.erb
@@ -24,6 +24,7 @@
 
     <table class="govuk-table app-table--vertical-align-middle" data-qa="course__choose_a_training_location">
       <caption class="govuk-visually-hidden">Choose a training location - List of locations, vacancies and codes</caption>
+
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">
           <th class="govuk-table__header" scope="col">Location</th>
@@ -37,11 +38,7 @@
             <td class="govuk-table__cell">
               <strong><%= smart_quotes(site_status.site.location_name) %></strong>
               <br>
-              <%=site_status.vac_status%>
-              <%=site_status.status%>
-              <%=site_status.publish%>
-              asd
-              <%#= smart_quotes(site_status.site.full_address) %>
+              <%= smart_quotes(site_status.site.full_address) %>
             </td>
             <td class="govuk-table__cell">
               <%= site_status.has_vacancies? ? "Yes" : "No" %>

--- a/app/views/publish/courses/preview/_apply.html.erb
+++ b/app/views/publish/courses/preview/_apply.html.erb
@@ -37,7 +37,11 @@
             <td class="govuk-table__cell">
               <strong><%= smart_quotes(site_status.site.location_name) %></strong>
               <br>
-              <%= smart_quotes(site_status.site.full_address) %>
+              <%=site_status.vac_status%>
+              <%=site_status.status%>
+              <%=site_status.publish%>
+              asd
+              <%#= smart_quotes(site_status.site.full_address) %>
             </td>
             <td class="govuk-table__cell">
               <%= site_status.has_vacancies? ? "Yes" : "No" %>

--- a/app/views/publish/courses/preview/_contact_details.html.erb
+++ b/app/views/publish/courses/preview/_contact_details.html.erb
@@ -1,0 +1,45 @@
+<div id="contact_section" class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-contact">Contact details</h2>
+
+  <div class="course-basicinfo">
+    <dl class="app-description-list">
+      <% if @provider.email.present? %>
+        <dt class="app-description-list__label">Email</dt>
+        <dd data-qa="provider__email">
+          <%= govuk_mail_to @provider.email, @provider.email, title: "Send email to course contact", aria: { label: "Send email to course contact" } %>
+        </dd>
+      <% end %>
+
+      <% if @provider.telephone.present? %>
+        <dt class="app-description-list__label">Telephone</dt>
+        <dd data-qa="provider__telephone">
+          <%= @provider.telephone %>
+        </dd>
+      <% end %>
+
+      <% if @provider.website.present? %>
+        <dt class="app-description-list__label">Website</dt>
+        <dd data-qa="provider__website">
+          <%= govuk_link_to @provider.website, @provider.website %>
+        </dd>
+      <% end %>
+
+      <% if course.provider.provider_code == '28T' && course.course_code == 'X104' %>
+        <dt class="app-description-list__label">Address</dt>
+        <dd data-qa="provider__address">
+          LSJS
+          <br>
+          44A Albert Road
+          <br>
+          London
+          <br>
+          NW4 2SJ
+      <% elsif @provider.full_address.present? %>
+        <dt class="app-description-list__label">Address</dt>
+        <dd data-qa="provider__address">
+          <%= @provider.full_address %>
+        </dd>
+      <% end %>
+    </dl>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/publish/courses/preview/_entry_requirements_qualifications.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-entry">Entry Requirements</h2>
+  <h3 class="govuk-heading-m">Qualifications needed</h3>
+  <% if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
+    <%= render DegreePreviewComponent::View.new(course: course) %>
+    <%= render GcsePreviewComponent::View.new(course: course) %>
+  <% else %>
+    <% if course.required_qualifications.present? %>
+      <div data-qa="course__required_qualifications">
+        <%= markdown(course.required_qualifications) %>
+      </div>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details for this section.</p>
+      <% end %>
+    <% end %>
+  <% end %>
+
+  <% if course.personal_qualities.present? %>
+    <h3 class="govuk-heading-m">Personal qualities</h3>
+    <div data-qa="course__personal_qualities">
+      <%= markdown(course.personal_qualities) %>
+    </div>
+  <% end %>
+
+  <% if course.other_requirements.present? %>
+    <h3 class="govuk-heading-m">Other requirements</h3>
+    <div data-qa="course__other_requirements">
+      <%= markdown(course.other_requirements) %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/publish/courses/preview/_entry_requirements_qualifications.html.erb
+++ b/app/views/publish/courses/preview/_entry_requirements_qualifications.html.erb
@@ -1,20 +1,9 @@
 <div class="govuk-!-margin-bottom-8">
   <h2 class="govuk-heading-l" id="section-entry">Entry Requirements</h2>
   <h3 class="govuk-heading-m">Qualifications needed</h3>
-  <% if course.provider.recruitment_cycle_year.to_i >= Provider::CHANGES_INTRODUCED_IN_2022_CYCLE %>
-    <%= render DegreePreviewComponent::View.new(course: course) %>
-    <%= render GcsePreviewComponent::View.new(course: course) %>
-  <% else %>
-    <% if course.required_qualifications.present? %>
-      <div data-qa="course__required_qualifications">
-        <%= markdown(course.required_qualifications) %>
-      </div>
-    <% else %>
-      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
-        <p class="govuk-body">Please add details for this section.</p>
-      <% end %>
-    <% end %>
-  <% end %>
+  
+  <%= render DegreePreviewComponent::View.new(course: course) %>
+  <%= render GcsePreviewComponent::View.new(course: course) %>
 
   <% if course.personal_qualities.present? %>
     <h3 class="govuk-heading-m">Personal qualities</h3>

--- a/app/views/publish/courses/preview/_fees.html.erb
+++ b/app/views/publish/courses/preview/_fees.html.erb
@@ -1,0 +1,36 @@
+<div class="govuk-!-margin-bottom-8">
+  <% if course.fee_uk_eu.present? %>
+    <% if course.fee_international.present? %>
+      <table class="govuk-table app-table--vertical-align-middle">
+        <caption class="govuk-table__caption govuk-!-font-weight-regular govuk-!-margin-bottom-4">The course fees for <%= course.cycle_range %> are as follows:</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-visually-hidden govuk-table__row">
+            <th scope="col" class="govuk-table__header">Student type</th>
+            <th scope="col" class="govuk-table__header">Fees to pay</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__cell">UK students</td>
+            <td class="govuk-table__cell" data-qa="course__uk_fees"><%= number_to_currency(course.fee_uk_eu) %></td>
+          </tr>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__cell">International students</td>
+            <td class="govuk-table__cell" data-qa="course__international_fees"><%= number_to_currency(course.fee_international) %></td>
+          </tr>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">The course fees for UK students in <%= @recruitment_cycle.year_range %> are <%= number_to_currency(course.fee_uk_eu) %>.</p>
+    <% end %>
+    <% if course.fee_details.present? %>
+      <div data-qa="course__fee_details">
+        <%= markdown(course.fee_details) %>
+      </div>
+    <% end %>
+  <% else %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+      <p class="govuk-body">Please add details for this section.</p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/publish/courses/preview/_fees_and_financial_support.html.erb
+++ b/app/views/publish/courses/preview/_fees_and_financial_support.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-financial-support">Financial support</h2>
+
+  <aside class="app-advice">
+    <h3 class="app-advice__title">
+      <span class="app-advice__caption">Advice from Get Into Teaching</span>
+      Financial support from the government
+    </h3>
+    <% if course.salaried? %>
+      <%= render partial: "publish/courses/preview/financial_support/salaried" %>
+    <% elsif course.use_financial_support_placeholder? %>
+      <%= render partial: "publish/courses/preview/financial_support/placeholder", locals: { course: course } %>
+    <% elsif course.excluded_from_bursary? %>
+      <%= render partial: "publish/courses/preview/financial_support/loan", locals: { course: course } %>
+    <% elsif course.bursary_only? %>
+      <%= render partial: "publish/courses/preview/financial_support/bursary", locals: { course: course } %>
+    <% elsif course.has_scholarship_and_bursary? %>
+      <%= render partial: "publish/courses/preview/financial_support/scholarship_and_bursary", locals: { course: course } %>
+    <% else %>
+      <%= render partial: "publish/courses/preview/financial_support/loan", locals: { course: course } %>
+    <% end %>
+  </aside>
+
+  <% if course.has_fees? %>
+    <%= render partial: "publish/courses/preview/fees", locals: { course: course } %>
+  <% end %>
+
+  <% if course.financial_support.present? %>
+    <h3 data-qa="course__financial_support_details" class="govuk-heading-m">Financial support from the training provider</h3>
+    <%= markdown(course.financial_support) %>
+  <% end %>
+</div>

--- a/app/views/publish/courses/preview/_international_students.html.erb
+++ b/app/views/publish/courses/preview/_international_students.html.erb
@@ -1,0 +1,32 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-international">International students</h2>
+  <% if @provider.declared_visa_sponsorship? %>
+    <p class="govuk-body">
+      <% if @provider.cannot_sponsor_visas? %>
+       We’re unable to sponsor visas. You’ll need to
+       <%= govuk_link_to(
+         "get the right visa or status to study in the UK",
+         "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+       ) %>.
+      <% else %>
+        We can sponsor
+      <%= govuk_link_to(
+        visa_sponsorship_short_status(@provider),
+        "https://www.gov.uk/government/publications/train-to-teach-in-england-non-uk-applicants/train-to-teach-in-england-non-uk-applicants#visas-and-immigration",
+      ) %>.
+      <% end %>
+    </p>
+  <% else %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+      <p class="govuk-heading-s">
+        Please add details
+        <%= govuk_link_to(
+          "about visa sponsorship",
+          provider_recruitment_cycle_visas_path(@provider.provider_code, @provider.recruitment_cycle_year),
+        ) %>
+      </p>
+    <% end %>
+  <% end %>
+  <p class="govuk-body">You do not need a visa if you already have settled or pre-settled status under the EU Settlement Scheme, or if you’re an Irish citizen.</p>
+  <p class="govuk-body">Candidates with qualifications from non-UK institutions may need to provide evidence of comparability by applying for a <%= govuk_link_to("UK ENIC statement", "https://www.enic.org.uk") %>.</p>
+</div>

--- a/app/views/publish/courses/preview/_interview_process.html.erb
+++ b/app/views/publish/courses/preview/_interview_process.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-interviews">Interview process</h2>
+  <div data-qa="course__interview_process">
+    <%= markdown(course.interview_process) %>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/_qualification.html.erb
+++ b/app/views/publish/courses/preview/_qualification.html.erb
@@ -1,0 +1,12 @@
+<% case course.outcome %>
+<% when "QTS" %>
+  <%= render partial: "publish/courses/preview/qualification/qts" %>
+<% when "PGCE with QTS" %>
+  <%= render partial: "publish/courses/preview/qualification/pgce_with_qts" %>
+<% when "PGDE with QTS" %>
+  <%= render partial: "publish/courses/preview/qualification/pgde_with_qts" %>
+<% when "PGCE" %>
+  <%= render partial: "publish/courses/preview/qualification/pgce" %>
+<% when "PGDE" %>
+  <%= render partial: "publish/courses/preview/qualification/pgde" %>
+<% end %>

--- a/app/views/publish/courses/preview/_salary.html.erb
+++ b/app/views/publish/courses/preview/_salary.html.erb
@@ -1,0 +1,10 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-salary">Salary</h2>
+  <% if course.salary_details.present? %>
+    <%= markdown(course.salary_details) %>
+  <% else %>
+    <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+      <p class="govuk-body">Please add details for this section.</p>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/publish/courses/preview/_train_with_disabilities.html.erb
+++ b/app/views/publish/courses/preview/_train_with_disabilities.html.erb
@@ -1,0 +1,12 @@
+<div class="govuk-!-margin-bottom-8">
+  <h2 class="govuk-heading-l" id="section-train-with-disabilities">Training with disabilities and other needs</h2>
+  <div data-qa="course__train_with_disabilities">
+    <% if @provider.train_with_disability.present? %>
+      <%= markdown(@provider.train_with_disability) %>
+    <% else %>
+      <%= govuk_inset_text(classes: "app-inset-text--narrow-border app-inset-text--important") do %>
+        <p class="govuk-body">Please add details about <%= govuk_link_to "training with disabilities", about_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) %>.</p>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/preview/financial_support/_bursary.html.erb
+++ b/app/views/publish/courses/preview/financial_support/_bursary.html.erb
@@ -1,0 +1,25 @@
+<div class="app-advice__body" data-qa="course__bursary_details">
+  <p class="govuk-body">
+    You’ll get a bursary of <%= number_to_currency(course.bursary_amount) %> if you have <%= course.bursary_first_line_ending %>
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <% if course.bursary_requirements.length > 1 %>
+      <% course.bursary_requirements.each do |requirement| %>
+        <li><%= requirement %></li>
+      <% end %>
+    <% end %>
+  </ul>
+
+  <p class="govuk-body">
+    You do not have to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out about <%= govuk_link_to "eligibility", "https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships" %> and <%= govuk_link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary" %>.
+  </p>
+
+  <p class="govuk-body">
+    You may be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans" %> – note that you’ll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
+  </p>
+
+  <p class="govuk-body">
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/guidance/financial-support-for-international-applicants" %>.
+  </p>
+</div>

--- a/app/views/publish/courses/preview/financial_support/_loan.html.erb
+++ b/app/views/publish/courses/preview/financial_support/_loan.html.erb
@@ -1,0 +1,8 @@
+<div class="app-advice__body" data-qa="course__loan_details">
+  <p class="govuk-body">
+    You may be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans" %> – note that you’ll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
+  </p>
+  <p class="govuk-body">
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/guidance/financial-support-for-international-applicants" %>.
+  </p>
+</div>

--- a/app/views/publish/courses/preview/financial_support/_placeholder.html.erb
+++ b/app/views/publish/courses/preview/financial_support/_placeholder.html.erb
@@ -1,0 +1,3 @@
+<%= govuk_inset_text do %>
+  <p class="govuk-body">Financial support for <%= course.cycle_range %> will be announced soon. Further information is available on <%= govuk_link_to "Get Into Teaching", "https://getintoteaching.education.gov.uk/funding-my-teacher-training/bursaries-and-scholarships-for-teacher-training", rel: "noopener noreferrer", target: "_blank" %>.</p>
+<% end %>

--- a/app/views/publish/courses/preview/financial_support/_salaried.html.erb
+++ b/app/views/publish/courses/preview/financial_support/_salaried.html.erb
@@ -1,0 +1,8 @@
+<div class="app-advice__body" data-qa="course__salary_details">
+  <p class="govuk-body">
+    Financial support is not available for this course because it comes with a salary.
+  </p>
+  <p class="govuk-body">
+    You may be eligible for financial support if you choose a course without a salary. This support includes bursaries, scholarships and loans.
+  </p>
+</div>

--- a/app/views/publish/courses/preview/financial_support/_scholarship_and_bursary.html.erb
+++ b/app/views/publish/courses/preview/financial_support/_scholarship_and_bursary.html.erb
@@ -1,0 +1,36 @@
+<div class="app-advice__body" data-qa="course__scholarship_and_bursary_details">
+  <p class="govuk-body">
+    You could be eligible for either:
+  </p>
+
+  <ul class="govuk-list govuk-list--bullet">
+    <li data-qa="course__scholarship_amount">a scholarship of <%= number_to_currency(course.scholarship_amount) %></li>
+    <li data-qa="course__bursary_amount">a bursary of <%= number_to_currency(course.bursary_amount) %></li>
+  </ul>
+
+  <% if course.has_early_career_payments? %>
+    <p class="govuk-body" data-qa="course__early_career_payment_details">
+      With a scholarship or bursary, you’ll also get early career payments of £2,000 in your second, third and fourth years of teaching (£3,000 in <%= govuk_link_to "some areas of England", "https://www.gov.uk/guidance/mathematics-early-career-payments-guidance-for-teachers-and-schools" %>).
+    </p>
+  <% end %>
+
+  <p class="govuk-body">
+    To qualify for a scholarship you’ll need a degree of 2:1 or above in <%= course.subject_name %> or a related subject. For a bursary you’ll need a 2:2 or above in any subject.
+  </p>
+
+  <p class="govuk-body">
+    You cannot claim both a bursary and a scholarship - you can only claim one.
+  </p>
+
+  <p class="govuk-body">
+    Find out how to <%= govuk_link_to "apply for a scholarship", "https://getintoteaching.education.gov.uk/funding-your-training#bursaries-and-scholarships" %>. You do not need to apply for a bursary - if you’re eligible, you’ll automatically start receiving it once you begin your course. Find out <%= govuk_link_to "how you’ll be paid", "https://getintoteaching.education.gov.uk/guidance/become-a-teacher-in-england#how-to-get-a-bursary" %>.
+  </p>
+
+  <p class="govuk-body">
+    You may also be eligible for a <%= govuk_link_to "loan while you study", "https://getintoteaching.education.gov.uk/funding-your-training#tuition-fee-and-maintenance-loans" %> – note that you’ll have to apply for <%= govuk_link_to "undergraduate student finance", "https://www.gov.uk/student-finance" %>.
+  </p>
+
+  <p class="govuk-body">
+    Find out about financial support if you’re from <%= govuk_link_to "outside the UK", "https://getintoteaching.education.gov.uk/guidance/financial-support-for-international-applicants" %>.
+  </p>
+</div>

--- a/app/views/publish/courses/preview/placement/_hei.html.erb
+++ b/app/views/publish/courses/preview/placement/_hei.html.erb
@@ -1,0 +1,9 @@
+<aside class="app-advice">
+  <h3 class="app-advice__title">
+    <span class="app-advice__caption">Advice from Get Into Teaching</span>
+    Where you will train
+  </h3>
+  <p class="govuk-body">You’ll be placed in schools for most of your course. Your school placements will be within commuting distance.</p>
+  <p class="govuk-body">You can’t pick which schools you want to be in, but your university will try to take your journey time into consideration.</p>
+  <p class="govuk-body">Universities can work with over 100 potential placement schools. Most will be within 10 miles of the university, but sometimes they can cover a wider area, especially outside of cities.</p>
+</aside>

--- a/app/views/publish/courses/preview/placement/_scitt.html.erb
+++ b/app/views/publish/courses/preview/placement/_scitt.html.erb
@@ -1,0 +1,7 @@
+<aside class="app-advice">
+  <h3 class="app-advice__title">
+    <span class="app-advice__caption">Advice from Get Into Teaching</span>
+    Where you will train
+  </h3>
+  <p class="govuk-body">You’ll be placed in different schools during your training. You can’t pick which schools you want to be in, but your course will try to place you in schools you can commute to.</p>
+</aside>

--- a/app/views/publish/courses/preview/qualification/_pgce.html.erb
+++ b/app/views/publish/courses/preview/qualification/_pgce.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "PGCE") do %>
+  <p class="govuk-body">A postgraduate certificate in education (PGCE) is an academic qualification in education.</p>
+  <p class="govuk-body">It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">This course does not lead to qualified teacher status (QTS).</p>
+<% end %>

--- a/app/views/publish/courses/preview/qualification/_pgce_with_qts.html.erb
+++ b/app/views/publish/courses/preview/qualification/_pgce_with_qts.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "PGCE with QTS") do %>
+  <p class="govuk-body">A postgraduate certificate in education (PGCE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">Many PGCE courses include credits that count toward a Master’s degree.</p>
+<% end %>

--- a/app/views/publish/courses/preview/qualification/_pgde.html.erb
+++ b/app/views/publish/courses/preview/qualification/_pgde.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "PGDE") do %>
+  <p class="govuk-body">A postgraduate diploma in education (PGDE) is equivalent to a postgraduate certificate in education (PGCE).</p>
+  <p class="govuk-body">It’s recognised internationally, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">This course does not lead to qualified teacher status (QTS).</p>
+<% end %>

--- a/app/views/publish/courses/preview/qualification/_pgde_with_qts.html.erb
+++ b/app/views/publish/courses/preview/qualification/_pgde_with_qts.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "PGDE with QTS") do %>
+  <p class="govuk-body">A postgraduate diploma in education (PGDE) with qualified teacher status (QTS) will allow you to teach in state schools in England and may allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach overseas, though you should always check what qualifications are needed in the country you’d like to teach in.</p>
+  <p class="govuk-body">Many PGDE courses include credits towards a Master’s degree.</p>
+<% end %>

--- a/app/views/publish/courses/preview/qualification/_qts.html.erb
+++ b/app/views/publish/courses/preview/qualification/_qts.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_details(summary_text: "QTS") do %>
+  <p class="govuk-body">Qualified teacher status (QTS) allows you to teach in state schools in England and may also allow you to teach in other parts of the UK.</p>
+  <p class="govuk-body">It may also allow you to teach in <%= govuk_link_to "the EU and EEA", "https://www.gov.uk/eu-eea" %>, though this could change after 2020.</p>
+  <p class="govuk-body">If you’re planning to teach overseas, you should always check what qualifications are needed in the country you’d like to teach in.</p>
+<% end %>

--- a/app/views/publish/courses/status_panel/_unpublished.html.erb
+++ b/app/views/publish/courses/status_panel/_unpublished.html.erb
@@ -3,9 +3,7 @@
 <p class="govuk-body">See how your unpublished changes will look on Find.</p>
 <p class="govuk-body">Preview to check for mistakes before publishing.</p>
 <p class="govuk-body">
-  <%= govuk_link_to "Preview course" %>
-
-  <%# govuk_link_to "Preview course", preview_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
+  <%=govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/publish/courses/status_panel/_unpublished.html.erb
+++ b/app/views/publish/courses/status_panel/_unpublished.html.erb
@@ -3,7 +3,7 @@
 <p class="govuk-body">See how your unpublished changes will look on Find.</p>
 <p class="govuk-body">Preview to check for mistakes before publishing.</p>
 <p class="govuk-body">
-  <%=govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
+  <%= govuk_link_to "Preview course", preview_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), "data-qa": "course__preview-link" %>
 </p>
 
 <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -3,5 +3,9 @@ import '../scripts/govuk_assets_import'
 import '../styles/application.scss'
 import '../scripts/components'
 import { initAll } from 'govuk-frontend'
+import initLocationsMap from "../scripts/locations-map";
 
 initAll()
+
+
+window.initLocationsMap = initLocationsMap;

--- a/app/webpacker/scripts/locations-map.js
+++ b/app/webpacker/scripts/locations-map.js
@@ -1,7 +1,6 @@
 import createPopupClass from "./map-popup";
 
 const initLocationsMap = () => {
-  console.log("im here")
   const $map = document.getElementById("locations-map");
   const trainingLocations = window.trainingLocations
     .filter(({lat, lng}) => lat !== "" && lng !== "")

--- a/app/webpacker/scripts/locations-map.js
+++ b/app/webpacker/scripts/locations-map.js
@@ -1,0 +1,99 @@
+import createPopupClass from "./map-popup";
+
+const initLocationsMap = () => {
+  console.log("im here")
+  const $map = document.getElementById("locations-map");
+  const trainingLocations = window.trainingLocations
+    .filter(({lat, lng}) => lat !== "" && lng !== "")
+    .map(location => {
+      location.lat = parseFloat(location.lat);
+      location.lng = parseFloat(location.lng);
+      return location;
+    })
+
+  if (trainingLocations.length === 0) {
+    console.error("Failed to initialise map: center is impossible to display, because none of the locations have a lat/lng.");
+    $map.style.display = 'none';
+    return;
+  }
+
+  const Popup = createPopupClass();
+  const bounds = new google.maps.LatLngBounds();
+
+  const centerLat = trainingLocations[0].lat;
+  const centerLng = trainingLocations[0].lng;
+
+  const map = new google.maps.Map($map, {
+    mapTypeId: google.maps.MapTypeId.ROADMAP,
+    mapTypeControl: false,
+    scaleControl: false,
+    streetViewControl: false,
+    rotateControl: false,
+    fullscreenControl: true,
+    fullscreenControlOptions: {
+      position: google.maps.ControlPosition.RIGHT_BOTTOM
+    },
+    zoom: 11,
+    center: {
+      lat: centerLat,
+      lng: centerLng
+    },
+    styles: [
+      {
+        featureType: "poi.business",
+        stylers: [
+          {
+            visibility: "off"
+          }
+        ]
+      },
+      {
+        featureType: "poi.park",
+        elementType: "labels.text",
+        stylers: [
+          {
+            visibility: "off"
+          }
+        ]
+      }
+    ]
+  });
+
+  const locations = window.trainingLocations;
+
+  for (let i = 0, length = locations.length; i < length; i++) {
+    const location = locations[i];
+    const latLng = new google.maps.LatLng(location.lat, location.lng);
+
+    const closedContent = document.createElement("div");
+    closedContent.innerHTML = location.name;
+
+    const openContent = document.createElement("div");
+    if (location.vacancies) {
+      openContent.insertAdjacentHTML(
+        "beforeend",
+        `<div class="govuk-tag govuk-tag--no-content govuk-!-margin-bottom-2">${ location.vacancies }</div>`
+      );
+    }
+    if (location.address) {
+      openContent.insertAdjacentHTML(
+        "beforeend",
+        `<p class="govuk-body">${location.address}</p>`
+      );
+    }
+
+    const popup = new Popup(latLng, closedContent, openContent);
+    popup.setMap(map);
+
+    // Extend the bounds by the locations so we get a decent number as part of the first view.
+    bounds.extend(latLng);
+  }
+
+  // Use provider address to center and zoom when only one location
+  if (locations.length > 1) {
+    map.fitBounds(bounds);
+    map.panToBounds(bounds);
+  }
+};
+
+export default initLocationsMap;

--- a/app/webpacker/scripts/map-popup.js
+++ b/app/webpacker/scripts/map-popup.js
@@ -1,0 +1,101 @@
+// Based on: https://developers.google.com/maps/documentation/javascript/examples/overlay-popup
+
+const createPopupClass = () => {
+  const panToWithOffset = function(map, latlng, offsetX, offsetY) {
+    const ov = new google.maps.OverlayView();
+    ov.onAdd = function() {
+      const proj = this.getProjection();
+      const aPoint = proj.fromLatLngToContainerPixel(latlng);
+      aPoint.x = aPoint.x + offsetX;
+      aPoint.y = aPoint.y + offsetY;
+      map.panTo(proj.fromContainerPixelToLatLng(aPoint));
+    };
+    ov.draw = function() {};
+    ov.setMap(map);
+  };
+
+  const Popup = function(position, closedContent, openContent) {
+    this.position = position;
+    const content = document.createElement("div");
+    content.classList.add("app-map__marker-content");
+    content.insertAdjacentHTML(
+      "beforeend",
+      '<button class="app-map__marker-close">&times;<span class="govuk-visually-hidden">Close this popup</span></button>'
+    );
+    closedContent.classList.add("app-map__marker-title");
+    openContent.classList.add("app-map__marker-body");
+    content.appendChild(closedContent);
+    content.appendChild(openContent);
+
+    this.anchor = document.createElement("div");
+    this.anchor.classList.add("app-map__marker");
+    this.anchor.appendChild(content);
+
+    this.stopEventPropagation();
+
+    const $closeButton = content.querySelector(".app-map__marker-close");
+    $closeButton.addEventListener("click", e => {
+      this.closeOpenPopups();
+    });
+
+    closedContent.addEventListener("click", e => {
+      panToWithOffset(this.getMap(), this.position, 0, -70);
+      this.closeOpenPopups();
+      this.anchor.classList.toggle("open");
+      e.stopPropagation();
+    });
+  };
+
+  // NOTE: google.maps.OverlayView is only defined once the Maps API has
+  // loaded. That is why Popup is defined inside createPopupClass().
+  Popup.prototype = Object.create(google.maps.OverlayView.prototype);
+
+  // Called when the popup is added to the map.
+  Popup.prototype.onAdd = function() {
+    this.getPanes().floatPane.appendChild(this.anchor);
+  };
+
+  // Called when the popup is removed from the map.
+  Popup.prototype.onRemove = function() {
+    if (this.anchor.parentElement) {
+      this.anchor.parentElement.removeChild(this.anchor);
+    }
+  };
+
+  // Called when the popup needs to draw itself.
+  Popup.prototype.draw = function() {
+    const divPosition = this.getProjection().fromLatLngToDivPixel(this.position);
+    // Hide the popup when it is far out of view.
+    const display = Math.abs(divPosition.x) < 4000 && Math.abs(divPosition.y) < 4000 ? "block" : "none";
+
+    if (display === "block") {
+      this.anchor.style.left = divPosition.x + "px";
+      this.anchor.style.top = divPosition.y + "px";
+    }
+    if (this.anchor.style.display !== display) {
+      this.anchor.style.display = display;
+    }
+  };
+
+  Popup.prototype.closeOpenPopups = () => {
+    const $anchors = document.querySelectorAll(".app-map__marker.open");
+    for (let i = 0; i < $anchors.length; i++) {
+      $anchors[i].classList.remove("open");
+    }
+  };
+
+  // Stops clicks/drags from bubbling up to the map.
+  Popup.prototype.stopEventPropagation = function() {
+    const anchor = this.anchor;
+    anchor.style.cursor = "auto";
+    ["click", "dblclick", "contextmenu", "wheel", "mousedown", "touchstart", "pointerdown"].forEach(function(event) {
+      anchor.addEventListener(event, function(e) {
+        e.stopPropagation();
+      });
+    });
+  };
+
+  return Popup;
+};
+
+export default createPopupClass;

--- a/app/webpacker/styles/_advice.scss
+++ b/app/webpacker/styles/_advice.scss
@@ -1,0 +1,23 @@
+.app-advice {
+  @include govuk-responsive-margin(4, "bottom");
+  background: govuk-colour("light-grey");
+  border-left: $govuk-border-width solid $git-brand-colour;
+  clear: both;
+  padding: govuk-spacing(4);
+}
+
+.app-advice__caption {
+  @include govuk-font($size: 19);
+  color: govuk-colour("dark-grey");
+  display: block;
+}
+
+.app-advice__title {
+  @include govuk-font($size: 24, $weight: "bold");
+  margin-top: 0;
+  margin-bottom: govuk-spacing(4);
+}
+
+.app-advice__body > *:last-child {
+  margin-bottom: 0;
+}

--- a/app/webpacker/styles/_description-list.scss
+++ b/app/webpacker/styles/_description-list.scss
@@ -1,0 +1,52 @@
+%app-description-list {
+  @include govuk-clearfix;
+  margin-top: 0;
+}
+
+%app-description-list > dt {
+  @include govuk-font($size: 19, $weight: bold);
+  vertical-align: top;
+
+  @include govuk-media-query($from: desktop) {
+    clear: left;
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 30%;
+  }
+}
+
+%app-description-list > dd {
+  @include govuk-font($size: 19, $weight: normal);
+  margin: 0 0 govuk-spacing(2) 0;
+  vertical-align: top;
+
+  @include govuk-media-query($from: desktop) {
+    float: left;
+    margin-bottom: govuk-spacing(1);
+    width: 70%;
+  }
+
+  .govuk-details,
+  .govuk-details__summary {
+    margin-bottom: 0;
+  }
+
+  .govuk-details__text {
+    margin-bottom: govuk-spacing(2);
+  }
+}
+
+.app-description-list {
+  @extend %app-description-list;
+
+  &__label:after {
+    display: inline-block;
+  }
+
+  &__hint {
+    @include govuk-font($size: 16, $weight: normal);
+    color: $govuk-secondary-text-colour;
+    display: block;
+    margin-bottom: govuk-space(1);
+  }
+}

--- a/app/webpacker/styles/_inset-text.scss
+++ b/app/webpacker/styles/_inset-text.scss
@@ -1,0 +1,34 @@
+.govuk-inset-text {
+  .govuk-summary-list__value & {
+    margin-top: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+.app-inset-text--narrow-border {
+  border-left-width: $govuk-border-width-narrow;
+}
+
+
+.app-inset-text--important {
+  border-color: govuk-colour("blue");
+
+  .app-inset-text__title {
+    color: govuk-colour("blue");
+  }
+}
+
+.app-inset-text--error {
+  border-color: $govuk-error-colour;
+  border-left-width: $govuk-border-width;
+
+  .govuk-heading-s {
+    color: $govuk-error-colour;
+  }
+
+  .govuk-link {
+    @include govuk-typography-weight-bold($important: true);
+    color: $govuk-error-colour;
+  }
+}

--- a/app/webpacker/styles/_list.scss
+++ b/app/webpacker/styles/_list.scss
@@ -1,0 +1,15 @@
+.app-list--dash {
+  padding-left: govuk-spacing(3);
+
+  li {
+    position: relative;
+
+    &:before {
+      color: govuk-colour("dark-grey");
+      content: "\2013";
+      left: -16px;
+      position: absolute;
+      top: 0;
+    }
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -7,6 +7,7 @@ $git-brand-colour: #159964;
 @import "advice";
 @import "card";
 @import "description-list";
+@import "inset-text";
 @import "status-box";
 @import "summary-list";
 @import "table";

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -2,7 +2,11 @@
 @import "~govuk-frontend/govuk/all";
 @import "~@ministryofjustice/frontend/moj/all";
 
+$git-brand-colour: #159964;
+
+@import "advice";
 @import "card";
+@import "description-list";
 @import "status-box";
 @import "summary-list";
 @import "table";

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -8,6 +8,7 @@ $git-brand-colour: #159964;
 @import "card";
 @import "description-list";
 @import "inset-text";
+@import "list";
 @import "status-box";
 @import "summary-list";
 @import "table";

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -116,6 +116,8 @@ Rails.application.routes.draw do
           patch "/salary", on: :member, to: "courses/salary#update"
           get "/locations", on: :member, to: "courses/sites#edit"
           put "/locations", on: :member, to: "courses/sites#update"
+
+          get "/preview", on: :member, to: "courses#preview"
         end
 
         scope module: :providers do

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,6 +64,7 @@ basic_auth:
   enabled: false
 
 google:
+  maps_api_key: replace_me
   bigquery:
     project_id: replaceme
     dataset: replaceme

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -721,17 +721,17 @@ describe CourseDecorator do
     end
   end
 
-  # describe "#cycle_range" do
-  #   let(:expected_cycle_range) do
-  #     "#{current_recruitment_cycle.year} to #{current_recruitment_cycle.year.to_i + 1}"
-  #   end
+  describe "#cycle_range" do
+    let(:expected_cycle_range) do
+      "#{current_recruitment_cycle.year} to #{current_recruitment_cycle.year.to_i + 1}"
+    end
 
-  #   subject { course.decorate.cycle_range }
+    subject { course.decorate.cycle_range }
 
-  #   it "should state the correct cycle range" do
-  #     expect(subject).to eq(expected_cycle_range)
-  #   end
-  # end
+    it "states the correct cycle range" do
+      expect(subject).to eq(expected_cycle_range)
+    end
+  end
 
   # describe "#use_financial_support_placeholder?" do
   #   before do

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -300,22 +300,22 @@ describe CourseDecorator do
   #     end
   #   end
 
-  #   describe "#subject_name" do
-  #     context "course has more than one subject" do
-  #       it "returns the course name" do
-  #         expect(decorated_course.subject_name).to eq("Mathematics")
-  #       end
-  #     end
+  describe "#subject_name" do
+    context "course has more than one subject" do
+      it "returns the course name" do
+        expect(decorated_course.subject_name).to eq("Mathematics")
+      end
+    end
 
-  #     context "course has one subject" do
-  #       let(:subject) { build :subject, subject_name: "Computer Science" }
-  #       let(:course) { build :course, subjects: [subject] }
+    context "course has one subject" do
+      let(:course_subject) { find_or_create :secondary_subject, :computing }
+      let(:course) { build :course, subjects: [course_subject] }
 
-  #       it "return the subject name" do
-  #         expect(decorated_course.subject_name).to eq("Computer Science")
-  #       end
-  #     end
-  #   end
+      it "return the subject name" do
+        expect(decorated_course.subject_name).to eq("Computing")
+      end
+    end
+  end
 
   #   describe "#bursary_requirements" do
   #     let(:subject) { decorated_course.bursary_requirements }

--- a/spec/factories/course_enrichments.rb
+++ b/spec/factories/course_enrichments.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :course_enrichment do
     course
     status { :draft }
-    about_course { Faker::Books::Dune.quote }
+    about_course { Faker::Lorem.sentence }
     course_length do
       # samples taken from real data
       [
@@ -49,10 +49,10 @@ FactoryBot.define do
         "You can find information about tuition fee loans and other financial help on the Gov.uk website - (https://www.gov.uk/student-finance)",
       ].sample
     end
-    how_school_placements_work { Faker::TvShows::GameOfThrones.quote }
-    interview_process { Faker::TvShows::Seinfeld.quote }
-    other_requirements { Faker::TvShows::TheITCrowd.quote }
-    personal_qualities { Faker::Hipster.paragraph }
+    how_school_placements_work { Faker::Lorem.sentence }
+    interview_process { Faker::Lorem.sentence }
+    other_requirements { Faker::Lorem.sentence }
+    personal_qualities { Faker::Lorem.sentence }
     required_qualifications { Faker::Educator.degree }
     # Technically, salary_details should align with whether the course is
     # salaried or not. Maybe worth implementing this somehow at some point.

--- a/spec/factories/subjects/secondary_subjects.rb
+++ b/spec/factories/subjects/secondary_subjects.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   subjects = {
-    # Modern Lanuages has been removed as it would cause validation errors if it
+    # Modern Languages has been removed as it would cause validation errors if it
     # isn't paired with a valid modern language subject use a trait if you want to create it
     "Ancient Greek" => "A1",
     "Ancient Hebrew" => "A2",

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -176,8 +176,7 @@ private
   end
 
   def user_with_custom_address_requested_via_zendesk
-    course = build(:course,
-                   course_code: "X104")
+    course = build(:course, course_code: "X104")
     provider = build(
       :provider, provider_code: "28T", courses: [course]
     )

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -127,5 +127,9 @@ module FeatureHelpers
     def publish_course_location_page
       @publish_course_location_page ||= PageObjects::Publish::CourseLocationEdit.new
     end
+
+    def publish_course_preview_page
+      @publish_course_preview_page ||= PageObjects::Publish::CoursePreview.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/course_preview.rb
+++ b/spec/support/page_objects/publish/course_preview.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class CoursePreview < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/preview"
+
+      element :sub_title, "[data-qa=course__provider_name]"
+      element :description, "[data-qa=course__description]"
+      element :accredited_body, "[data-qa=course__accredited_body]"
+      element :qualifications, "[data-qa=course__qualifications]"
+      element :funding_option, "[data-qa=course__funding_option]"
+      element :length, "[data-qa=course__length]"
+      element :applications_open_from, "[data-qa=course__applications_open]"
+      element :start_date, "[data-qa=course__start_date]"
+      element :provider_website, "[data-qa=course__provider_website]"
+      element :vacancies, "[data-qa=course__vacancies]"
+      element :about_course, "[data-qa=course__about_course]"
+      element :interview_process, "[data-qa=course__interview_process]"
+      element :school_placements, '[data-qa="course__about_schools"]'
+      element :uk_fees, "[data-qa=course__uk_fees]"
+      element :fee_details, "[data-qa=course__fee_details]"
+      element :international_fees, "[data-qa=course__international_fees]"
+      element :loan_details, "[data-qa=course__loan_details]"
+      element :scholarship_and_bursary_details, "[data-qa=course__scholarship_and_bursary_details]"
+      element :scholarship_amount, "[data-qa=course__scholarship_amount]"
+      element :bursary_details, "[data-qa=course__bursary_details]"
+      element :bursary_amount, "[data-qa=course__bursary_amount]"
+      element :early_career_payment_details, "[data-qa=course__early_career_payment_details]"
+      element :financial_support_details, "[data-qa=course__financial_support_details]"
+      element :required_qualifications, "[data-qa=course__required_qualifications]"
+      element :personal_qualities, "[data-qa=course__personal_qualities]"
+      element :other_requirements, "[data-qa=course__other_requirements]"
+      element :train_with_us, "[data-qa=course__about_provider]"
+      element :about_accrediting_body, "[data-qa=course__about_accrediting_body]"
+      element :train_with_disability, "[data-qa=course__train_with_disabilities]"
+      element :contact_email, "[data-qa=provider__email]"
+      element :contact_telephone, "[data-qa=provider__telephone]"
+      element :contact_website, "[data-qa=provider__website]"
+      element :contact_address, "[data-qa=provider__address]"
+      element :course_advice, "#section-advice"
+      element :course_apply, "#section-apply"
+      element :choose_a_training_location_table, "[data-qa=course__choose_a_training_location]"
+      element :locations_map, "[data-qa=course__locations_map]"
+      element :salary_details, "[data-qa=course__salary_details]"
+      element :age_range_in_years, "[data-qa=course__age_range_in_years]"
+    end
+  end
+end


### PR DESCRIPTION
### Context
Course preview

### Changes proposed in this pull request
Added course preview

### Guidance to review
Go to any course that has is `rolled_over`, `empty`, `withdrawn`, `published_with_unpublished_changes` or `draft` basically when it is not `published`

The preview it 

https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2CF/2022/courses/J659
vs 
https://teacher-training-api-pr-2546.london.cloudapps.digital/publish/organisations/2CF/2022/courses/J659

No matter what. This address is shown as the `Contact details` for provider_code: `28T` course_code: `X104`


![image](https://user-images.githubusercontent.com/470137/156801679-7d5d8a97-f400-48ab-82ae-99e36f3210e1.png)


https://qa.publish-teacher-training-courses.service.gov.uk/organisations/28T/2022/courses/X104
vs 
https://teacher-training-api-pr-2546.london.cloudapps.digital/publish/organisations/28T/2022/courses/X104

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
