### PR TITLE
Fix libretls vulnerability CVE-2022-0778

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM ruby:2.7.5-alpine3.15 AS middleman
-# Remove apk add for gmp 6.2.1-r1 when the base image is updated
+# Remove apk add for libretls when the base image is updated
 
 RUN apk add --update --no-cache npm git build-base
 
-# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
-RUN apk add --no-cache gmp=6.2.1-r1
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libretls
+RUN apk add --no-cache libretls=3.3.4-r3
 
 COPY docs/Gemfile docs/Gemfile.lock /
 
@@ -28,8 +28,8 @@ RUN apk add --update --no-cache tzdata && \
 RUN apk add --update --no-cache --virtual runtime-dependances \
  postgresql-dev git ncurses shared-mime-info
 
-# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest gmp
-RUN apk add --no-cache gmp=6.2.1-r1
+# Remove once base image ruby:2.7.5-alpine3.15 has been updated with latest libretls
+RUN apk add --no-cache libretls=3.3.4-r3
 
 ENV APP_HOME /app
 


### PR DESCRIPTION
### Context
Fix base image vulnerability for libretls, https://github.com/advisories/GHSA-x3mh-jvjw-3xwx.
Info: https://snyk.io/vuln/SNYK-ALPINE315-LIBRETLS-2428776

### Changes proposed in this pull request
Bump libretls from 3.3.4-r2 to 3.3.4-r3
Also remove gmp bump to 6.2.1-r1 as this is now in the base image

### Guidance to review
Check build completes successfully
Run build-no-cache workflow against branch

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
