### PR TITLE
[596] Port over degree requirements flow

### DIFF
--- a/app/components/degree_row_content_component/view.html.erb
+++ b/app/components/degree_row_content_component/view.html.erb
@@ -12,13 +12,13 @@
   <%= govuk_inset_text(classes: inset_text_css_classes) do %>
     <p class="govuk-heading-s app-inset-text__title">Do you require a minimum degree classification?</p>
     <p class="govuk-body">
-      <%= govuk_link_to "Enter degree requirements", "#"
-        # degrees_start_provider_recruitment_cycle_course_path(
-        #   course.provider.provider_code,
-        #   course.recruitment_cycle_year,
-        #   course.course_code,
-        # ) 
-        %>
+      <%= govuk_link_to "Enter degree requirements",
+        degrees_start_publish_provider_recruitment_cycle_course_path(
+          course.provider.provider_code,
+          course.recruitment_cycle_year,
+          course.course_code,
+        ) 
+      %>
     </p>
   <% end %>
 <% end %>

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -32,7 +32,9 @@ module Publish
         end
 
         def grade_params
-          params.dig(:publish_degree_grade_form, :grade)
+          return if params[:publish_degree_grade_form].blank?
+
+          params.require(:publish_degree_grade_form).permit(:grade)[:grade]
         end
       end
     end

--- a/app/controllers/publish/courses/degrees/grade_controller.rb
+++ b/app/controllers/publish/courses/degrees/grade_controller.rb
@@ -1,0 +1,40 @@
+module Publish
+  module Courses
+    module Degrees
+      class GradeController < PublishController
+        def edit
+          authorize(provider)
+
+          @grade_form = DegreeGradeForm.build_from_course(course)
+        end
+
+        def update
+          authorize(provider)
+
+          @grade_form = DegreeGradeForm.new(grade: grade_params)
+
+          if course.is_primary? && @grade_form.save(course)
+            flash[:success] = I18n.t("success.saved")
+
+            redirect_to publish_provider_recruitment_cycle_course_path
+          elsif @grade_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          else
+            @errors = @grade_form.errors.messages
+            render :edit
+          end
+        end
+
+      private
+
+        def course
+          @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+        end
+
+        def grade_params
+          params.dig(:publish_degree_grade_form, :grade)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -35,7 +35,9 @@ module Publish
         end
 
         def grade_required_params
-          params.dig(:publish_degree_start_form, :degree_grade_required)
+          return if params[:publish_degree_start_form].blank?
+
+          params.require(:publish_degree_start_form).permit(:degree_grade_required)[:degree_grade_required]
         end
       end
     end

--- a/app/controllers/publish/courses/degrees/start_controller.rb
+++ b/app/controllers/publish/courses/degrees/start_controller.rb
@@ -1,0 +1,43 @@
+module Publish
+  module Courses
+    module Degrees
+      class StartController < PublishController
+        def edit
+          authorize(provider)
+
+          @start_form = DegreeStartForm.new
+          @start_form.build_from_course(course)
+        end
+
+        def update
+          authorize(provider)
+
+          @start_form = DegreeStartForm.new(degree_grade_required: grade_required_params)
+
+          if course.is_primary? && @start_form.save(course)
+            flash[:success] = I18n.t("success.saved")
+
+            redirect_to publish_provider_recruitment_cycle_course_path
+          elsif @start_form.save(course)
+            redirect_to degrees_subject_requirements_publish_provider_recruitment_cycle_course_path
+          elsif @start_form.degree_grade_required.present?
+            redirect_to degrees_grade_publish_provider_recruitment_cycle_course_path
+          else
+            @errors = @start_form.errors.messages
+            render :edit
+          end
+        end
+
+      private
+
+        def course
+          @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+        end
+
+        def grade_required_params
+          params.dig(:publish_degree_start_form, :degree_grade_required)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
+++ b/app/controllers/publish/courses/degrees/subject_requirements_controller.rb
@@ -1,0 +1,56 @@
+module Publish
+  module Courses
+    module Degrees
+      class SubjectRequirementsController < PublishController
+        before_action :redirect_to_course_details_page_if_course_is_primary
+
+        def edit
+          authorize(provider)
+
+          set_backlink
+          @subject_requirements_form = SubjectRequirementForm.build_from_course(course)
+        end
+
+        def update
+          authorize(provider)
+
+          @subject_requirements_form = SubjectRequirementForm.new(subject_requirements_params)
+
+          if @subject_requirements_form.save(@course)
+            flash[:success] = I18n.t("success.saved")
+
+            redirect_to publish_provider_recruitment_cycle_course_path
+          else
+            set_backlink
+            @errors = @subject_requirements_form.errors.messages
+            render :edit
+          end
+        end
+
+      private
+
+        def course
+          @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+        end
+
+        def subject_requirements_params
+          params
+            .require(:publish_subject_requirement_form)
+            .permit(:additional_degree_subject_requirements, :degree_subject_requirements)
+        end
+
+        def set_backlink
+          @backlink = if course.degree_grade == "not_required"
+                        degrees_start_publish_provider_recruitment_cycle_course_path
+                      else
+                        degrees_grade_publish_provider_recruitment_cycle_course_path
+                      end
+        end
+
+        def redirect_to_course_details_page_if_course_is_primary
+          redirect_to publish_provider_recruitment_cycle_course_path if course.is_primary?
+        end
+      end
+    end
+  end
+end

