### PR TITLE
[0597] Migrate  GCSEs and equivalency tests 

### DIFF
--- a/app/components/gcse_preview_component/view.html.erb
+++ b/app/components/gcse_preview_component/view.html.erb
@@ -17,12 +17,12 @@
 <% else %>
   <%= govuk_inset_text(classes: "app-inset-text--important") do %>
     <p class="govuk-body">
-      Please add details <%= govuk_link_to "about GCSE requirements", "#"
-        # gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(
-        #   course.provider.provider_code,
-        #   course.provider.recruitment_cycle_year,
-        #   course.course_code,
-        # ) 
+      Please add details <%= govuk_link_to "about GCSE requirements",
+        gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(
+          course.provider.provider_code,
+          course.provider.recruitment_cycle_year,
+          course.course_code,
+        ) 
         %>.
     </p>
   <% end %>

--- a/app/components/gcse_row_content_component/view.html.erb
+++ b/app/components/gcse_row_content_component/view.html.erb
@@ -15,12 +15,12 @@
   <%= govuk_inset_text(classes: inset_text_css_classes) do %>
     <p class="govuk-heading-s app-inset-text__title">GCSE and equivalency tests</p>
     <p class="govuk-body">
-      <%= govuk_link_to "Enter GCSE and equivalency test requirements", "#"
-        # gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(
-        #   course.provider.provider_code,
-        #   course.provider.recruitment_cycle_year,
-        #   course.course_code,
-        # ) 
+      <%= govuk_link_to "Enter GCSE and equivalency test requirements", 
+        gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(
+          course.provider.provider_code,
+          course.provider.recruitment_cycle_year,
+          course.course_code,
+        )
         %>
     </p>
   <% end %>

--- a/app/controllers/publish/courses/gcse_requirements_controller.rb
+++ b/app/controllers/publish/courses/gcse_requirements_controller.rb
@@ -1,0 +1,72 @@
+module Publish
+  module Courses
+    class GcseRequirementsController < PublishController
+      def edit
+        authorize(provider)
+
+        if params[:copy_from].present?
+          @copied_fields = Courses::Copy.get_present_fields_in_source_course(Courses::Copy::GCSE_FIELDS, @source_course, course)
+        end
+
+        @gcse_requirements_form = GcseRequirementsForm.build_from_course(course)
+      end
+
+      def update
+        authorize(provider)
+
+        @gcse_requirements_form = GcseRequirementsForm.new(**gcse_requirements_form_params.merge(level: course.level))
+
+        if @gcse_requirements_form.save(course)
+          flash[:success] = I18n.t("success.saved")
+
+          redirect_to publish_provider_recruitment_cycle_course_path
+        else
+          @errors = @gcse_requirements_form.errors.messages
+          render :edit
+        end
+      end
+
+    private
+
+      def course
+        @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+      end
+
+      def translatable_params
+        %i[accept_pending_gcse
+           accept_gcse_equivalency
+           accept_english_gcse_equivalency
+           accept_maths_gcse_equivalency
+           accept_science_gcse_equivalency]
+      end
+
+      def gcse_requirements_form_params
+        translatable_params.index_with do |key|
+          translate_params(publish_gcse_requirements_form_params[key])
+        end.merge(additional_gcse_equivalencies: helpers.raw(publish_gcse_requirements_form_params[:additional_gcse_equivalencies]))
+      end
+
+      def publish_gcse_requirements_form_params
+        @publish_gcse_requirements_form_params ||= params.require(:publish_gcse_requirements_form).permit(
+          :accept_pending_gcse,
+          :accept_english_gcse_equivalency,
+          :accept_gcse_equivalency,
+          { accept_english_gcse_equivalency: [] },
+          { accept_maths_gcse_equivalency: [] },
+          { accept_science_gcse_equivalency: [] },
+          :additional_gcse_equivalencies,
+        )
+      end
+
+      def translate_params(value)
+        return if value.blank?
+
+        if value.is_a?(Array)
+          (%w[Maths English Science] & value).present?
+        else
+          value == "true"
+        end
+      end
+    end
+  end
+end

