### PR TITLE
[619] Port over outcome editing for course

### DIFF
--- a/app/models/concerns/publish/course_basic_detail_concern.rb
+++ b/app/models/concerns/publish/course_basic_detail_concern.rb
@@ -17,9 +17,13 @@ module Publish
       authorize(@provider, :can_create_course?)
     end
 
-    def edit; end
+    def edit
+      authorize(provider)
+    end
 
     def update
+      authorize(provider)
+
       @errors = errors
       return render :edit if @errors.present?
 

--- a/app/views/publish/courses/_basic_details_tab.html.erb
+++ b/app/views/publish/courses/_basic_details_tab.html.erb
@@ -46,8 +46,8 @@
         <% row.key { "Outcome" } %>
         <% row.value { course.outcome } %>
         <% row.action({
-          # href: outcome_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
-          # visually_hidden_text: "outcome",
+          href: outcome_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code),
+          visually_hidden_text: "outcome",
         }) %>
       <% end %>
 

--- a/app/views/publish/courses/outcome/_form_fields.html.erb
+++ b/app/views/publish/courses/outcome/_form_fields.html.erb
@@ -1,10 +1,10 @@
 <% legend = capture do %>
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-        <h1 class="govuk-fieldset__heading">
-            <%= course_name_and_code %>
-            Pick a course outcome
-        </h1>
-    </legend>
+	<legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+		<h1 class="govuk-fieldset__heading">
+			<%= course_name_and_code %>
+			Pick a course outcome
+		</h1>
+	</legend>
 <% end %>
 
 <%= render "publish/shared/edit_options_radio_buttons",

--- a/app/views/publish/courses/outcome/edit.html.erb
+++ b/app/views/publish/courses/outcome/edit.html.erb
@@ -1,7 +1,9 @@
 <% content_for :page_title, title_with_error_prefix("Pick a course outcome – #{course.name_and_code}", course.errors.any?) %>
 
 <% content_for :before_content do %>
-  <%= govuk_back_link_to(details_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)) %>
+  <%= govuk_back_link_to(
+    details_publish_provider_recruitment_cycle_course_path(course.provider_code, course.recruitment_cycle_year, course.course_code)
+    ) %>
 <% end %>
 
 <%= render "publish/shared/errors" %>
@@ -9,7 +11,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: course,
-                  url: outcome_provider_recruitment_cycle_course_path(@course.provider_code, @course.recruitment_cycle_year, @course.course_code),
+                  url: outcome_publish_provider_recruitment_cycle_course_path(
+                    @course.provider_code, 
+                    @course.recruitment_cycle_year, 
+                    @course.course_code),
                   method: :put do |form| %>
 
       <% course_name_and_code = capture do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,9 @@ Rails.application.routes.draw do
 
           get "/preview", on: :member, to: "courses#preview"
 
