### PR TITLE
Fix GHCR login for build-no-cache workflow

### DIFF
--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -45,12 +45,13 @@ jobs:
           secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
           key: SNYK_TOKEN
 
-      - name: Login to DockerHub
+      - name: Login to GitHub Container Registry
         if: github.actor != 'dependabot[bot]'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.12.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PERSONAL_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -98,5 +99,3 @@ jobs:
           SLACK_TITLE: Build failure on weekly rebuild cache workflow
           SLACK_MESSAGE: ':alert: <!channel> Teacher Training API Build failure :sadparrot:'
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-


### PR DESCRIPTION
### Context

Fix Github Container Registry login for the build-no-cache workflow.

### Changes proposed in this pull request

Alter workflow to use GHCR secrets instead of Dockerhub

### Guidance to review

Workflow has been run against branch

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
