### PR TITLE
[616] Port the withdrawing courses flow

### DIFF
--- a/app/controllers/publish/courses/withdrawals_controller.rb
+++ b/app/controllers/publish/courses/withdrawals_controller.rb
@@ -1,0 +1,64 @@
+module Publish
+  module Courses
+    class WithdrawalsController < PublishController
+      before_action :redirect_to_courses, if: :course_withdrawn?
+      before_action :redirect_to_courses, unless: -> { course.is_published? }
+
+      def edit
+        authorize(provider)
+
+        @course_withdrawal_form = CourseWithdrawalForm.new(course)
+      end
+
+      def update
+        authorize(provider)
+
+        @course_withdrawal_form = CourseWithdrawalForm.new(course, params: withdrawal_params)
+
+        if @course_withdrawal_form.save!
+          flash[:success] = "#{course.name} (#{course.course_code}) has been withdrawn"
+
+          redirect_to publish_provider_recruitment_cycle_courses_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+          )
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def redirect_to_courses
+        message = if course_withdrawn?
+                    "#{course.name} (#{course.course_code}) has already been withdrawn"
+                  else
+                    "Courses that have not been published should be deleted not withdrawn"
+                  end
+
+        flash[:error] = { id: "withdraw-error", message: message }
+
+        redirect_to publish_provider_recruitment_cycle_courses_path(
+          provider.provider_code,
+          course.recruitment_cycle_year,
+        )
+      end
+
+      def course
+        @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+      end
+
+      def course_withdrawn?
+        course.content_status == :withdrawn
+      end
+
+      def withdrawal_params
+        return { course_code: nil } if params[:publish_course_withdrawal_form].blank?
+
+        params
+          .require(:publish_course_withdrawal_form)
+          .permit(CourseWithdrawalForm::FIELDS)
+      end
+    end
+  end
+end

--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -7,7 +7,7 @@ module Publish
   private
 
     def provider
-      @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code])
+      @provider ||= recruitment_cycle.providers.find_by(provider_code: params[:provider_code] || params[:code])
     end
 
     def recruitment_cycle

--- a/app/controllers/publish/users_controller.rb
+++ b/app/controllers/publish/users_controller.rb
@@ -1,7 +1,8 @@
 module Publish
   class UsersController < PublishController
     def index
-      authorize(provider, :index?)
+      authorize(provider)
+
       @users = provider.users
     end
   end

