### PR TITLE
[754] Check for new and not running ucas_status when discarding

### DIFF
--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -10,7 +10,7 @@ class Course < ApplicationRecord
   after_initialize :set_defaults
 
   before_discard do
-    raise "You cannot delete the running course #{self}" unless ucas_status == :new
+    raise "You cannot delete the running course #{self}" unless %i[new not_running].include?(ucas_status)
   end
 
   has_associated_audits


### PR DESCRIPTION
### Context

- https://trello.com/c/fHcLxzsC/754-remove-organisation

We've got a couple of orgs which need to be deleted in prod but fail to be discarded as the logic is only checking `ucas_status` is new. 

### Changes proposed in this pull request

Updating logic to also check for `ucas_status == :not_running` so orgs who wish to be deleted and have no running courses can.

### Guidance to review

Tested with the latest prod dump locally on the orgs who couldn't be removed in prod.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