--- a/app/forms/publish/degree_grade_form.rb
+++ b/app/forms/publish/degree_grade_form.rb
@@ -1,0 +1,20 @@
+module Publish
+  class DegreeGradeForm
+    # TODO: Refactor to use our form object pattern
+    include ActiveModel::Model
+
+    attr_accessor :grade
+
+    validates :grade, presence: { message: "Select the minimum degree classification you require" }
+
+    def save(course)
+      return false unless valid?
+
+      course.update(degree_grade: grade)
+    end
+
+    def self.build_from_course(course)
+      new(grade: course.degree_grade)
+    end
+  end
+end

--- a/app/forms/publish/degree_start_form.rb
+++ b/app/forms/publish/degree_start_form.rb
@@ -1,0 +1,41 @@
+module Publish
+  class DegreeStartForm
+    # TODO: Refactor to use our form object pattern
+    include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
+
+    attr_accessor :degree_grade_required
+
+    before_validation :cast_degree_grade_required
+
+    validates :degree_grade_required, inclusion: { in: [true, false], message: "Select if you require a minimum degree classification" }
+
+    def save(course)
+      return false unless valid? && degree_grade_required_is_false?
+
+      course.update(degree_grade: "not_required")
+    end
+
+    def build_from_course(course)
+      self.degree_grade_required = handle_degree_grade_required(course)
+    end
+
+  private
+
+    def cast_degree_grade_required
+      self.degree_grade_required = ActiveModel::Type::Boolean.new.cast(degree_grade_required)
+    end
+
+    def degree_grade_required_is_false?
+      degree_grade_required == false
+    end
+
+    def handle_degree_grade_required(course)
+      if course.degree_grade == "not_required"
+        false
+      elsif course.degree_grade.present?
+        true
+      end
+    end
+  end
+end

--- a/app/forms/publish/subject_requirement_form.rb
+++ b/app/forms/publish/subject_requirement_form.rb
@@ -1,0 +1,36 @@
+module Publish
+  class SubjectRequirementForm
+    # TODO: Refactor to use our form object pattern
+    include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
+
+    attr_accessor :additional_degree_subject_requirements, :degree_subject_requirements
+
+    before_validation :cast_additional_degree_subject_requirements
+
+    validates :additional_degree_subject_requirements, inclusion: { in: [true, false], message: "Select if you have degree subject requirements" }
+    validates :degree_subject_requirements, presence: { message: "Enter details of degree subject requirements" }, if: -> { additional_degree_subject_requirements }
+
+    def save(course)
+      return false unless valid?
+
+      course.update(
+        additional_degree_subject_requirements: additional_degree_subject_requirements,
+        degree_subject_requirements: additional_degree_subject_requirements.present? ? degree_subject_requirements : nil,
+      )
+    end
+
+    def self.build_from_course(course)
+      new(
+        additional_degree_subject_requirements: course.additional_degree_subject_requirements,
+        degree_subject_requirements: course.degree_subject_requirements,
+      )
+    end
+
+  private
+
+    def cast_additional_degree_subject_requirements
+      self.additional_degree_subject_requirements = ActiveModel::Type::Boolean.new.cast(additional_degree_subject_requirements)
+    end
+  end
+end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -545,6 +545,14 @@ class Course < ApplicationRecord
     level == "further_education"
   end
 
