### PR TITLE
[620] Port over study mode editing

### DIFF
--- a/app/controllers/publish/courses/study_mode_controller.rb
+++ b/app/controllers/publish/courses/study_mode_controller.rb
@@ -3,7 +3,40 @@ module Publish
     class StudyModeController < PublishController
       include CourseBasicDetailConcern
 
+      def edit
+        authorize(provider)
+
+        @course_study_mode_form = CourseStudyModeForm.new(@course)
+      end
+
+      def update
+        authorize(provider)
+
+        @course_study_mode_form = CourseStudyModeForm.new(@course, params: study_mode_params)
+        if @course_study_mode_form.save!
+          flash[:success] = I18n.t("success.saved")
+
+          redirect_to details_publish_provider_recruitment_cycle_course_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+            course.course_code,
+          )
+        else
+          render :edit
+        end
+      end
+
     private
+
+      def build_course
+        @course = provider.courses.find_by!(course_code: params[:code])
+      end
+
+      def study_mode_params
+        return { study_mode: nil } if params[:publish_course_study_mode_form].blank?
+
+        params.require(:publish_course_study_mode_form).permit(*CourseStudyModeForm::FIELDS)
+      end
 
       def current_step
         :full_or_part_time

--- a/app/forms/publish/course_study_mode_form.rb
+++ b/app/forms/publish/course_study_mode_form.rb
@@ -1,0 +1,19 @@
+module Publish
+  class CourseStudyModeForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[study_mode].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :study_mode,
+              presence: true,
+              inclusion: { in: Course.study_modes.keys }
+
+  private
+
+    def compute_fields
+      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+  end
+end

--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -4,7 +4,7 @@ module Publish
 
     included do
       decorates_assigned :course
-      before_action :build_new_course, :build_provider, only: %i[back new continue]
+      before_action :build_new_course, only: %i[back new continue]
       before_action :build_previous_course_creation_params, only: %i[new continue]
       before_action :build_meta_course_creation_params, only: %i[new continue]
       before_action :build_back_link, only: %i[new back continue]
