### PR TITLE
Use job environment to update deployment status

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -20,20 +20,27 @@ inputs:
   slack-webhook:
     required: true
 
+outputs:
+  deploy-url:
+    value: ${{ steps.set_env_var.outputs.deploy_url }}
+
 runs:
   using: composite
   steps:
     - name: Set Environment variables
+      id: set_env_var
       shell: bash
       run: |
         if [ -n "${{ inputs.pr-number }}" ]; then
-          echo "DEPLOY_ENV=${{ inputs.environment }}-${{ inputs.pr-number }}" >> $GITHUB_ENV
           echo "APP_NAME=${{ inputs.pr-number }}" >> $GITHUB_ENV
-          echo "DEPLOY_URL=https://teacher-training-api-pr-${{ inputs.pr-number }}.london.cloudapps.digital" >> $GITHUB_ENV
+          echo "::set-output name=deploy_url::https://teacher-training-api-pr-${{ inputs.pr-number }}.london.cloudapps.digital"
           echo "DEPLOY_REF=${{ github.head_ref }}" >> $GITHUB_ENV
         else
-          echo "DEPLOY_ENV=${{ inputs.environment }}" >> $GITHUB_ENV
-          echo "DEPLOY_URL=https://${{ inputs.environment }}.api.publish-teacher-training-courses.service.gov.uk" >> $GITHUB_ENV
+          if [ ${{ inputs.environment }} == "production" ]; then
+            echo "::set-output name=deploy_url::https://api.publish-teacher-training-courses.service.gov.uk"
+          else
+            echo "::set-output name=deploy_url::https://${{ inputs.environment }}.api.publish-teacher-training-courses.service.gov.uk"
+          fi
           echo "DEPLOY_REF=${{ github.ref }}" >> $GITHUB_ENV
         fi;
 
@@ -41,15 +48,6 @@ runs:
         echo "key_vault_name=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
         echo "key_vault_app_secret_name=$(jq -r '.key_vault_app_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
         echo "key_vault_infra_secret_name=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
-
-    - name: Start ${{ inputs.environment }} Deployment
-      uses: bobheadxi/deployments@v1
-      id:   deployment
-      with:
-        step: start
-        token: ${{ github.token }}
-        env:   ${{ env.DEPLOY_ENV }}
-        ref: ${{ env.DEPLOY_REF }}
 
     - name: Checkout
       uses: actions/checkout@v2
@@ -103,19 +101,6 @@ runs:
       shell: bash
       run: exit 1
 
-    - name: Update ${{ env.DEPLOY_ENV }} status
-      if:   always()
-      uses: bobheadxi/deployments@v1
-      with:
-        step:   finish
-        token:  ${{ github.token }}
-        env:    ${{ env.DEPLOY_ENV }}
-        status: ${{ job.status }}
-        deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-        env_url: ${{ env.DEPLOY_URL }}
-        ref: ${{ env.DEPLOY_REF }}
-        override: false
-
     - name: Alert on Failure
       if: ${{ failure() && github.ref == 'refs/heads/master' }}
       uses: rtCamp/action-slack-notify@master
@@ -124,6 +109,6 @@ runs:
         SLACK_COLOR: '#ef5343'
         SLACK_ICON_EMOJI: ':github-logo:'
         SLACK_USERNAME: Teacher Training API
-        SLACK_TITLE: Deploy to ${{ env.DEPLOY_ENV }} Failed
-        SLACK_MESSAGE: ':alert: <!channel> Build failure on ${{ env.DEPLOY_ENV }} :sadparrot:'
+        SLACK_TITLE: Deploy to ${{ inputs.environment }} Failed
+        SLACK_MESSAGE: ':alert: <!channel> Build failure on ${{ inputs.environment }} :sadparrot:'
         SLACK_WEBHOOK: ${{ inputs.slack-webhook }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -151,10 +151,20 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
+      - name: Start review-${{ github.event.pull_request.number }} Deployment
+        uses: bobheadxi/deployments@v1
+        id:   deployment
+        with:
+          step: start
+          token: ${{ secrets.GITHUB_TOKEN }}
+          env:   review-${{ github.event.pull_request.number }}
+          ref: ${{ github.head_ref }}
+
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Deploy App to Review
+        id: deploy_review
         uses: ./.github/actions/deploy/
         with:
           actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
@@ -165,9 +175,24 @@ jobs:
           sha: ${{ needs.build.outputs.image_tag }}
           slack-webhook: ${{ secrets.SLACK_WEBHOOK }}
 
+      - name: Update review-${{ github.event.pull_request.number }} status
+        if:   always()
+        uses: bobheadxi/deployments@v1
+        with:
+          step:   finish
+          token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    review-${{ github.event.pull_request.number }}
+          status: ${{ job.status }}
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+          env_url: ${{ steps.deploy_review.outputs.deploy-url }}
+          ref: ${{ github.head_ref }}
+
   deploy-all:
     name: Deployment To All
     concurrency: deploy_all
+    environment: 
+      name: ${{ matrix.environment }}
+      url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/master' }}
     needs: [test]
     runs-on: ubuntu-latest
@@ -180,6 +205,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Deploy App to ${{ matrix.environment }}
+        id: deploy_app
         uses: ./.github/actions/deploy/
         with:
           actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -75,4 +75,4 @@ jobs:
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
-          env:    ${{ env.PR_NUMBER }}
+          env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,12 +19,16 @@ on:
 jobs:
   deploy:
     name: Deployment to ${{ github.event.inputs.environment }}
+    environment:
+      name: ${{ github.event.inputs.environment }}
+      url: ${{ steps.deploy_app.outputs.deploy-url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Deploy App to ${{ github.event.inputs.environment }}
+        id: deploy_app
         uses: ./.github/actions/deploy/
         with:
           actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}


### PR DESCRIPTION
### Context
The bobheadxi/deployments GitHub Action is used to update deployment statuses, this is ineffective when deploying to persistent environments such as qa or prod.

### Changes proposed in this pull request
This change removes that action from non-review app deployment workflows and uses the built in functionality instead.
Review apps continue to use the bobheadxi/deployments action.

### Guidance to review
- Check that the [environments page](https://github.com/DFE-Digital/teacher-training-api/deployments) is updated as expected including correct View Deployment link
- Check that delete-review-app workflow functions as expected

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
