### PR TITLE
Update gmp in Dockerfile to fix vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ruby:2.7.5-alpine3.15 AS middleman
+# Remove apk add for gmp 6.2.1-r1 when the base image is updated
 
 RUN apk add --update --no-cache npm git build-base
+
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
+RUN apk add --no-cache gmp=6.2.1-r1
 
 COPY docs/Gemfile docs/Gemfile.lock /
 
@@ -23,6 +27,9 @@ RUN apk add --update --no-cache tzdata && \
 
 RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
+
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
+RUN apk add --no-cache gmp=6.2.1-r1
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context

SNYK has highlighted vulnerability in gmp 6.2.1-r0 in the base image
This is fixed in 6.2.1-r1

### Changes proposed in this pull request

Change to Dockerfile to update gmp to the new version

### Guidance to review

Check build completes successfully

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
