### PR TITLE
[0803] Migrate notifications logic for when courses are changed

### DIFF
--- a/app/controllers/publish/courses/modern_languages_controller.rb
+++ b/app/controllers/publish/courses/modern_languages_controller.rb
@@ -34,7 +34,7 @@ module Publish
       def update
         authorize(provider)
 
-        if assign_subjects_service.save
+        if course_subjects_form.save!
           flash[:success] = I18n.t("success.saved")
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
@@ -68,8 +68,8 @@ module Publish
         @updated_subject_list ||= selected_language_subjects_ids.concat(selected_non_language_subjects_ids)
       end
 
-      def assign_subjects_service
-        @assign_subjects_service ||= ::Courses::AssignSubjectsService.call(course: @course, subject_ids: updated_subject_list)
+      def course_subjects_form
+        @course_subjects_form ||= CourseSubjectsForm.new(@course, params: updated_subject_list)
       end
 
       def error_keys

--- a/app/controllers/publish/courses/subjects_controller.rb
+++ b/app/controllers/publish/courses/subjects_controller.rb
@@ -27,7 +27,7 @@ module Publish
             ),
           )
 
-        elsif assign_subjects_service.save
+        elsif course_subjects_form.save!
           flash[:success] = I18n.t("success.saved")
           redirect_to(
             details_publish_provider_recruitment_cycle_course_path(
@@ -44,8 +44,8 @@ module Publish
 
     private
 
-      def assign_subjects_service
-        @assign_subjects_service ||= ::Courses::AssignSubjectsService.call(course: @course, subject_ids: selected_subject_ids)
+      def course_subjects_form
+        @course_subjects_form ||= CourseSubjectsForm.new(@course, params: selected_subject_ids)
       end
 
       def modern_languages_subject_id

--- a/app/forms/publish/base_course_form.rb
+++ b/app/forms/publish/base_course_form.rb
@@ -1,0 +1,27 @@
+module Publish
+  class BaseCourseForm < BaseModelForm
+    alias_method :course, :model
+
+    def save!
+      if valid?
+        save_action
+      else
+        false
+      end
+    end
+
+  private
+
+    def after_successful_save_action; end
+
+    def save_action
+      assign_attributes_to_model
+      if model.save!
+        after_successful_save_action
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/forms/publish/base_course_form.rb
+++ b/app/forms/publish/base_course_form.rb
@@ -12,7 +12,9 @@ module Publish
 
   private
 
-    def after_successful_save_action; end
+    def after_successful_save_action
+      NotificationService::CourseUpdated.call(course: course)
+    end
 
     def save_action
       assign_attributes_to_model

--- a/app/forms/publish/course_location_form.rb
+++ b/app/forms/publish/course_location_form.rb
@@ -1,21 +1,40 @@
 module Publish
-  class CourseLocationForm < BaseModelForm
-    alias_method :course, :model
-
+  class CourseLocationForm < BaseCourseForm
     FIELDS = %i[site_ids].freeze
 
     attr_accessor(*FIELDS)
 
     validate :no_locations_selected
 
+    def initialize(model, params: {})
+      @previous_site_names = model.sites.map(&:location_name)
+      super
+    end
+
   private
+
+    attr_reader :previous_site_names
+
+    def after_successful_save_action
+      return if previous_site_names == updated_site_names
+
+      NotificationService::CourseSitesUpdated.call(
+        course: course,
+        previous_site_names: previous_site_names,
+        updated_site_names: updated_site_names,
+      )
+    end
+
+    def updated_site_names
+      @updated_site_names ||= course.sites.map(&:location_name)
+    end
 
     def compute_fields
       { site_ids: course.site_ids }.merge(new_attributes)
     end
 
     def no_locations_selected
-      return unless site_ids.nil?
+      return if params[:site_ids].present?
 
       errors.add(:site_ids, :no_locations)
     end

--- a/app/forms/publish/course_subjects_form.rb
+++ b/app/forms/publish/course_subjects_form.rb
@@ -1,0 +1,46 @@
+module Publish
+  class CourseSubjectsForm < BaseCourseForm
+    alias_method :subject_ids, :params
+
+    def initialize(model, params: {})
+      @previous_subject_names = model.subjects.map(&:subject_name)
+      @previous_course_name = model.name
+      super
+    end
+
+  private
+
+    attr_reader :previous_subject_names, :previous_course_name
+
+    def valid?
+      super && assign_subjects_service.valid?
+    end
+
+    def compute_fields
+      {}
+    end
+
+    def after_successful_save_action
+      return if (previous_course_name == course.name) && (previous_subject_names == course.subjects.map(&:subject_name))
+
+      NotificationService::CourseSubjectsUpdated.call(
+        course: course,
+        previous_subject_names: previous_subject_names,
+        previous_course_name: previous_course_name,
+      )
+    end
+
+    def assign_subjects_service
+      @assign_subjects_service ||= ::Courses::AssignSubjectsService.call(course: course, subject_ids: subject_ids)
+    end
+
+    def save_action
+      if assign_subjects_service.save
+        after_successful_save_action
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/app/forms/publish/course_withdrawal_form.rb
+++ b/app/forms/publish/course_withdrawal_form.rb
@@ -1,5 +1,5 @@
 module Publish
-  class CourseWithdrawalForm < BaseModelForm
+  class CourseWithdrawalForm < BaseCourseForm
     alias_method :course, :model
 
     FIELDS = %i[
@@ -13,12 +13,18 @@ module Publish
     def save!
       if valid?
         course.withdraw
+        after_successful_save_action
+        true
       else
         false
       end
     end
 
   private
+
+    def after_successful_save_action
+      NotificationService::CourseWithdrawn.call(course: course)
+    end
 
     def compute_fields
       course.attributes.symbolize_keys.slice(*FIELDS).merge(new_attributes)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -374,6 +374,11 @@ en:
           attributes:
             site_ids:
               no_locations: "Select at least one location"
+        publish/course_vacancies_form:
+          attributes:
+            change_vacancies_confirmation:
+              confirm_close_application: "Please confirm there are no vacancies to close applications"
+              confirm_reopen_application: "Please confirm there are vacancies to reopen applications"
         publish/course_requirement_form:
           attributes:
             required_qualifications:

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -32,7 +32,8 @@ private
   end
 
   def given_i_am_authenticated_as_a_provider_user
-    @user = create(:user, :with_provider)
+    provider = create(:provider)
+    @user = create(:user, providers: [provider])
     given_i_am_authenticated(user: @user)
   end
 

--- a/spec/forms/publish/base_course_form_spec.rb
+++ b/spec/forms/publish/base_course_form_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  class InheritedBaseCourseForm < BaseCourseForm
+    def compute_fields
+      {}
+    end
+  end
+
+  describe "BaseCourseForm", type: :model do
+    let(:params) { {} }
+    let(:course) { create(:course) }
+
+    let(:form) { InheritedBaseCourseForm.new(course, params: params) }
+
+    subject { form }
+
+    describe "#save!" do
+      it "calls the course updated notification service" do
+        expect(NotificationService::CourseUpdated).to receive(:call).with(course: course)
+        subject.save!
+      end
+    end
+  end
+end

--- a/spec/forms/publish/course_location_form_spec.rb
+++ b/spec/forms/publish/course_location_form_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseLocationForm, type: :model do
+    let(:params) { {} }
+    let(:site1) { build(:site, location_name: "location 1") }
+    let(:site2) { build(:site, location_name: "location 2") }
+    let(:site_status) { build(:site_status, :running, site: site1) }
+    let(:provider) { build(:provider, sites: [site1, site2]) }
+    let(:course) { create(:course, provider: provider, site_statuses: [site_status]) }
+
+    subject { described_class.new(course, params: params) }
+
+    describe "validations" do
+      before { subject.valid? }
+
+      it "validates :site_ids" do
+        expect(subject.errors[:site_ids]).to include(I18n.t("activemodel.errors.models.publish/course_location_form.attributes.site_ids.no_locations"))
+      end
+    end
+
+    describe "#save!" do
+      let(:previous_site_names) { course.sites.map(&:location_name) }
+
+      context "different site_ids to course site_ids" do
+        let(:params) { { site_ids: provider.site_ids } }
+
+        let(:updated_site_names) { provider.sites.map(&:location_name) }
+
+        it "calls the course sites updated notification service" do
+          expect(NotificationService::CourseSitesUpdated).to receive(:call)
+          .with(course: course, previous_site_names: previous_site_names, updated_site_names: updated_site_names)
+          subject.save!
+        end
+      end
+
+      context "same site_ids to course site_ids" do
+        let(:params) { { site_ids: course.site_ids } }
+
+        it "calls the course sites updated notification service" do
+          expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
+          subject.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/publish/course_location_form_spec.rb
+++ b/spec/forms/publish/course_location_form_spec.rb
@@ -39,7 +39,7 @@ module Publish
       context "same site_ids to course site_ids" do
         let(:params) { { site_ids: course.site_ids } }
 
-        it "calls the course sites updated notification service" do
+        it "does not call the course subjects updated notification service" do
           expect(NotificationService::CourseSitesUpdated).not_to receive(:call)
           subject.save!
         end

--- a/spec/forms/publish/course_subjects_form_spec.rb
+++ b/spec/forms/publish/course_subjects_form_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseSubjectsForm, type: :model do
+    let(:params) { subject_ids }
+    let(:subject_ids) { [biology_secondary_subject.id] }
+    let(:name) { "History" }
+    let(:course) { create(:course, :secondary, subjects: [history_secondary_subject], name: name) }
+    let(:biology_secondary_subject) { find_or_create(:secondary_subject, :biology) }
+    let(:history_secondary_subject) { find_or_create(:secondary_subject, :history) }
+
+    subject { described_class.new(course, params: params) }
+
+    describe "#save!" do
+      let(:previous_site_names) { course.sites.map(&:location_name) }
+
+      context "different subjects to course subjects" do
+        let(:previous_subject_names) { course.subjects.map(&:subject_name) }
+        let(:previous_course_name) { course.name }
+
+        it "calls the course subjects updated notification service" do
+          expect(NotificationService::CourseSubjectsUpdated).to receive(:call)
+          .with(course: course, previous_subject_names: previous_subject_names, previous_course_name: previous_course_name)
+          subject.save!
+        end
+      end
+
+      context "same subects to course subects" do
+        let(:params) { course.subject_ids }
+
+        it "calls the course subjects updated notification service" do
+          expect(NotificationService::CourseSubjectsUpdated).not_to receive(:call)
+          subject.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/publish/course_subjects_form_spec.rb
+++ b/spec/forms/publish/course_subjects_form_spec.rb
@@ -30,7 +30,7 @@ module Publish
       context "same subects to course subects" do
         let(:params) { course.subject_ids }
 
-        it "calls the course subjects updated notification service" do
+        it "does not call the course subjects updated notification service" do
           expect(NotificationService::CourseSubjectsUpdated).not_to receive(:call)
           subject.save!
         end

--- a/spec/forms/publish/course_vacancies_form_spec.rb
+++ b/spec/forms/publish/course_vacancies_form_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseVacanciesForm, type: :model do
+    let(:params) { {} }
+    let(:provider) { build(:provider, sites: [site]) }
+    let(:site) { build(:site) }
+    let(:findable) { build(:site_status, :findable, site: site) }
+    let(:study_mode) { :full_time }
+    let(:course) { create(:course, study_mode, provider: provider, site_statuses: site_statuses) }
+    let(:site_statuses) { [findable] }
+
+    subject { described_class.new(course, params: params) }
+
+    describe "validations" do
+      before { subject.valid? }
+
+      context "course has no vacancies" do
+        let(:site_statuses) { [] }
+
+        it "validates :change_vacancies_confirmation" do
+          expect(subject.errors[:change_vacancies_confirmation]).to include(I18n.t("activemodel.errors.models.publish/course_vacancies_form.attributes.change_vacancies_confirmation.confirm_reopen_application"))
+        end
+      end
+
+      context "course has vacancies" do
+        it "validates :change_vacancies_confirmation" do
+          expect(subject.errors[:change_vacancies_confirmation]).to include(I18n.t("activemodel.errors.models.publish/course_vacancies_form.attributes.change_vacancies_confirmation.confirm_close_application"))
+        end
+      end
+    end
+
+    describe "#save!" do
+      let(:vacancy_statuses) { [{ id: id, status: status }] }
+
+      context "multi sites" do
+        let(:with_any_vacancy) { build(:site_status, :with_any_vacancy, site: site) }
+        let(:site_statuses) { [findable, with_any_vacancy] }
+        let(:id) { with_any_vacancy.id }
+
+        let(:params) { { site_statuses_attributes: { "0": { id: with_any_vacancy.id } }, has_vacancies: false } }
+        let(:status) { "no_vacancies" }
+
+        context "with change_vacancies_confirmation as no_vacancies_confirmation" do
+          let(:change_vacancies_confirmation) { "no_vacancies_confirmation" }
+          let(:status) { "no_vacancies" }
+
+          it "calls the course vacancies updated notification service" do
+            expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
+            .with(course: course, vacancy_statuses: vacancy_statuses)
+            subject.save!
+          end
+        end
+      end
+
+      context "single site" do
+        let(:params) { { change_vacancies_confirmation: change_vacancies_confirmation } }
+        let(:id) { findable.id }
+
+        context "with change_vacancies_confirmation as no_vacancies_confirmation" do
+          let(:change_vacancies_confirmation) { "no_vacancies_confirmation" }
+          let(:status) { "no_vacancies" }
+
+          it "calls the course vacancies updated notification service" do
+            expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
+            .with(course: course, vacancy_statuses: vacancy_statuses)
+            subject.save!
+          end
+        end
+
+        context "with change_vacancies_confirmation as has_vacancies_confirmation" do
+          let(:change_vacancies_confirmation) { "has_vacancies_confirmation" }
+
+          context "with full time study mode" do
+            let(:status) { "full_time_vacancies" }
+
+            it "calls the course vacancies updated notification service" do
+              expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
+              .with(course: course, vacancy_statuses: vacancy_statuses)
+              subject.save!
+            end
+
+            context "with part time time study mode" do
+              let(:study_mode) { :part_time }
+              let(:site_statuses) { [findable_with_part_time_vacancies] }
+              let(:status) { "part_time_vacancies" }
+              let(:id) { findable_with_part_time_vacancies.id }
+              let(:findable_with_part_time_vacancies) { build(:site_status, :part_time_vacancies, :findable, site: site) }
+
+              let(:updated_site_names) { provider.sites.map(&:location_name) }
+
+              it "calls the course vacancies updated notification service" do
+                expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
+                .with(course: course, vacancy_statuses: vacancy_statuses)
+                subject.save!
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/forms/publish/course_vacancies_form_spec.rb
+++ b/spec/forms/publish/course_vacancies_form_spec.rb
@@ -81,21 +81,21 @@ module Publish
               .with(course: course, vacancy_statuses: vacancy_statuses)
               subject.save!
             end
+          end
 
-            context "with part time time study mode" do
-              let(:study_mode) { :part_time }
-              let(:site_statuses) { [findable_with_part_time_vacancies] }
-              let(:status) { "part_time_vacancies" }
-              let(:id) { findable_with_part_time_vacancies.id }
-              let(:findable_with_part_time_vacancies) { build(:site_status, :part_time_vacancies, :findable, site: site) }
+          context "with part time study mode" do
+            let(:study_mode) { :part_time }
+            let(:site_statuses) { [findable_with_part_time_vacancies] }
+            let(:status) { "part_time_vacancies" }
+            let(:id) { findable_with_part_time_vacancies.id }
+            let(:findable_with_part_time_vacancies) { build(:site_status, :part_time_vacancies, :findable, site: site) }
 
-              let(:updated_site_names) { provider.sites.map(&:location_name) }
+            let(:updated_site_names) { provider.sites.map(&:location_name) }
 
-              it "calls the course vacancies updated notification service" do
-                expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
-                .with(course: course, vacancy_statuses: vacancy_statuses)
-                subject.save!
-              end
+            it "calls the course vacancies updated notification service" do
+              expect(NotificationService::CourseVacanciesUpdated).to receive(:call)
+              .with(course: course, vacancy_statuses: vacancy_statuses)
+              subject.save!
             end
           end
         end

--- a/spec/forms/publish/course_withdrawal_form_spec.rb
+++ b/spec/forms/publish/course_withdrawal_form_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module Publish
+  describe CourseWithdrawalForm, type: :model do
+    let(:params) { {} }
+    let(:course) { create(:course) }
+
+    subject { described_class.new(course, params: params) }
+
+    describe "validations" do
+      before { subject.valid? }
+
+      it "validates :confirm_course_code" do
+        expect(subject.errors[:confirm_course_code]).to include(I18n.t("activemodel.errors.models.publish/course_withdrawal_form.attributes.confirm_course_code.invalid_code", course_code: course.course_code))
+      end
+    end
+
+    describe "#save!" do
+      let(:params) { { confirm_course_code: course.course_code } }
+
+      it "withdraws the course" do
+        expect(course).to receive(:withdraw)
+        subject.save!
+      end
+
+      it "calls the course withdrawn notification service" do
+        expect(NotificationService::CourseWithdrawn).to receive(:call).with(course: course)
+        subject.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context
Migrate notifications logic

### Changes proposed in this pull request
Migrated notifications logic for
- `NotificationService::CourseSitesUpdated`
- `NotificationService::CourseSubjectsUpdated`
- `NotificationService::CourseUpdated`
- `NotificationService::CourseVacanciesUpdated`
- `NotificationService::CourseWithdrawn`

An email for one of the above is sent whenever a change has been made to the related fields


### Guidance to review

Embedded it on the forms as well as some general tidy up.


- `NotificationService::CoursePublished` is covered elsewhere


### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