+          get "/outcome", on: :member, to: "courses/outcome#edit"
+          put "/outcome", on: :member, to: "courses/outcome#update"
+
           get "/full-part-time", on: :member, to: "courses/study_mode#edit"
           put "/full-part-time", on: :member, to: "courses/study_mode#update"
 

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Editing course outcome" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "i can update the course outcome" do
+    and_there_is_a_qts_course_i_want_to_edit
+    when_i_visit_the_course_outcome_page
+    and_i_update_the_course_outcome
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_outcome_is_updated
+  end
+
+  scenario "updating with invalid data" do
+    and_there_is_a_course_with_no_outcome
+    when_i_visit_the_course_outcome_page
+    and_i_submit
+    then_i_should_see_an_error_message
+  end
+
+  context "a course offering QTS" do
+    scenario "shows the correct outcome options to choose from" do
+      and_there_is_a_qts_course_i_want_to_edit
+      when_i_visit_the_course_outcome_page
+      then_i_am_shown_the_correct_qts_options
+    end
+  end
+
+  context "a further education course not offering QTS" do
+    scenario "shows the correct outcome options to choose from" do
+      and_there_is_a_non_qts_course_i_want_to_edit
+      when_i_visit_the_course_outcome_page
+      then_i_am_shown_the_correct_non_qts_options
+    end
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_qts_course_i_want_to_edit
+    given_a_course_exists(:resulting_in_qts)
+  end
+
+  def and_there_is_a_non_qts_course_i_want_to_edit
+    given_a_course_exists(:resulting_in_pgde, level: "further_education")
+  end
+
+  def and_there_is_a_course_with_no_outcome
+    given_a_course_exists
+    # There is a NOT NULL constraint on the outcome column, so we need to set it
+    # to an out of range enum integer which will force a validation error
+    @course.update_columns(qualification: 99)
+  end
+
+  def when_i_visit_the_course_outcome_page
+    publish_course_outcome_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_update_the_course_outcome
+    publish_course_outcome_page.pgce_with_qts.choose
+  end
+
+  def and_i_submit
+    publish_course_outcome_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content(I18n.t("success.saved"))
+  end
+
+  def and_the_course_outcome_is_updated
+    expect(course.reload).to be_pgce_with_qts
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_outcome_page.error_messages).to include("Pick an outcome")
+    expect(publish_course_outcome_page).to have_selector("#qualification-error")
+  end
+
+  def then_i_am_shown_the_correct_qts_options
+    expect(publish_course_outcome_page.qualification_names).to match_array(
+      ["QTS", "PGCE with QTS", "PGDE with QTS"],
+    )
+  end
+
+  def then_i_am_shown_the_correct_non_qts_options
+    expect(publish_course_outcome_page.qualification_names).to match_array(
+      ["PGCE only (without QTS)", "PGDE only (without QTS)"],
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+end

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -16,13 +16,6 @@ feature "Editing course outcome" do
     and_the_course_outcome_is_updated
   end
 
-  scenario "updating with invalid data" do
-    and_there_is_a_course_with_no_outcome
-    when_i_visit_the_course_outcome_page
-    and_i_submit
-    then_i_should_see_an_error_message
-  end
-
   context "a course offering QTS" do
     scenario "shows the correct outcome options to choose from" do
       and_there_is_a_qts_course_i_want_to_edit
@@ -51,13 +44,6 @@ feature "Editing course outcome" do
     given_a_course_exists(:resulting_in_pgde, level: "further_education")
   end
 
-  def and_there_is_a_course_with_no_outcome
-    given_a_course_exists
-    # There is a NOT NULL constraint on the outcome column, so we need to set it
-    # to an out of range enum integer which will force a validation error
-    @course.update_columns(qualification: 99)
-  end
-
   def when_i_visit_the_course_outcome_page
     publish_course_outcome_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
@@ -78,11 +64,6 @@ feature "Editing course outcome" do
 
   def and_the_course_outcome_is_updated
     expect(course.reload).to be_pgce_with_qts
-  end
-
-  def then_i_should_see_an_error_message
-    expect(publish_course_outcome_page.error_messages).to include("Pick an outcome")
-    expect(publish_course_outcome_page).to have_selector("#qualification-error")
   end
 
   def then_i_am_shown_the_correct_qts_options

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -148,6 +148,10 @@ module FeatureHelpers
       @publish_course_study_mode_page ||= PageObjects::Publish::CourseStudyModeEdit.new
     end
 
+    def publish_course_outcome_page
+      @publish_course_outcome_page ||= PageObjects::Publish::Courses::OutcomeEditPage.new
+    end
+
     def gcse_requirements_page
       @gcse_requirements_page ||= PageObjects::Publish::Courses::GcseRequirementsPage.new
     end

--- a/spec/support/page_objects/publish/courses/outcome_edit_page.rb
+++ b/spec/support/page_objects/publish/courses/outcome_edit_page.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/errorlink"
+require_relative "../../sections/qualification"
+
+module PageObjects
+  module Publish
+    module Courses
+      class OutcomeEditPage < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/outcome"
+
+        sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+        sections :qualifications, Sections::Qualification, ".govuk-radios__item"
+
+        element :qts, "#course_qualification_qts"
+        element :pgce_with_qts, "#course_qualification_pgce_with_qts"
+
+        element :submit, 'input.govuk-button[type="submit"]'
+
+        def error_messages
+          errors.map(&:text)
+        end
+
+        def qualification_names
+          qualifications.map { |el| el.find(".govuk-label").text }
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/sections/qualification.rb
+++ b/spec/support/page_objects/sections/qualification.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative "base"
+require "forwardable"
+
+module PageObjects
+  module Sections
+    class Qualification < PageObjects::Sections::Base
+      extend Forwardable
+
+      element :name, ".govuk-radios__label"
+      element :radio, ".govuk-radios__input"
+
+      def_delegators :radio, :checked?
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/smfqS9tO/619-migrate-courses-course-show-page-updating-outcome

### Changes proposed in this pull request

- Port over the course outcome editing flow from the course page
- Improve test coverage

### Guidance to review

Original implementation here: https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2022/courses/AK12/details (click update Outcome)

migrated version: https://teacher-training-api-pr-2566.london.cloudapps.digital/publish/organisations/2AT/2022/courses/AK12/details (click update Outcome)

Check:

You can update the course outcome.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