--- a/app/forms/publish/gcse_requirements_form.rb
+++ b/app/forms/publish/gcse_requirements_form.rb
@@ -1,0 +1,63 @@
+module Publish
+  class GcseRequirementsForm
+    include ActiveModel::Model
+    include ActiveModel::Validations::Callbacks
+
+    attr_accessor :accept_pending_gcse, :accept_gcse_equivalency, :accept_english_gcse_equivalency,
+                  :accept_maths_gcse_equivalency, :accept_science_gcse_equivalency, :additional_gcse_equivalencies, :level
+
+    validates :accept_pending_gcse, inclusion: { in: [true, false], message: "Select if you consider candidates with pending GCSEs" }
+    validates :accept_gcse_equivalency, inclusion: { in: [true, false], message: "Select if you consider candidates with pending equivalency tests" }
+    validate :primary_or_secondary_equivalency_details_not_given, if: -> { equivalencies_not_selected? }
+    validates :additional_gcse_equivalencies, presence: { message: "Enter details about equivalency tests" }, if: -> { equivalencies_not_selected? }
+    validates :additional_gcse_equivalencies, words_count: { maximum: 200 }
+
+    def save(course)
+      return false unless valid?
+
+      set_equivalency_values_to_false unless accept_gcse_equivalency
+
+      course.update(
+        accept_pending_gcse: accept_pending_gcse,
+        accept_gcse_equivalency: accept_gcse_equivalency,
+        accept_english_gcse_equivalency: accept_english_gcse_equivalency,
+        accept_maths_gcse_equivalency: accept_maths_gcse_equivalency,
+        accept_science_gcse_equivalency: accept_science_gcse_equivalency,
+        additional_gcse_equivalencies: additional_gcse_equivalencies,
+      )
+    end
+
+    def self.build_from_course(course)
+      new(
+        accept_pending_gcse: course.accept_pending_gcse,
+        accept_gcse_equivalency: course.accept_gcse_equivalency,
+        accept_english_gcse_equivalency: course.accept_english_gcse_equivalency,
+        accept_maths_gcse_equivalency: course.accept_maths_gcse_equivalency,
+        accept_science_gcse_equivalency: course.accept_science_gcse_equivalency,
+        additional_gcse_equivalencies: course.additional_gcse_equivalencies,
+        level: course.level,
+      )
+    end
+
+  private
+
+    def primary_or_secondary_equivalency_details_not_given
+      if level == "primary"
+        errors.add(:equivalencies, "Select if you accept equivalency tests in English, maths or science")
+      else
+        errors.add(:equivalencies, "Select if you accept equivalency tests in English or maths")
+      end
+    end
+
+    def equivalencies_not_selected?
+      accept_gcse_equivalency.present? && accept_english_gcse_equivalency.blank? && accept_maths_gcse_equivalency.blank? && accept_science_gcse_equivalency.blank?
+    end
+
+    def set_equivalency_values_to_false
+      self.accept_english_gcse_equivalency = false
+      self.accept_maths_gcse_equivalency = false
+      self.accept_science_gcse_equivalency = false
+      self.additional_gcse_equivalencies = nil
+    end
+  end
+end

--- a/app/views/publish/courses/_description_content.html.erb
+++ b/app/views/publish/courses/_description_content.html.erb
@@ -138,7 +138,7 @@
       (render GcseRowContentComponent::View.new(course: course, errors: @errors)),
       %w[accept_pending_gcse accept_gcse_equivalency accept_english_gcse_equivalency accept_maths_gcse_equivalency accept_science_gcse_equivalency additional_gcse_equivalencies],
       truncate_value: false,
-      action_path: nil, #course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
+      action_path: course.gcse_section_complete? ? gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year, course.course_code) : nil,
       action_visually_hidden_text: "GCSEs",
     ) %>
   

