### PR TITLE
[828] Port course deletion flow

### DIFF
--- a/app/controllers/publish/courses/deletions_controller.rb
+++ b/app/controllers/publish/courses/deletions_controller.rb
@@ -1,6 +1,8 @@
 module Publish
   module Courses
     class DeletionsController < PublishController
+      before_action :redirect_to_courses, if: -> { course.is_published? }
+
       def edit
         authorize(provider)
 
@@ -25,6 +27,13 @@ module Publish
       end
 
     private
+
+      def redirect_to_courses
+        redirect_to publish_provider_recruitment_cycle_courses_path(
+          provider.provider_code,
+          course.recruitment_cycle_year,
+        )
+      end
 
       def course
         @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))

--- a/app/controllers/publish/courses/deletions_controller.rb
+++ b/app/controllers/publish/courses/deletions_controller.rb
@@ -1,0 +1,42 @@
+module Publish
+  module Courses
+    class DeletionsController < PublishController
+      def edit
+        authorize(provider)
+
+        @course_deletion_form = CourseDeletionForm.new(course)
+      end
+
+      def destroy
+        authorize(provider)
+
+        @course_deletion_form = CourseDeletionForm.new(course, params: deletion_params)
+
+        if @course_deletion_form.destroy!
+          flash[:success] = "#{@course.name} (#{@course.course_code}) has been deleted"
+
+          redirect_to publish_provider_recruitment_cycle_courses_path(
+            provider.provider_code,
+            recruitment_cycle.year,
+          )
+        else
+          render :edit
+        end
+      end
+
+    private
+
+      def course
+        @course ||= CourseDecorator.new(provider.courses.find_by!(course_code: params[:code]))
+      end
+
+      def deletion_params
+        return { course_code: nil } if params[:publish_course_deletion_form].blank?
+
+        params
+          .require(:publish_course_deletion_form)
+          .permit(CourseDeletionForm::FIELDS)
+      end
+    end
+  end
+end

--- a/app/controllers/publish/courses/deletions_controller.rb
+++ b/app/controllers/publish/courses/deletions_controller.rb
@@ -40,11 +40,7 @@ module Publish
       end
 
       def deletion_params
-        return { course_code: nil } if params[:publish_course_deletion_form].blank?
-
-        params
-          .require(:publish_course_deletion_form)
-          .permit(CourseDeletionForm::FIELDS)
+        params.require(:publish_course_deletion_form).permit(CourseDeletionForm::FIELDS)
       end
     end
   end

--- a/app/forms/publish/course_deletion_form.rb
+++ b/app/forms/publish/course_deletion_form.rb
@@ -1,0 +1,33 @@
+module Publish
+  class CourseDeletionForm < BaseModelForm
+    alias_method :course, :model
+
+    FIELDS = %i[
+      confirm_course_code
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validate :course_code_is_correct
+
+    def destroy!
+      if valid?
+        course.discard!
+      else
+        false
+      end
+    end
+
+  private
+
+    def compute_fields
+      course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)
+    end
+
+    def course_code_is_correct
+      return if course.course_code == confirm_course_code
+
+      errors.add(:confirm_course_code, :invalid_code, course_code: course.course_code)
+    end
+  end
+end

--- a/app/policies/provider_policy.rb
+++ b/app/policies/provider_policy.rb
@@ -61,6 +61,7 @@ class ProviderPolicy
   alias_method :can_create_course?, :show?
   alias_method :edit?, :show?
   alias_method :update?, :show?
+  alias_method :destroy?, :show?
   alias_method :build_new?, :show?
   alias_method :can_list_training_providers?, :show?
 

--- a/app/views/publish/courses/_description_status_panel.html.erb
+++ b/app/views/publish/courses/_description_status_panel.html.erb
@@ -31,9 +31,7 @@
     <hr class="govuk-section-break govuk-section-break--visible govuk-section-break--m">
     <h3 class="govuk-heading-m govuk-visually-hidden">Delete</h3>
     <p class="govuk-body">
-      <%= govuk_link_to "Delete this course" %>
-
-      <%# govuk_link_to "Delete this course", delete_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__delete-link" } %>
+      <%= govuk_link_to "Delete this course", delete_publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code), class: "app-link--destructive", data: { qa: "course__delete-link" } %>
     </p>
   <% end %>
 </div>