+  def degree_section_complete?
+    degree_grade.present?
+  end
+
+  def is_primary?
+    level == "primary"
+  end
+
   def is_uni_or_scitt?
     provider.accredited_body?
   end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -127,7 +127,7 @@
       (render DegreeRowContentComponent::View.new(course: course, errors: @errors)),
       %w[degree_grade degree_subject_requirements],
       truncate_value: false,
-      action_path: nil, #course.degree_section_complete? ? degrees_start_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      action_path: course.degree_section_complete? ? degrees_start_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
       action_visually_hidden_text: "degree",
     ) %>
 

--- a/app/views/publish/courses/degrees/grade/edit.html.erb
+++ b/app/views/publish/courses/degrees/grade/edit.html.erb
@@ -1,0 +1,30 @@
+<% page_title = "What is the minimum degree classification you require?" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @grade_form.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(degrees_start_publish_provider_recruitment_cycle_course_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @grade_form, url: degrees_grade_publish_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :grade, caption: { text: @course.name_and_code, size: "l" }, legend: { text: page_title, size: "l", tag: "h1" } do %>
+        <%= f.govuk_radio_button :grade, "two_one", label: { text: "2:1 or above (or equivalent)" }, data: { qa: "degree_grade__two_one" }, link_errors: true %>
+        <%= f.govuk_radio_button :grade, "two_two", label: { text: "2:2 or above (or equivalent)" }, data: { qa: "degree_grade__two_two" } %>
+        <%= f.govuk_radio_button :grade, "third_class", label: { text: "Third or above (or equivalent)" }, data: { qa: "degree_grade__third_class" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Save", data: { qa: "degree_grade__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/degrees/start/edit.html.erb
+++ b/app/views/publish/courses/degrees/start/edit.html.erb
@@ -1,0 +1,30 @@
+<% page_title = "Do you require a minimum degree classification?" %>
+
+<% content_for :page_title, title_with_error_prefix(page_title, @start_form.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @start_form, url: degrees_start_publish_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <%= f.govuk_radio_buttons_fieldset :degree_grade_required, legend: { text: page_title, size: "l", tag: "h1" }, hint: { text: "If you specify a minimum (for example, 2:1), candidates will be discouraged but not blocked from applying if they do not meet this level." } do %>
+        <%= f.govuk_radio_button :degree_grade_required, true, label: { text: "Yes" }, data: { qa: "start__yes_radio" }, link_errors: true %>
+        <%= f.govuk_radio_button :degree_grade_required, false, label: { text: "No" }, data: { qa: "start__no_radio" } %>
+      <% end %>
+
+      <%= f.govuk_submit "Save", data: { qa: "start__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
+++ b/app/views/publish/courses/degrees/subject_requirements/edit.html.erb
@@ -1,0 +1,42 @@
+<% page_title = "Degree subject" %>
+<% content_for :page_title, title_with_error_prefix(page_title, @subject_requirements_form.errors.present?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to @backlink %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @subject_requirements_form, url: degrees_subject_requirements_publish_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+        <%= page_title %>
+      </h1>
+
+      <p class="govuk-body">Candidates will be advised that their degree subject should match or be closely related to <%= @course.name %>.</p>
+
+      <%= f.govuk_radio_buttons_fieldset :additional_degree_subject_requirements, legend: { text: "Do you have any additional degree subject requirements?" } do %>
+        <%= f.govuk_radio_button :additional_degree_subject_requirements, false, label: { text: "No" }, data: { qa: "degree_subject_requirements__no_radio" }, link_errors: true %>
+        <%= f.govuk_radio_button :additional_degree_subject_requirements, true, label: { text: "Yes" }, data: { qa: "degree_subject_requirements__yes_radio" } do %>
+          <%= f.govuk_text_area :degree_subject_requirements,
+            form_group: { id: "degree-subject-requirements" },
+            label: { text: "Degree subject requirements" }, 
+            data: { qa: "degree_subject_requirements__requirements" } 
+          %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit "Save", data: { qa: "degree_subject_requirements__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,14 @@ Rails.application.routes.draw do
           put "/locations", on: :member, to: "courses/sites#update"
 
           get "/preview", on: :member, to: "courses#preview"
+          get "/degrees/start", on: :member, to: "courses/degrees/start#edit"
+          put "/degrees/start", on: :member, to: "courses/degrees/start#update"
+
+          get "/degrees/grade", on: :member, to: "courses/degrees/grade#edit"
+          put "/degrees/grade", on: :member, to: "courses/degrees/grade#update"
+
+          get "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#edit"
+          put "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#update"
         end
 
         scope module: :providers do

--- a/spec/components/degree_row_content_component/view_preview.rb
+++ b/spec/components/degree_row_content_component/view_preview.rb
@@ -11,8 +11,8 @@ module DegreeRowContentComponent
       "two_one",
     ].each do |degree_grade|
       define_method "degree_grade_is_#{degree_grade || 'nil'}" do
-        provider = Provider.new(provider_code: "BAT")
-        course = Course.new(degree_grade: degree_grade, provider: provider)
+        provider = Provider.new(provider_code: "BAT", recruitment_cycle: RecruitmentCycle.current)
+        course = Course.new(degree_grade: degree_grade, provider: provider, course_code: "2KT")
 
         render(DegreeRowContentComponent::View.new(course: course.decorate))
       end

--- a/spec/components/degree_row_content_component/view_spec.rb
+++ b/spec/components/degree_row_content_component/view_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module DegreeRowContentComponent
   describe View, type: :component do
+    include Rails.application.routes.url_helpers
+
     let(:recruitment_cycle) { build(:recruitment_cycle) }
     let(:provider) { build(:provider, recruitment_cycle: recruitment_cycle) }
     let(:course) do
@@ -19,13 +21,13 @@ module DegreeRowContentComponent
       render_inline(described_class.new(course: course.decorate))
     end
 
-    context "when the degree section is incomplete", skip: true do
+    context "when the degree section is incomplete" do
       let(:degree_grade) { nil }
 
       it "renders a link to the degree section" do
         expect(page).to have_link(
           "Enter degree requirements",
-          href: Rails.application.routes.url_helpers.degrees_start_provider_recruitment_cycle_course_path(
+          href: degrees_start_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
             provider.recruitment_cycle.year,
             course.course_code,

--- a/spec/features/publish/courses/editing_degree_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_degree_requirements_spec.rb
@@ -1,0 +1,197 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing degree requirements" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "requires minimum degree classification" do
+    and_there_is_a_course_i_want_to_edit
+    when_i_visit_the_degrees_start_page
+    and_i_require_a_classification
+    then_i_should_see_the_degree_grade_page
+    when_i_set_a_required_grade
+    then_i_should_see_the_subject_requirements_page
+    when_i_set_additional_requirements
+    then_i_should_see_a_success_message
+    and_the_required_grade_is_updated_with("two_one")
+    and_the_additional_requirements_are_updated
+  end
+
+  scenario "does not require minimum degree classification" do
+    and_there_is_a_course_i_want_to_edit
+    when_i_visit_the_degrees_start_page
+    and_i_do_not_require_a_classification
+    then_i_should_see_the_subject_requirements_page
+    when_i_set_additional_requirements
+    then_i_should_see_a_success_message
+    and_the_required_grade_is_updated_with("not_required")
+    and_the_additional_requirements_are_updated
+  end
+
+  context "primary course" do
+    scenario "requires minimum degree classification" do
+      and_there_is_a_primary_course_i_want_to_edit
+      when_i_visit_the_degrees_start_page
+      and_i_require_a_classification
+      then_i_should_see_the_degree_grade_page
+      when_i_set_a_required_grade
+      then_i_should_see_a_success_message
+      and_the_required_grade_is_updated_with("two_one")
+    end
+
+    scenario "does not require minimum degree classification" do
+      and_there_is_a_primary_course_i_want_to_edit
+      when_i_visit_the_degrees_start_page
+      and_i_do_not_require_a_classification
+      then_i_should_see_a_success_message
+      and_the_required_grade_is_updated_with("not_required")
+    end
+  end
+
+  context "start page" do
+    scenario "pre-populates selected degree classification" do
+      and_there_is_a_course_i_want_to_edit
+      when_i_visit_the_degrees_start_page
+      then_the_start_page_should_show_the_selected_classification
+    end
+
+    scenario "updating with invalid data" do
+      given_a_course_exists(:secondary, degree_grade: nil)
+      when_i_visit_the_degrees_start_page
+      and_i_submit
+      then_i_should_see_an_error_message("Select if you require a minimum degree classification")
+    end
+  end
+
+  context "grade page" do
+    scenario "pre-populates selected grade classification" do
+      and_there_is_a_course_i_want_to_edit
+      when_i_visit_the_degrees_grade_page
+      then_the_grade_page_should_show_the_selected_grade
+    end
+
+    scenario "updating with invalid data" do
+      given_a_course_exists(:secondary, degree_grade: nil)
+      when_i_visit_the_degrees_grade_page
+      and_i_submit
+      then_i_should_see_an_error_message("Select the minimum degree classification you require")
+    end
+  end
+
+  context "subject requirements page" do
+    scenario "pre-populates additional subject requirements" do
+      given_a_course_exists(:secondary, degree_subject_requirements: "Maths A Level")
+      when_i_visit_the_degrees_subject_requirements_page
+      then_the_subject_requirements_page_should_show_the_requirements
+    end
+
+    scenario "updating with invalid data" do
+      given_a_course_exists(:secondary, degree_subject_requirements: nil)
+      when_i_visit_the_degrees_subject_requirements_page
+      and_i_submit
+      then_i_should_see_an_error_message("Enter details of degree subject requirements")
+    end
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_edit
+    given_a_course_exists(:secondary)
+  end
+
+  def and_there_is_a_primary_course_i_want_to_edit
+    given_a_course_exists(:primary)
+  end
+
+  def when_i_visit_the_degrees_start_page
+    publish_degree_start_page.load(route_data)
+  end
+
+  def when_i_visit_the_degrees_grade_page
+    publish_degree_grade_page.load(route_data)
+  end
+
+  def when_i_visit_the_degrees_subject_requirements_page
+    publish_degree_subject_requirement_page.load(route_data)
+  end
+
+  def and_i_require_a_classification
+    publish_degree_start_page.yes_radio.choose
+    and_i_submit
+  end
+
+  def and_i_do_not_require_a_classification
+    publish_degree_start_page.no_radio.choose
+    and_i_submit
+  end
+
+  def then_i_should_see_the_degree_grade_page
+    expect(publish_degree_grade_page).to be_displayed
+  end
+
+  def when_i_set_a_required_grade
+    publish_degree_grade_page.two_one.choose
+    and_i_submit
+  end
+
+  def then_i_should_see_the_subject_requirements_page
+    expect(publish_degree_subject_requirement_page).to be_displayed
+  end
+
+  def when_i_set_additional_requirements
+    @some_additional_requiremet = "Some additional requirement"
+
+    publish_degree_subject_requirement_page.yes_radio.choose
+    publish_degree_subject_requirement_page.requirements.set(@some_additional_requiremet)
+    and_i_submit
+  end
+
+  def and_i_submit
+    publish_course_requirements_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content(I18n.t("success.saved"))
+  end
+
+  def and_the_additional_requirements_are_updated
+    course.reload
+
+    expect(course.additional_degree_subject_requirements).to be(true)
+    expect(course.degree_subject_requirements).to eq(@some_additional_requiremet)
+  end
+
+  def and_the_required_grade_is_updated_with(grade)
+    expect(course.reload.degree_grade).to eq(grade)
+  end
+
+  def then_the_start_page_should_show_the_selected_classification
+    expect(publish_degree_start_page.yes_radio).to be_checked
+  end
+
+  def then_the_grade_page_should_show_the_selected_grade
+    expect(publish_degree_grade_page.two_one).to be_checked
+  end
+
+  def then_the_subject_requirements_page_should_show_the_requirements
+    expect(publish_degree_subject_requirement_page.yes_radio).to be_checked
+    expect(publish_degree_subject_requirement_page.requirements.value).to eq("Maths A Level")
+  end
+
+  def then_i_should_see_an_error_message(message)
+    expect(publish_course_requirements_page.error_messages).to include(message)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def route_data
+    { provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code }
+  end
+end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2604,4 +2604,40 @@ describe Course, type: :model do
       expect(course.provider.changed_at).to eq(Time.zone.now)
     end
   end
+
+  describe "#degree_section_complete?" do
+    context "when degree_grade is set" do
+      subject { build(:course, degree_grade: "two_one") }
+
+      it "returns true" do
+        expect(subject.degree_section_complete?).to be(true)
+      end
+    end
+
+    context "when degree_grade is nil" do
+      subject { build(:course, degree_grade: nil) }
+
+      it "returns false" do
+        expect(subject.degree_section_complete?).to be(false)
+      end
+    end
+  end
+
+  describe "#is_primary?" do
+    context "when course is primary" do
+      subject { build(:course, level: :primary) }
+
+      it "returns true" do
+        expect(subject.is_primary?).to be(true)
+      end
+    end
+
+    context "when degree_grade is nil" do
+      subject { build(:course, level: :secondary) }
+
+      it "returns false" do
+        expect(subject.is_primary?).to be(false)
+      end
+    end
+  end
 end

--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2632,7 +2632,7 @@ describe Course, type: :model do
       end
     end
 
-    context "when degree_grade is nil" do
+    context "when course is not primary" do
       subject { build(:course, level: :secondary) }
 
       it "returns false" do

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -131,5 +131,17 @@ module FeatureHelpers
     def publish_course_preview_page
       @publish_course_preview_page ||= PageObjects::Publish::CoursePreview.new
     end
+
+    def publish_degree_start_page
+      @publish_degree_start_page ||= PageObjects::Publish::DegreeStart.new
+    end
+
+    def publish_degree_grade_page
+      @publish_degree_grade_page ||= PageObjects::Publish::DegreeGrade.new
+    end
+
+    def publish_degree_subject_requirement_page
+      @publish_degree_subject_requirement_page ||= PageObjects::Publish::DegreeSubjectRequirement.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/degree_grade.rb
+++ b/spec/support/page_objects/publish/degree_grade.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class DegreeGrade < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/degrees/grade"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :two_one, '[data-qa="degree_grade__two_one"]'
+      element :two_two, '[data-qa="degree_grade__two_two"]'
+      element :third_class, '[data-qa="degree_grade__third_class"]'
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/degree_start.rb
+++ b/spec/support/page_objects/publish/degree_start.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class DegreeStart < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/degrees/start"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :yes_radio, '[data-qa="start__yes_radio"]'
+      element :no_radio, '[data-qa="start__no_radio"]'
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/degree_subject_requirement.rb
+++ b/spec/support/page_objects/publish/degree_subject_requirement.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class DegreeSubjectRequirement < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/degrees/subject-requirements"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :yes_radio, '[data-qa="degree_subject_requirements__yes_radio"]'
+      element :no_radio, '[data-qa="degree_subject_requirements__no_radio"]'
+      element :requirements, '[data-qa="degree_subject_requirements__requirements"]'
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/cEGtwmt0/596-migrate-courses-course-show-page-edit-requirements-eligibility-degree

### Changes proposed in this pull request

- Port over the degree editing logic within the course show page
- Increase test coverage for this flow

### Tech notes

The form objects need to be refactored to follow our pattern. Some of the controller redirect logic can be simplified after cleaning up the forms. As this is mostly a lift and shift from old publish have marked these as TODOs.

### Guidance to review

Original implementation here: https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2022/courses/AK12/degrees/start

migrated version: https://teacher-training-api-pr-2553.london.cloudapps.digital/publish/organisations/2AT/2022/courses/AK12 (click change)

Check:

You can update the degree requirements with:

- classification required
- classification not required
- either of the above with additional requirements set

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