--- a/app/forms/publish/course_withdrawal_form.rb
+++ b/app/forms/publish/course_withdrawal_form.rb
@@ -1,0 +1,33 @@
+module Publish
+  class CourseWithdrawalForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[
+      confirm_course_code
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validate :course_code_is_correct
+
+    def save!
+      if valid?
+        course.withdraw
+      else
+        false
+      end
+    end
+
+  private
+
+    def compute_fields
+      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def course_code_is_correct
+      return if course.course_code == confirm_course_code
+
+      errors.add(:confirm_course_code, "Enter the course code #{course.course_code} to withdraw this course")
+    end
+  end
+end

--- a/app/forms/publish/course_withdrawal_form.rb
+++ b/app/forms/publish/course_withdrawal_form.rb
@@ -27,7 +27,7 @@ module Publish
     def course_code_is_correct
       return if course.course_code == confirm_course_code
 
-      errors.add(:confirm_course_code, "Enter the course code #{course.course_code} to withdraw this course")
+      errors.add(:confirm_course_code, :invalid_code, course_code: course.course_code)
     end
   end
 end

--- a/app/views/publish/courses/_description_status_panel.html.erb
+++ b/app/views/publish/courses/_description_status_panel.html.erb
@@ -25,9 +25,7 @@
     <h3 class="govuk-heading-m">Withdraw</h3>
     <p class="govuk-body">Remove this course from Find and close applications.</p>
     <p class="govuk-body">
-      <%= govuk_link_to "Withdraw this course" %>
-
-      <%# govuk_link_to "Withdraw this course", withdraw_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__withdraw-link" } %>
+      <%= govuk_link_to "Withdraw this course", withdraw_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__withdraw-link" } %>
     </p>
   <% elsif course.new_and_not_running? %>
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">

--- a/app/views/publish/courses/withdrawals/edit.html.erb
+++ b/app/views/publish/courses/withdrawals/edit.html.erb
@@ -1,0 +1,51 @@
+<% content_for :page_title, title_with_error_prefix("Are you sure you want to withdraw #{@course.name_and_code})?", @course_withdrawal_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(
+    @course.provider_code, 
+    @course.recruitment_cycle_year, 
+    @course.course_code)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @course_withdrawal_form,
+      url: withdraw_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+      method: :patch,
+      local: true,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+        Are you sure you want to withdraw this course?
+      </h1>
+
+      <p class="govuk-body">Withdrawing this course will:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>immediately remove it from Find</li>
+        <li>close applications for it</li>
+      </ul>
+
+      <p class="govuk-body">Once you’ve withdrawn a course, you cannot publish it again this cycle.</p>
+
+      <h2 class="govuk-heading-m">Confirm withdrawal</h2>
+
+      <%= f.govuk_text_field :confirm_course_code, label: { text: "Enter the course code to confirm" }, width: 5 %>
+
+      <%= f.govuk_submit "Yes I’m sure – withdraw this course", class: "govuk-button govuk-button--warning" %>
+    <% end %>
+
+    <p class="govuk-body govuk-!-margin-top-5">
+      <%= govuk_link_to(
+        "Cancel",
+        publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+        no_visited_state: true,
+      ) %>
+    </p>
+  </div>
+</div>

--- a/app/views/publish/providers/access_requests/new.html.erb
+++ b/app/views/publish/providers/access_requests/new.html.erb
@@ -28,9 +28,9 @@
 
         <%= f.govuk_email_field :email_address, label: { text: "Email address" } %>
 
-        <%= f.govuk_text_field :organisation %>
+        <%= f.govuk_text_field :organisation, label: { text: "Their organisation" } %>
 
-        <%= f.govuk_text_area :reason, width: "two-thirds" %>
+        <%= f.govuk_text_area :reason, width: "two-thirds", label: { text: "Reason they need access" } %>
       <% end %>
 
       <%= f.govuk_submit "Request access" %>

--- a/app/webpacker/styles/_link.scss
+++ b/app/webpacker/styles/_link.scss
@@ -1,0 +1,5 @@
+.govuk-link {
+  &.app-link--destructive {
+    color: $govuk-error-colour;
+  }
+}

--- a/app/webpacker/styles/application.scss
+++ b/app/webpacker/styles/application.scss
@@ -8,6 +8,7 @@ $git-brand-colour: #159964;
 @import "card";
 @import "description-list";
 @import "inset-text";
+@import "link";
 @import "list";
 @import "status-box";
 @import "summary-list";

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -387,6 +387,10 @@ en:
           attributes:
             study_mode:
               blank: "Pick full time, part time or full time and part time"
+        publish/course_withdrawal_form:
+          attributes:
+            confirm_course_code:
+              invalid_code: "Enter the course code %{course_code} to withdraw this course"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -117,6 +117,10 @@ Rails.application.routes.draw do
           patch "/fees", on: :member, to: "courses/fees#update"
           get "/salary", on: :member, to: "courses/salary#edit"
           patch "/salary", on: :member, to: "courses/salary#update"
+
+          get "/withdraw", on: :member, to: "courses/withdrawals#edit"
+          patch "/withdraw", on: :member, to: "courses/withdrawals#update"
+
           get "/locations", on: :member, to: "courses/sites#edit"
           put "/locations", on: :member, to: "courses/sites#update"
 

--- a/spec/features/publish/courses/withdrawing_a_course_spec.rb
+++ b/spec/features/publish/courses/withdrawing_a_course_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Withdrawing courses" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "i can withdraw a course" do
+    and_there_is_a_course_i_want_to_withdraw
+    when_i_visit_the_course_withdrawal_page
+    and_i_confirm_the_course_code
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_is_withdrawn
+  end
+
+  scenario "wrong course code provided" do
+    and_there_is_a_course_i_want_to_withdraw
+    when_i_visit_the_course_withdrawal_page
+    and_i_submit_with_the_wrong_code
+    then_i_should_see_an_error_message
+  end
+
+  scenario "course already withdrawn" do
+    and_there_is_a_course_already_withdrawn
+    when_i_visit_the_course_withdrawal_page
+    then_i_am_redirected_to_the_courses_page
+    and_i_see_the(already_withdrawn_message)
+  end
+
+  scenario "attempting to withdraw a non published course" do
+    and_there_is_a_draft_course
+    when_i_visit_the_course_withdrawal_page
+    then_i_am_redirected_to_the_courses_page
+    and_i_see_the(course_should_be_deleted_message)
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_withdraw
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
+    given_a_site_exists(:full_time_vacancies, :findable)
+  end
+
+  def and_there_is_a_course_already_withdrawn
+    given_a_course_exists(enrichments: [build(:course_enrichment, :withdrawn)])
+  end
+
+  def and_there_is_a_draft_course
+    given_a_course_exists(enrichments: [build(:course_enrichment, :initial_draft)])
+  end
+
+  def when_i_visit_the_course_withdrawal_page
+    publish_course_withdrawal_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_confirm_the_course_code
+    publish_course_withdrawal_page.confirm_course_code.set(course.course_code)
+  end
+
+  def and_i_submit_with_the_wrong_code
+    publish_course_withdrawal_page.confirm_course_code.set("random")
+    and_i_submit
+  end
+
+  def and_i_submit
+    publish_course_information_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content(withdrawn_message)
+  end
+
+  def and_the_course_is_withdrawn
+    enrichment = course.reload.enrichments.max_by(&:created_at)
+
+    expect(enrichment).to be_withdrawn
+    expect(course.site_statuses.pluck(:vac_status)).to all(eq("no_vacancies"))
+  end
+
+  def then_i_am_redirected_to_the_courses_page
+    expect(publish_provider_courses_index_page).to be_displayed
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_information_page.error_messages).to include(
+      "Enter the course code #{course.course_code} to withdraw this course",
+    )
+  end
+
+  def and_i_see_the(message)
+    expect(page).to have_content(message)
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def withdrawn_message
+    "#{course_name_and_code} has been withdrawn"
+  end
+
+  def already_withdrawn_message
+    "#{course_name_and_code} has already been withdrawn"
+  end
+
+  def course_should_be_deleted_message
+    "Courses that have not been published should be deleted not withdrawn"
+  end
+
+  def course_name_and_code
+    "#{course.name} (#{course.course_code})"
+  end
+end

--- a/spec/features/publish/editing_vacancies_spec.rb
+++ b/spec/features/publish/editing_vacancies_spec.rb
@@ -187,10 +187,6 @@ private
     given_a_site_exists(:full_time_vacancies, :suspended, site: build(:site, location_name: "Not running Uni"))
   end
 
-  def given_a_site_exists(*traits, **overrides)
-    course.site_statuses << build(:site_status, *traits, **overrides)
-  end
-
   def when_i_visit_the_vacancy_edit_page_for_a_course
     publish_provider_vacancies_edit_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,

--- a/spec/support/feature_helpers/course_steps.rb
+++ b/spec/support/feature_helpers/course_steps.rb
@@ -7,5 +7,9 @@ module FeatureHelpers
     def given_a_course_exists(*traits, **overrides)
       @course ||= create(:course, *traits, **overrides, provider: current_user.providers.first)
     end
+
+    def given_a_site_exists(*traits, **overrides)
+      course.site_statuses << build(:site_status, *traits, **overrides)
+    end
   end
 end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -156,6 +156,10 @@ module FeatureHelpers
       @publish_course_outcome_page ||= PageObjects::Publish::Courses::OutcomeEditPage.new
     end
 
+    def publish_course_withdrawal_page
+      @publish_course_withdrawal_page ||= PageObjects::Publish::Courses::WithdrawalPage.new
+    end
+
     def gcse_requirements_page
       @gcse_requirements_page ||= PageObjects::Publish::Courses::GcseRequirementsPage.new
     end

--- a/spec/support/page_objects/publish/courses/withdrawal_page.rb
+++ b/spec/support/page_objects/publish/courses/withdrawal_page.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/errorlink"
+
+module PageObjects
+  module Publish
+    module Courses
+      class WithdrawalPage < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/withdraw"
+
+        sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+        element :confirm_course_code, "#publish-course-withdrawal-form-confirm-course-code-field"
+
+        element :submit, 'input.govuk-button[type="submit"]'
+
+        def error_messages
+          errors.map(&:text)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/QXTXwmQX/616-migrate-courses-course-show-page-status-sidebar-withdrawing

### Changes proposed in this pull request

- Port the course withdrawal flow
- Refactor markup to use govuk formbuilder
- Refactor original code to use form object pattern
- Increase test coverage

### Guidance to review

Original implementation here: https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2022/courses/3CXB (click withdraw this course)

migrated version:  https://teacher-training-api-pr-2574.london.cloudapps.digital/publish/organisations/2AT/2022/courses/3CXB (click the same link above)

Check:

You can withdraw the course.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