--- a/app/views/publish/courses/deletions/edit.html.erb
+++ b/app/views/publish/courses/deletions/edit.html.erb
@@ -1,0 +1,52 @@
+<% content_for :page_title, title_with_error_prefix("Are you sure you want to withdraw #{@course.name_and_code})?", @course_deletion_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_course_path(
+    @course.provider_code, 
+    @course.recruitment_cycle_year, 
+    @course.course_code)
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @course_deletion_form,
+      url: delete_publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+      data: { qa: "enrichment-form", module: "form-check-leave" },
+      method: :delete,
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l"><%= @course.name_and_code %></span>
+        Are you sure you want to delete this course?
+      </h1>
+
+    <p class="govuk-body">You can only delete a course if it has not been published in this cycle.</p>
+
+    <p class="govuk-body">Delete a course if you:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>created it by mistake</li>
+      <li>will not offer it again</li>
+    </ul>
+
+    <p class="govuk-body">Deleting a course is permanent – you cannot undo it. If you need to recreate a course after deleting it, it will have a new course code.</p>
+
+    <h2 class="govuk-heading-m">Confirm delete</h2>
+
+      <%= f.govuk_text_field :confirm_course_code, label: { text: "Enter the course code to confirm" }, width: 5 %>
+
+      <%= f.govuk_submit "Yes I’m sure – delete this course", class: "govuk-button govuk-button--warning" %>
+    <% end %>
+
+    <p class="govuk-body govuk-!-margin-top-5">
+      <%= govuk_link_to(
+        "Cancel",
+        publish_provider_recruitment_cycle_course_path(@provider.provider_code, @course.recruitment_cycle_year, @course.course_code),
+        no_visited_state: true,
+      ) %>
+    </p>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -391,6 +391,10 @@ en:
           attributes:
             confirm_course_code:
               invalid_code: "Enter the course code %{course_code} to withdraw this course"
+        publish/course_deletion_form:
+          attributes:
+            confirm_course_code:
+              invalid_code: "Enter the course code %{course_code} to delete this course"
   errors:
     messages:
       email: "^Enter an email address in the correct format, like name@example.com"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -120,6 +120,8 @@ Rails.application.routes.draw do
 
           get "/withdraw", on: :member, to: "courses/withdrawals#edit"
           patch "/withdraw", on: :member, to: "courses/withdrawals#update"
+          get "/delete", on: :member, to: "courses/deletions#edit"
+          delete "/delete", on: :member, to: "courses/deletions#destroy"
 
           get "/locations", on: :member, to: "courses/sites#edit"
           put "/locations", on: :member, to: "courses/sites#update"

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Deleting courses" do
+  before do
+    given_i_am_authenticated_as_a_provider_user
+  end
+
+  scenario "i can delete a course" do
+    and_there_is_a_course_i_want_to_delete
+    when_i_visit_the_course_deletion_page
+    and_i_confirm_the_course_code
+    and_i_submit
+    then_i_should_see_a_success_message
+    and_the_course_is_deleted
+  end
+
+  scenario "wrong course code provided" do
+    and_there_is_a_course_i_want_to_delete
+    when_i_visit_the_course_deletion_page
+    and_i_submit_with_the_wrong_code
+    then_i_should_see_an_error_message
+  end
+
+  def given_i_am_authenticated_as_a_provider_user
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def and_there_is_a_course_i_want_to_delete
+    given_a_course_exists(enrichments: [build(:course_enrichment, :initial_draft)])
+  end
+
+  def when_i_visit_the_course_deletion_page
+    publish_course_deletion_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    )
+  end
+
+  def and_i_confirm_the_course_code
+    publish_course_deletion_page.confirm_course_code.set(course.course_code)
+  end
+
+  def and_i_submit_with_the_wrong_code
+    publish_course_deletion_page.confirm_course_code.set("random")
+    and_i_submit
+  end
+
+  def and_i_submit
+    publish_course_deletion_page.submit.click
+  end
+
+  def then_i_should_see_a_success_message
+    expect(page).to have_content("#{course_name_and_code} has been deleted")
+  end
+
+  def and_the_course_is_deleted
+    expect(course.reload).to be_discarded
+  end
+
+  def then_i_am_redirected_to_the_courses_page
+    expect(publish_provider_courses_index_page).to be_displayed
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_deletion_page.error_messages).to include(
+      "Enter the course code #{course.course_code} to delete this course",
+    )
+  end
+
+  def provider
+    @current_user.providers.first
+  end
+
+  def course_name_and_code
+    "#{course.name} (#{course.course_code})"
+  end
+end

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -45,7 +45,7 @@ feature "Deleting courses" do
   def when_i_visit_the_course_page
     publish_provider_courses_show_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
-    ) 
+    )
   end
 
   def when_i_visit_the_course_deletion_page

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -9,7 +9,8 @@ feature "Deleting courses" do
 
   scenario "i can delete a course" do
     and_there_is_a_course_i_want_to_delete
-    when_i_visit_the_course_deletion_page
+    when_i_visit_the_course_page
+    and_i_click_the_delete_link
     and_i_confirm_the_course_code
     and_i_submit
     then_i_should_see_a_success_message