@@ -26,7 +26,7 @@ module Publish
       if @course.update(course_params)
         flash[:success] = I18n.t("success.saved")
         redirect_to(
-          details_provider_recruitment_cycle_course_path(
+          details_publish_provider_recruitment_cycle_course_path(
             @course.provider_code,
             @course.recruitment_cycle_year,
             @course.course_code,
@@ -67,18 +67,6 @@ module Publish
 
     def error_keys
       []
-    end
-
-    def build_provider
-      @provider = RecruitmentCycle.find_by(year: params[:recruitment_cycle_year]).providers.find_by(provider_code: params[:provider_code])
-    end
-
-    def build_course
-      @course = Course
-        .where(recruitment_cycle_year: params[:recruitment_cycle_year])
-        .where(provider_code: params[:provider_code])
-        .find(params[:code])
-        .first
     end
 
     def course_params

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -83,8 +83,8 @@
         <% row.key { "Full or part time" } %>
         <% row.value { course.study_mode&.humanize } %>
         <% row.action({
-          # href: full_part_time_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-          # visually_hidden_text: "if full or part time",
+          href: full_part_time_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          visually_hidden_text: "if full or part time",
         }) %>
       <% end %>
 

--- a/app/views/publish/courses/study_mode/edit.html.erb
+++ b/app/views/publish/courses/study_mode/edit.html.erb
@@ -1,21 +1,40 @@
-<% content_for :page_title, title_with_error_prefix("Full time or part time? – #{course.name_and_code}", course.errors.any?) %>
+<% content_for :page_title, title_with_error_prefix("Full time or part time? – #{course.name_and_code}", @course_study_mode_form.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(details_publish_provider_recruitment_cycle_course_path(
+    course.provider_code, 
+    course.recruitment_cycle_year, 
+    course.course_code)
+  ) %>
 <% end %>
-
-<%= render "publish/shared/errors" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with model: course,
-                  url: full_part_time_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
-                  method: :put do |form| %>
+    <%= form_with(
+      model: @course_study_mode_form,
+      url: full_part_time_publish_provider_recruitment_cycle_course_path(
+        course.provider_code, 
+        course.recruitment_cycle_year, 
+        course.course_code,
+      ),
+      method: :put,
+      local: true
+    ) do |f| %>
 
-      <%= render "form_fields", form: form %>
+      <%= f.govuk_error_summary %>
 
-      <%= form.submit course.is_running? ? "Save and publish changes" : "Save",
-        class: "govuk-button", data: { qa: "course__save" } %>
+      <%= f.govuk_radio_buttons_fieldset(:study_mode, legend: { text: "Full time or part time?", tag: "h1", size: "l" }) do %>
+        <% course.edit_course_options["study_modes"].each_with_index do |study_mode, index| %>
+          <%= f.govuk_radio_button(
+            :study_mode,
+            study_mode,
+            label: { text: t("edit_options.study_modes.#{study_mode}.label") },
+            link_errors: index.zero?,
+          ) %>
+        <% end %>
+      <% end %>
+
+      <%= f.govuk_submit course.is_running? ? "Save and publish changes" : "Save" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -365,6 +365,10 @@ en:
               too_long: "Reduce the word count for personal qualities"
             other_requirements:
               too_long: "Reduce the word count for other requirements"
+        publish/course_study_mode_form:
+          attributes:
+            study_mode:
+              blank: "Pick full time, part time or full time and part time"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -118,6 +118,10 @@ Rails.application.routes.draw do
           put "/locations", on: :member, to: "courses/sites#update"
 
           get "/preview", on: :member, to: "courses#preview"
+
+          get "/full-part-time", on: :member, to: "courses/study_mode#edit"
+          put "/full-part-time", on: :member, to: "courses/study_mode#update"
+
           get "/degrees/start", on: :member, to: "courses/degrees/start#edit"
           put "/degrees/start", on: :member, to: "courses/degrees/start#update"
 

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing course study mode" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "i can update the course study mode" do
+    and_there_is_a_part_time_course_i_want_to_edit
+    when_i_visit_the_course_study_mode_page
+    and_i_choose_a_full_time_study_mode
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_study_mode_is_updated
+  end
+
+  scenario "updating with invalid data" do
+    and_there_is_a_course_with_no_study_mode
+    when_i_visit_the_course_study_mode_page
+    and_i_submit
+    then_i_should_see_an_error_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_part_time_course_i_want_to_edit
+    given_a_course_exists(study_mode: :part_time)
+  end
+
+  def and_there_is_a_course_with_no_study_mode
+    given_a_course_exists
+    @course.update_column(:study_mode, nil)
+  end
+
+  def when_i_visit_the_course_study_mode_page
+    publish_course_study_mode_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_choose_a_full_time_study_mode
+    publish_course_study_mode_page.full_time.choose
+  end
+
+  def and_i_submit
+    publish_course_study_mode_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content(I18n.t("success.saved"))
+  end
+
+  def and_the_course_study_mode_is_updated
+    expect(course.reload).to be_full_time
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_study_mode_page.error_messages).to include(
+       I18n.t("activemodel.errors.models.publish/course_study_mode_form.attributes.study_mode.blank"),
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -143,5 +143,9 @@ module FeatureHelpers
     def publish_degree_subject_requirement_page
       @publish_degree_subject_requirement_page ||= PageObjects::Publish::DegreeSubjectRequirement.new
     end
+
+    def publish_course_study_mode_page
+      @publish_course_study_mode_page ||= PageObjects::Publish::CourseStudyModeEdit.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/course_study_mode_edit.rb
+++ b/spec/support/page_objects/publish/course_study_mode_edit.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class CourseStudyModeEdit < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/full-part-time"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :full_time, "#publish-course-study-mode-form-study-mode-full-time-field"
+      element :part_time, "#publish-course-study-mode-form-study-mode-part-time-field"
+      element :full_or_part_time, "#publish-course-study-mode-form-study-mode-full-time-or-part-time-field"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/9Ecv3g2w/620-migrate-courses-course-show-page-updating-study-mode

### Changes proposed in this pull request

- Port over editing the study mode from the course details tab
- Fix up errors not linking by refactoring to govuk form builder and our form object pattern

### Guidance to review

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