--- a/app/views/publish/courses/gcse_requirements/edit.html.erb
+++ b/app/views/publish/courses/gcse_requirements/edit.html.erb
@@ -1,0 +1,63 @@
+<% content_for :page_title, title_with_error_prefix("GCSEs and equivalency tests", @errors && @errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code)) %>
+<% end %>
+
+<%# if params[:copy_from].present? %>
+  <%#= render partial: "courses/copy_content_warning", locals: { copied_fields: @copied_fields } %>
+<%# end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+
+    <%= form_with(
+      model: @gcse_requirements_form, url:
+      gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(
+        @course.provider.provider_code,
+        @course.provider.recruitment_cycle_year,
+        @course.course_code,
+      ),
+      method: :put,
+      builder: GOVUKDesignSystemFormBuilder::FormBuilder
+    ) do |f| %>
+
+    <%= f.govuk_error_summary %>
+
+    <h1 class="govuk-heading-l">
+      <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+      GCSEs and equivalency tests
+    </h1>
+
+      <%= f.govuk_radio_buttons_fieldset :accept_pending_gcse, legend: { text: "Will you consider candidates with pending GCSEs?", size: "m" }, hint: { text: "These are candidates who expect to have the qualification before the beginning of the course. You can give them an offer, on the condition that they pass their GCSEs." } do %>
+        <%= f.govuk_radio_button :accept_pending_gcse, true, label: { text: "Yes" }, data: { qa: "gcse_requirements__pending_gcse_yes_radio" }, link_errors: true %>
+        <%= f.govuk_radio_button :accept_pending_gcse, false, label: { text: "No" }, data: { qa: "gcse_requirements__pending_gcse_no_radio" } %>
+      <% end %>
+
+      <%= f.govuk_radio_buttons_fieldset :accept_gcse_equivalency, legend: { text: "Will you consider candidates who need to take an equivalency test in English, maths or science?", size: "m" } do %>
+        <%= f.govuk_radio_button :accept_gcse_equivalency, true, label: { text: "Yes" }, data: { qa: "gcse_requirements__gcse_equivalency_yes_radio" }, link_errors: true do %>
+          <%= f.govuk_fieldset legend: { text: "Which subjects will you accept equivalency tests in?", size: "s" } do %>
+            <%= f.govuk_check_box :accept_english_gcse_equivalency, "English", label: { text: "English" }, data: { qa: "gcse_requirements__english_equivalency" } %>
+            <%= f.govuk_check_box :accept_maths_gcse_equivalency, "Maths", label: { text: "Maths" }, data: { qa: "gcse_requirements__maths_equivalency" } %>
+            <% if @course.primary_course? %>
+              <%= f.govuk_check_box :accept_science_gcse_equivalency, "Science", label: { text: "Science" }, data: { qa: "gcse_requirements__science_equivalency" } %>
+            <% end %>
+          <% end %>
+          <%= f.govuk_text_area :additional_gcse_equivalencies, label: { text: "Details about equivalency tests you offer or accept", size: "s" }, hint: { text: "For example, if you offer the tests or ask candidates to use a third party, and if there are any costs to pay." }, data: { qa: "gcse_requirements__additional_requirements" }, max_words: 200 %>
+        <% end %>
+        <%= f.govuk_radio_button :accept_gcse_equivalency, false, label: { text: "No" }, data: { qa: "gcse_requirements__gcse_equivalency_no_radio" } %>
+      <% end %>
+
+      <%= f.submit "Save", class: "govuk-button", data: { qa: "gcse_requirements__save" } %>
+    <% end %>
+  </div>
+  <aside class="govuk-grid-column-one-third">
+     <%# render(
+      partial: "courses/related_sidebar",
+      locals: {
+        course: @course,
+        page_path: gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(@course.provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      },
+    ) %>
+  </aside>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,9 @@ Rails.application.routes.draw do
 
           get "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#edit"
           put "/degrees/subject-requirements", on: :member, to: "courses/degrees/subject_requirements#update"
+
+          get "/gcses-pending-or-equivalency-tests", on: :member, to: "courses/gcse_requirements#edit"
+          put "/gcses-pending-or-equivalency-tests", on: :member, to: "courses/gcse_requirements#update"
         end
 
         scope module: :providers do

--- a/spec/components/gcse_row_content_component/view_preview.rb
+++ b/spec/components/gcse_row_content_component/view_preview.rb
@@ -3,7 +3,7 @@
 module GcseRowContentComponent
   class ViewPreview < ViewComponent::Preview
     def incomplete
-      course = Course.new
+      course = Course.new(course_code: "C0D3", provider: Provider.new(provider_code: "E2E", recruitment_cycle: RecruitmentCycle.new(year: "2022")))
 
       render(GcseRowContentComponent::View.new(course: course.decorate))
     end

--- a/spec/components/gcse_row_content_component/view_spec.rb
+++ b/spec/components/gcse_row_content_component/view_spec.rb
@@ -6,10 +6,8 @@ module GcseRowContentComponent
   describe View, type: :component do
     let(:provider) { build(:provider) }
 
-    context "when the gcse section is incomplete", skip: true do
+    context "when the gcse section is incomplete" do
       it "renders a link to the gcse section" do