@@ -41,10 +42,20 @@ feature "Deleting courses" do
     given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
   end
 
+  def when_i_visit_the_course_page
+    publish_provider_courses_show_page.load(
+      provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
+    ) 
+  end
+
   def when_i_visit_the_course_deletion_page
     publish_course_deletion_page.load(
       provider_code: provider.provider_code, recruitment_cycle_year: provider.recruitment_cycle_year, course_code: course.course_code,
     )
+  end
+
+  def and_i_click_the_delete_link
+    publish_provider_courses_show_page.status_sidebar.delete_course_link.click
   end
 
   def and_i_confirm_the_course_code

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -23,12 +23,22 @@ feature "Deleting courses" do
     then_i_should_see_an_error_message
   end
 
+  scenario "attempting to delete a published course" do
+    and_there_is_a_published_course
+    when_i_visit_the_course_deletion_page
+    then_i_am_redirected_to_the_courses_page
+  end
+
   def given_i_am_authenticated_as_a_provider_user
     given_i_am_authenticated(user: create(:user, :with_provider))
   end
 
   def and_there_is_a_course_i_want_to_delete
     given_a_course_exists(enrichments: [build(:course_enrichment, :initial_draft)])
+  end
+
+  def and_there_is_a_published_course
+    given_a_course_exists(enrichments: [build(:course_enrichment, :published)])
   end
 
   def when_i_visit_the_course_deletion_page

--- a/spec/features/publish/courses/withdrawing_a_course_spec.rb
+++ b/spec/features/publish/courses/withdrawing_a_course_spec.rb
@@ -70,7 +70,7 @@ feature "Withdrawing courses" do
   end
 
   def and_i_submit
-    publish_course_information_page.submit.click
+    publish_course_withdrawal_page.submit.click
   end
 
   def then_i_should_see_a_success_message
@@ -89,7 +89,7 @@ feature "Withdrawing courses" do
   end
 
   def then_i_should_see_an_error_message
-    expect(publish_course_information_page.error_messages).to include(
+    expect(publish_course_withdrawal_page.error_messages).to include(
       "Enter the course code #{course.course_code} to withdraw this course",
     )
   end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -168,6 +168,10 @@ module FeatureHelpers
       @publish_course_withdrawal_page ||= PageObjects::Publish::Courses::WithdrawalPage.new
     end
 
+    def publish_course_deletion_page
+      @publish_course_deletion_page ||= PageObjects::Publish::Courses::DeletePage.new
+    end
+
     def gcse_requirements_page
       @gcse_requirements_page ||= PageObjects::Publish::Courses::GcseRequirementsPage.new
     end

--- a/spec/support/page_objects/publish/courses/delete_page.rb
+++ b/spec/support/page_objects/publish/courses/delete_page.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/errorlink"
+
+module PageObjects
+  module Publish
+    module Courses
+      class DeletePage < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/courses/{course_code}/delete"
+
+        sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+        element :confirm_course_code, "#publish-course-deletion-form-confirm-course-code-field"
+
+        element :submit, 'button.govuk-button[type="submit"]'
+
+        def error_messages
+          errors.map(&:text)
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/publish/courses/withdrawal_page.rb
+++ b/spec/support/page_objects/publish/courses/withdrawal_page.rb
@@ -12,7 +12,7 @@ module PageObjects
 
         element :confirm_course_code, "#publish-course-withdrawal-form-confirm-course-code-field"
 
-        element :submit, 'input.govuk-button[type="submit"]'
+        element :submit, 'button.govuk-button[type="submit"]'
 
         def error_messages
           errors.map(&:text)

--- a/spec/support/page_objects/sections/status_sidebar.rb
+++ b/spec/support/page_objects/sections/status_sidebar.rb
@@ -7,6 +7,8 @@ module PageObjects
     class StatusSidebar < PageObjects::Sections::Base
       element :unpublished_partial, '[data-qa="unpublished__partial"]'
       element :published_partial, '[data-qa="published__partial"]'
+
+      element :delete_course_link, "a.govuk-link.app-link--destructive", text: "Delete this course"
     end
   end
 end


### PR DESCRIPTION
### Context

- https://trello.com/c/E7R3KM6v/828-migrate-courses-course-show-page-status-sidebar-deleting

### Changes proposed in this pull request

- Port the course deletion flow
- Refactor markup to use govuk formbuilder
- Refactor original code to use form object pattern
- Increase test coverage

### Guidance to review

Original implementation here: https://qa.publish-teacher-training-courses.service.gov.uk/organisations/2AT/2022/courses/3CXB (click delete this course)

migrated version:  

Check:

You can delete the course and it no longer appears on the course index page

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
