### PR TITLE
Refactor smoke test workflow as a reusable action

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -78,28 +78,12 @@ runs:
         TF_VAR_azure_credentials:   ${{ inputs.azure-credentials }}
         CONFIRM_PRODUCTION:         yes
 
-    - name: Trigger ${{ inputs.environment }} Smoke Tests
-      uses: benc-uk/workflow-dispatch@v1
+    - name: Run Smoke Tests for ${{ inputs.environment }}
+      uses: ./.github/actions/smoke-test/
       with:
-        workflow: Smoke Tests
-        ref: ${{ env.DEPLOY_REF }}
-        token:    ${{ inputs.actions-api-access-token }}
-        inputs:   '{"environment": "${{ inputs.environment }}", "pr": "${{ inputs.pr-number }}"}'
-
-    - name: Wait for smoke tests
-      id:   wait_for_smoke_tests
-      uses: fountainhead/action-wait-for-check@v1.0.0
-      with:
-        token: ${{ github.token }}
-        ref:   ${{ env.DEPLOY_REF }}
-        checkName: smoke-tests-${{ inputs.environment }} 
-        timeoutSeconds:  300
-        intervalSeconds: 15
-
-    - name: Stop when smoke tests fail
-      if:   steps.wait_for_smoke_tests.outputs.conclusion != 'success'
-      shell: bash
-      run: exit 1
+        environment: ${{ inputs.environment }}
+        pr-number: ${{ inputs.pr-number }}
+        slack-webhook: ${{ inputs.slack-webhook }}
 
     - name: Alert on Failure
       if: ${{ failure() && github.ref == 'refs/heads/master' }}

--- a/.github/actions/smoke-test/action.yml
+++ b/.github/actions/smoke-test/action.yml
@@ -1,0 +1,53 @@
+name: smoke-test
+description: runs smoke tests
+
+inputs:
+  environment:
+    description: Environment to run tests in
+    required: true
+  pr-number:
+    description: PR number if testing a review app
+    required: false
+  slack-webhook:
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Ruby 2.7.5
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7.5
+
+    - name: install bundler and gems
+      shell: bash
+      run: |
+        gem install bundler
+        echo 'gem "httparty"' >> Gemfile
+        echo 'gem "rspec"' >> Gemfile
+        bundle
+
+    - name: Set Environment variables
+      shell: bash
+      run: |
+        if [ ! -z "${{ inputs.pr-number }}" ]; then
+          PR_NUMBER=${{ inputs.pr-number }}
+          echo "base_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
+          echo "publish_api_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
+        fi;
+
+    - name: Smoke Tests ${{ inputs.environment }}
+      shell: bash
+      run: RAILS_ENV=${{ inputs.environment }} ./bin/bundle exec rspec spec/smoke --format documentation
+
+    - name: 'Notify #twd_publish_tech on failure'
+      if: ${{ failure() && inputs.environment != 'review' }}
+      uses: rtCamp/action-slack-notify@master
+      env:
+        SLACK_CHANNEL: twd_publish_tech
+        SLACK_COLOR: '#ef5343'
+        SLACK_ICON_EMOJI: ':github-logo:'
+        SLACK_USERNAME: Teacher Training API
+        SLACK_TITLE: Smoke tests failure
+        SLACK_MESSAGE: ':alert: <!channel> Smoke tests failure on ${{ inputs.environment }} :sadparrot:'
+        SLACK_WEBHOOK: ${{ inputs.slack-webhook }}

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,7 +4,15 @@ on:
     inputs:
       environment:
         description: 'The environment to run tests against (qa, staging, production, sandbox or review)'
+        default: qa
         required: true
+        type: choice
+        options:
+        - review
+        - qa
+        - staging
+        - production
+        - sandbox
       pr:
         description: 'The PR number if the environment is review'
         required: false
@@ -12,46 +20,14 @@ on:
 jobs:
   smoke_tests:
     name: smoke-tests-${{ github.event.inputs.environment }}
+    concurrency: smoke-tests-${{ github.event.inputs.environment }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.7.5
-        uses: ruby/setup-ruby@v1
+      - name: Run Smoke Tests for ${{ github.event.inputs.environment }}
+        uses: ./.github/actions/smoke-test/
         with:
-          ruby-version: 2.7.5
-
-      - name: install bundler and gems
-        run: |
-          gem install bundler
-          echo 'gem "httparty"' >> Gemfile
-          echo 'gem "rspec"' >> Gemfile
-          bundle
-
-      - uses: softprops/turnstyle@v1
-        name: Wait for other runs
-        env:
-          GITHUB_TOKEN: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
-
-      - name: Set Environment variables
-        run: |
-          if [ ! -z "${{ github.event.inputs.pr }}" ]; then
-            PR_NUMBER=${{ github.event.inputs.pr }}
-            echo "base_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
-            echo "publish_api_url: https://teacher-training-api-pr-$PR_NUMBER.london.cloudapps.digital" >> config/settings/review.yml
-          fi;
-
-      - name: Smoke Tests ${{ github.event.inputs.environment }}
-        run: RAILS_ENV=${{ github.event.inputs.environment }} ./bin/bundle exec rspec spec/smoke --format documentation
-
-      - name: 'Notify #twd_publish_tech on failure'
-        if: ${{ failure() && github.event.inputs.environment != 'review' }}
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_CHANNEL: twd_publish_tech
-          SLACK_COLOR: '#ef5343'
-          SLACK_ICON_EMOJI: ':github-logo:'
-          SLACK_USERNAME: Teacher Training API
-          SLACK_TITLE: Smoke tests failure
-          SLACK_MESSAGE: ':alert: <!channel> Smoke tests failure on ${{ github.event.inputs.environment }} :sadparrot:'
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          environment: ${{ github.event.inputs.environment }}
+          pr-number: ${{ github.event.inputs.pr }}
+          slack-webhook: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
### Context
The smoke tests are mainly ran using workflow dispatch from the build workflow. This makes the logs harder to follow and rerunning failed checks harder.

https://trello.com/c/D6tyzjoj

### Changes proposed in this pull request
This change refactors the workflow as a reusable action.

The `softprops/turnstyle` step has been removed, instead we rely on concurrency at the workflow level to prevent multiple tests running against the same environment (though with the current smoke tests only hitting the healthcheck endpoint this shouldn't be a concern at present).

### Guidance to review
- Check that smoke tests run as expected when:
  - running as part of the `deploy_review` job
  - deploying to an environment, eg QA, using the `deploy` workflow
  - running manually using the `smoke-test` workflow against an environment, eg QA, and a review app

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