-        Rails.application.routes.url_helpers.stub(:provider_recruitment_cycle_course_path).and_return(true)
-
         course = build(
           :course,
           provider: provider,
@@ -25,7 +23,7 @@ module GcseRowContentComponent
 
         expect(page).to have_link(
           "Enter GCSE and equivalency test requirements",
-          href: Rails.application.routes.url_helpers.gcses_pending_or_equivalency_tests_provider_recruitment_cycle_course_path(
+          href: Rails.application.routes.url_helpers.gcses_pending_or_equivalency_tests_publish_provider_recruitment_cycle_course_path(
             provider.provider_code,
             provider.recruitment_cycle.year,
             course.course_code,

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -170,6 +170,6 @@ private
   end
 
   def and_i_see_the_success_summary
-    expect(publish_provider_courses_index_page.success_summary).to have_content("Success\nYour changes have been saved.")
+    expect(publish_provider_courses_index_page.success_summary).to have_content(I18n.t("success.saved"))
   end
 end

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+feature "GCSE equivalency requirements", type: :feature do
+  scenario "a provider completes the gcse equivalency requirements section" do
+    given_i_am_authenticated(user: user_with_courses)
+    when_i_visit_the_course_gcse_requirements_page(course: course)
+
+    and_i_click_save
+    and_i_see_pending_gcse_and_equivalency_tests_errors
+    and_i_set_the_gcse_requirements
+
+    and_there_is_no_science_equivalency
+    and_i_click_save
+    and_i_see_equivalency_errors
+
+    then_i_fill_the_equivalency_requirements
+    and_i_click_save
+    and_i_am_on_the_course_page
+    and_i_see_the_success_summary
+  end
+
+  scenario "a provider views course pages with course 2 GCSE requirements" do
+    given_i_am_authenticated(user: user_with_courses)
+    when_i_visit_the_course_page(course: course2)
+    then_i_see_course_2_gcse_requirements
+  end
+
+  scenario "a provider views course pages with course 3 GCSE requirements" do
+    given_i_am_authenticated(user: user_with_courses)
+    when_i_visit_the_course_page(course: course3)
+
+    then_i_see_course_3_gcse_requirements
+  end
+
+  scenario "a provider has completed the pending GCSE & equivalency requirements and sees their answer pre-populated on the gcse requirements page" do
+    given_i_am_authenticated(user: user_with_courses)
+    when_i_visit_the_course_gcse_requirements_page(course: course3)
+
+    then_i_see_the_form_pre_populated
+  end
+
+  scenario "a provider copies gcse data from another course", skip: true do
+    course_page.load_with_course(course)
+    visit_gcse_requirements_page
+    gcse_requirements_page.copy_content.copy(course3)
+
+    [
+      "Your changes are not yet saved",
+      "Accept pending GCSE",
+      "Accept GCSE equivalency",
+      "Accept English GCSE equivalency",
+      "Accept Maths GCSE equivalency",
+      "Additional GCSE equivalencies",
+    ].each do |name|
+      expect(gcse_requirements_page.warning_message).to have_content(name)
+    end
+
+    expect(gcse_requirements_page.pending_gcse_yes_radio).to be_checked
+
+    expect(gcse_requirements_page.gcse_equivalency_yes_radio).to be_checked
+    expect(gcse_requirements_page.english_equivalency).to be_checked
+    expect(gcse_requirements_page.maths_equivalency).to be_checked
+    expect(gcse_requirements_page.additional_requirements.text).to eq course3.additional_gcse_equivalencies
+  end
+
+private
+
+  def user_with_courses
+    course = build(:course, :secondary, course_code: "XXX1", additional_gcse_equivalencies: nil)
+    course2 = build(:course, :primary, course_code: "XXX2", accept_pending_gcse: false, accept_gcse_equivalency: false, additional_gcse_equivalencies: nil)
+    course3 = build(:course, :secondary,
+                    course_code: "XXX3", accept_pending_gcse: true, accept_gcse_equivalency: true,
+                    accept_english_gcse_equivalency: true, accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: nil,
+                    additional_gcse_equivalencies: "Cycling Proficiency")
+
+    provider = build(
+      :provider, courses: [course, course2, course3]
+    )
+
+    create(
+      :user,
+      providers: [provider],
+    )
+  end
+
+  def when_i_visit_the_course_gcse_requirements_page(course:)
+    gcse_requirements_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def provider
+    @provider ||= @current_user.providers.first
+  end
+
+  def course
+    @course ||= provider.courses.find_by(course_code: "XXX1")
+  end
+
+  def course2
+    @course2 ||= provider.courses.find_by(course_code: "XXX2")
+  end
+
+  def course3
+    @course3 ||= provider.courses.find_by(course_code: "XXX3")
+  end
+
+  def when_i_visit_the_course_page(course:)
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def then_i_see_course_3_gcse_requirements
+    expect(page).to have_content("Grade 4 (C) or above in English and maths")
+    expect(page).to have_content("Candidates with pending GCSEs will be considered")
+    expect(page).to have_content("Equivalency tests will be accepted in English or maths")
+    expect(page).to have_content("Cycling Proficiency")
+  end
+
+  def then_i_see_course_2_gcse_requirements
+    expect(page).to have_content("Grade 4 (C) or above in English, maths and science")
+    expect(page).to have_content("Candidates with pending GCSEs will not be considered")
+    expect(page).to have_content("Equivalency tests will not be accepted")
+  end
+
+  def then_i_see_the_form_pre_populated
+    expect(gcse_requirements_page.pending_gcse_yes_radio).to be_checked
+    expect(gcse_requirements_page.gcse_equivalency_yes_radio).to be_checked
+    expect(gcse_requirements_page.english_equivalency).to be_checked
+    expect(gcse_requirements_page.maths_equivalency).to be_checked
+    expect(gcse_requirements_page.additional_requirements).to have_content("Cycling Proficiency")
+  end
+
+  def and_i_click_save
+    gcse_requirements_page.save.click
+  end
+
+  def and_i_see_pending_gcse_and_equivalency_tests_errors
+    expect(page).to have_content("Select if you consider candidates with pending GCSEs")
+    expect(page).to have_content("Select if you consider candidates with pending equivalency tests")
+  end
+
+  def and_i_set_the_gcse_requirements
+    gcse_requirements_page.pending_gcse_yes_radio.click
+    gcse_requirements_page.gcse_equivalency_yes_radio.click
+  end
+
+  def and_there_is_no_science_equivalency
+    expect(gcse_requirements_page).not_to have_science_equivalency
+  end
+
+  def and_i_see_equivalency_errors
+    expect(page).to have_content("Enter details about equivalency tests")
+    expect(page).to have_content("Select if you accept equivalency tests in English or maths")
+  end
+
+  def then_i_fill_the_equivalency_requirements
+    gcse_requirements_page.english_equivalency.check
+    gcse_requirements_page.maths_equivalency.check
+    gcse_requirements_page.additional_requirements.set("Cycling Proficiency")
+  end
+
+  def and_i_am_on_the_course_page
+    expect(page).to have_current_path publish_provider_recruitment_cycle_course_path(
+      provider.provider_code,
+      course.recruitment_cycle.year,
+      course.course_code,
+    )
+  end
+
+  def and_i_see_the_success_summary
+    expect(publish_provider_courses_index_page.success_summary).to have_content("Success\nYour changes have been saved.")
+  end
+end

--- a/spec/forms/publish/gcse_requirements_form_spec.rb
+++ b/spec/forms/publish/gcse_requirements_form_spec.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe GcseRequirementsForm do
+    describe "validations" do
+      it "is invalid if no value is selected for accept_pending_gcse" do
+        form = described_class.new(accept_pending_gcse: nil)
+        expect(form.valid?).to be_falsey
+      end
+
+      it "is invalid if no value is selected for accept_gcse_equivalency" do
+        form = described_class.new(accept_gcse_equivalency: nil)
+        expect(form.valid?).to be_falsey
+      end
+
+      it "is invalid if accept_gcse_equivalency is true but no value is selected for equivalencies for primary course" do
+        form = described_class.new(
+          accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
+          accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+          additional_gcse_equivalencies: nil, level: "primary"
+        )
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:equivalencies]).to be_present
+      end
+
+      it "is invalid if accept_gcse_equivalency is true but no value is selected for equivalencies for non primary course" do
+        form = described_class.new(
+          accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
+          accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+          additional_gcse_equivalencies: nil, level: "secondary"
+        )
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:equivalencies]).to be_present
+      end
+
+      it "is invalid if no value is selected for additional_gcse_equivalencies" do
+        form = described_class.new(
+          accept_gcse_equivalency: true, accept_english_gcse_equivalency: nil,
+          accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+          additional_gcse_equivalencies: nil
+        )
+        expect(form.valid?).to be_falsey
+        expect(form.errors[:additional_gcse_equivalencies]).to be_present
+      end
+    end
+
+    describe "#save" do
+      let(:course) { instance_double(Course) }
+
+      it "returns false if invalid" do
+        form = described_class.new(
+          accept_pending_gcse: nil, accept_gcse_equivalency: nil, accept_english_gcse_equivalency: nil,
+          accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+          additional_gcse_equivalencies: nil
+        )
+        expect(form.save(course)).to be false
+      end
+
+      context "all values marked as true and completed" do
+        it "returns true if valid" do
+          allow(course).to receive(:update).and_return(true)
+
+          form = described_class.new(
+            accept_pending_gcse: true, accept_gcse_equivalency: true, accept_english_gcse_equivalency: true,
+            accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: true,
+            additional_gcse_equivalencies: "Geography"
+          )
+          expect(form.save(course)).to be true
+        end
+      end
+
+      context "essential values marked as false" do
+        it "returns true if valid" do
+          allow(course).to receive(:update).and_return(true)
+
+          form = described_class.new(
+            accept_pending_gcse: false, accept_gcse_equivalency: false, accept_english_gcse_equivalency: nil,
+            accept_maths_gcse_equivalency: nil, accept_science_gcse_equivalency: nil,
+            additional_gcse_equivalencies: nil
+          )
+          expect(form.save(course)).to be true
+        end
+      end
+    end
+
+    describe "#build_from_course" do
+      it "builds a new GcseRequirementsForm and sets the attrs based on the course" do
+        course = build(
+          :course,
+          accept_pending_gcse: true, accept_gcse_equivalency: true, accept_english_gcse_equivalency: true,
+          accept_maths_gcse_equivalency: true, accept_science_gcse_equivalency: true,
+          additional_gcse_equivalencies: "Geography"
+        )
+        form = described_class.build_from_course(course)
+
+        expect(form.accept_pending_gcse).to be true
+        expect(form.accept_gcse_equivalency).to be true
+        expect(form.accept_english_gcse_equivalency).to be true
+        expect(form.accept_maths_gcse_equivalency).to be true
+        expect(form.accept_science_gcse_equivalency).to be true
+        expect(form.additional_gcse_equivalencies).to eq "Geography"
+      end
+    end
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -147,5 +147,9 @@ module FeatureHelpers
     def publish_course_study_mode_page
       @publish_course_study_mode_page ||= PageObjects::Publish::CourseStudyModeEdit.new
     end
