### PR TITLE
Removed dependabot conditions in build workflows

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -46,7 +46,6 @@ jobs:
         echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
     - name: Login to GitHub Container Registry
-      if: github.actor != 'dependabot[bot]'
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io
@@ -60,8 +59,7 @@ jobs:
       uses: docker/build-push-action@v2
       with:
         tags: ${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
-        push: ${{ github.actor != 'dependabot[bot]' }}
-        load: ${{ github.actor == 'dependabot[bot]' }}
+        push: true
         target: middleman
         cache-from: |
           type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:master

--- a/.github/workflows/build-nocache.yml
+++ b/.github/workflows/build-nocache.yml
@@ -46,7 +46,6 @@ jobs:
           key: SNYK_TOKEN
 
       - name: Login to GitHub Container Registry
-        if: github.actor != 'dependabot[bot]'
         uses: docker/login-action@v1.12.0
         with:
           registry: ghcr.io


### PR DESCRIPTION
### Context
Dependabot has been granted permissions to push to the GitHub Container Registry so there is no longer a requirement to skip container related steps in the build.

### Changes proposed in this pull request
Run all container related steps for Dependabot triggered build workflow runs.

### Guidance to review
- Check review app is deploying

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