+
+    def gcse_requirements_page
+      @gcse_requirements_page ||= PageObjects::Publish::Courses::GcseRequirementsPage.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/courses/gcse_requirements_page.rb
+++ b/spec/support/page_objects/publish/courses/gcse_requirements_page.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module Courses
+      class GcseRequirementsPage < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/gcses-pending-or-equivalency-tests{?query*}"
+
+        element :pending_gcse_yes_radio, '[data-qa="gcse_requirements__pending_gcse_yes_radio"]'
+        element :pending_gcse_no_radio, '[data-qa="gcse_requirements__pending_gcse_no_radio"]'
+
+        element :gcse_equivalency_yes_radio, '[data-qa="gcse_requirements__gcse_equivalency_yes_radio"]'
+        element :english_equivalency, '[data-qa="gcse_requirements__english_equivalency"]'
+        element :maths_equivalency, '[data-qa="gcse_requirements__maths_equivalency"]'
+        element :science_equivalency, '[data-qa="gcse_requirements__science_equivalency"]'
+        element :additional_requirements, '[data-qa="gcse_requirements__additional_requirements"]'
+        element :gcse_equivalency_no_radio, '[data-qa="gcse_requirements__gcse_equivalency_no_radio"]'
+
+        element :save, '[data-qa="gcse_requirements__save"]'
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
GCSE

### Changes proposed in this pull request
Migrated GCSE 

### Guidance to review
It works

ie
Original implementations
https://qa.publish-teacher-training-courses.service.gov.uk/organisations/D87/2022/courses/2F24/gcses-pending-or-equivalency-tests
vs
Migrated implementations
https://teacher-training-api-pr-2564.london.cloudapps.digital/publish/organisations/D87/2022/courses/2F24/gcses-pending-or-equivalency-tests


The changes is reflected on the course details page as well as the course preview page

Out of scope 
`Copy content from another course`
 
### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
