### PR TITLE
[836] Migrate the training providers list

### DIFF
--- a/app/controllers/publish/training_providers/courses_controller.rb
+++ b/app/controllers/publish/training_providers/courses_controller.rb
@@ -1,0 +1,26 @@
+module Publish
+  module TrainingProviders
+    class CoursesController < PublishController
+      def index
+        authorize(provider, :index?)
+
+        @courses = fetch_courses
+      end
+
+    private
+
+      def training_provider
+        @training_provider ||= provider.training_providers.find_by(provider_code: params[:training_provider_code])
+      end
+
+      def fetch_courses
+        training_provider
+          .courses
+          .includes(:enrichments, site_statuses: [:site], provider: [:recruitment_cycle])
+          .where(accredited_body_code: provider.provider_code)
+          .order(:name)
+          .map(&:decorate)
+      end
+    end
+  end
+end

--- a/app/controllers/publish/training_providers_controller.rb
+++ b/app/controllers/publish/training_providers_controller.rb
@@ -1,0 +1,10 @@
+module Publish
+  class TrainingProvidersController < PublishController
+    def index
+      authorize(provider, :can_list_training_providers?)
+
+      @training_providers = provider.training_providers.include_accredited_courses_counts(provider.provider_code).order(:provider_name)
+      @course_counts = @training_providers.to_h { |p| [p.provider_code, p.accredited_courses_count] }
+    end
+  end
+end

--- a/app/views/publish/courses/_course_table.html.erb
+++ b/app/views/publish/courses/_course_table.html.erb
@@ -13,6 +13,6 @@
     </tr>
   </thead>
   <tbody class="govuk-table__body">
-    <%= render partial: "course_table_row", collection: courses, as: :course %>
+    <%= render partial: "publish/courses/course_table_row", collection: courses, as: :course %>
   </tbody>
 </table>

--- a/app/views/publish/training_providers/courses/index.html.erb
+++ b/app/views/publish/training_providers/courses/index.html.erb
@@ -1,0 +1,14 @@
+<% content_for :page_title, @provider.provider_name %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l">Training provider</span>
+  <%= @training_provider.provider_name %>
+</h1>
+
+<section data-qa="courses__table-section">
+  <%= render partial: "publish/courses/course_table", locals: { courses: @courses } %>
+</section>

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -1,0 +1,47 @@
+<% content_for :page_title, "Courses as an accredited body" %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    old_publish_link_for(
+      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    )
+  ) %>
+<% end %>
+
+<h1 class="govuk-heading-l">
+  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  Courses as an accredited body
+</h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Use this section to:</p>
+    <ul class="govuk-list govuk-list--bullet">
+      <li>see who lists you as their accredited body</li>
+      <li>see which courses you’re the accredited body for</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">Training providers</h2>
+    <ul class="govuk-list" data-qa="provider__training_providers_list">
+      <% @training_providers.each do |training_provider| %>
+        <li data-qa="training_provider">
+          <h3 class="govuk-heading-s">
+            <%= govuk_link_to(
+              training_provider.provider_name,
+              publish_provider_recruitment_cycle_training_provider_courses_path(
+                @provider.provider_code,
+                @provider.recruitment_cycle_year,
+                training_provider.provider_code,
+              ),
+              class: "govuk-!-font-weight-bold",
+              data: { qa: "link" },
+            ) %>
+            <span class="govuk-hint govuk-!-display-inline" data-qa="course_count">
+              <%= pluralize(@course_counts[training_provider.provider_code], "course") %>
+            </span>
+          </h3>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+</div>

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -34,7 +34,7 @@
                 training_provider.provider_code,
               ),
               class: "govuk-!-font-weight-bold",
-              data: { qa: "link" },
+              data: { qa: "training_provider_name" },
             ) %>
             <span class="govuk-hint govuk-!-display-inline" data-qa="course_count">
               <%= pluralize(@course_counts[training_provider.provider_code], "course") %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,10 @@ Rails.application.routes.draw do
         put "/about", on: :member, to: "providers#update"
         get "/details", on: :member, to: "providers#details"
 
+        resources :training_providers, path: "/training-providers", only: [:index], param: :code do
+          resources :courses, only: [:index], controller: "training_providers/courses"
+        end
+
         resource :courses, only: %i[create] do
           resource :outcome, on: :member, only: %i[new], controller: "courses/outcome" do
             get "continue"

--- a/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
+++ b/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing courses as an accredited body" do
+  before do
+    given_i_am_authenticated_as_an_accredited_body_user
+    and_some_courses_exist_with_one_i_accredit
+    when_i_visit_the_training_providers_page
+  end
+
+  scenario "i can see who lists me as their accredited body" do
+    then_i_should_see_a_list_of_training_providers
+    and_i_should_see_a_count_of_the_courses_i_accredit
+  end
+
+  scenario "i can see which courses i am the accredited body for" do
+    and_i_click_on_a_training_provider
+    then_i_see_the_courses_i_accredit_for
+  end
+
+  def given_i_am_authenticated_as_an_accredited_body_user
+    given_i_am_authenticated(user: create(:user, providers: [create(:provider, :accredited_body)]))
+  end
+
+  def and_some_courses_exist_with_one_i_accredit
+    given_a_course_exists(
+      enrichments: [build(:course_enrichment, :published)],
+      provider: create(:provider),
+      accrediting_provider: accrediting_provider,
+    )
+
+    create(:course, enrichments: [build(:course_enrichment, :published)], provider: create(:provider))
+  end
+
+  def when_i_visit_the_training_providers_page
+    training_providers_page.load(
+      provider_code: accrediting_provider.provider_code, recruitment_cycle_year: accrediting_provider.recruitment_cycle_year,
+    )
+  end
+
+  def then_i_should_see_a_list_of_training_providers
+    expect(training_providers_page.training_provider_rows.size).to eq(1)
+
+    expect(training_providers_page.training_provider_rows.first.name).to have_text(training_provider.provider_name)
+  end
+
+  def and_i_should_see_a_count_of_the_courses_i_accredit
+    expect(training_providers_page.training_provider_rows.first.course_count).to have_text("1")
+  end
+
+  def and_i_click_on_a_training_provider
+    training_providers_page.training_provider_rows.first.name.click
+  end
+
+  def then_i_see_the_courses_i_accredit_for
+    expect(training_provider_courses_page).to be_displayed
+    expect(training_provider_courses_page.courses.size).to eq(1)
+    expect(training_provider_courses_page.courses.first.name).to have_text(course.name)
+  end
+
+  def accrediting_provider
+    @current_user.providers.first
+  end
+
+  def training_provider
+    @training_provider ||= course.provider
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -175,5 +175,13 @@ module FeatureHelpers
     def gcse_requirements_page
       @gcse_requirements_page ||= PageObjects::Publish::Courses::GcseRequirementsPage.new
     end
+
+    def training_providers_page
+      @training_providers_page ||= PageObjects::Publish::TrainingProviderIndex.new
+    end
+
+    def training_provider_courses_page
+      @training_provider_courses_page ||= PageObjects::Publish::TrainingProviders::CourseIndex.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/training_provider_index.rb
+++ b/spec/support/page_objects/publish/training_provider_index.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require_relative "../sections/training_provider"
+
+module PageObjects
+  module Publish
+    class TrainingProviderIndex < PageObjects::Base
+      set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/training-providers"
+
+      sections :training_provider_rows, Sections::TrainingProvider, '[data-qa="provider__training_providers_list"]'
+    end
+  end
+end

--- a/spec/support/page_objects/publish/training_providers/course_index.rb
+++ b/spec/support/page_objects/publish/training_providers/course_index.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    module TrainingProviders
+      class CourseIndex < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/training-providers/{training_provider_code}/courses"
+
+        sections :courses, '[data-qa="courses__table-section"]' do
+          element :name, '[data-qa="courses-table__course-name"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/sections/training_provider.rb
+++ b/spec/support/page_objects/sections/training_provider.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative "base"
+
+module PageObjects
+  module Sections
+    class TrainingProvider < PageObjects::Sections::Base
+      element :name, '[data-qa="link"]'
+      element :course_count, '[data-qa="course_count"]'
+    end
+  end
+end

--- a/spec/support/page_objects/sections/training_provider.rb
+++ b/spec/support/page_objects/sections/training_provider.rb
@@ -5,7 +5,7 @@ require_relative "base"
 module PageObjects
   module Sections
     class TrainingProvider < PageObjects::Sections::Base
-      element :name, '[data-qa="link"]'
+      element :name, '[data-qa="training_provider_name"]'
       element :course_count, '[data-qa="course_count"]'
     end
   end


### PR DESCRIPTION
Also migrates their courses

### Context

- https://trello.com/c/fiQ1HxwQ/836-migrate-the-courses-as-an-accredited-body-section

### Changes proposed in this pull request

- Migrate the training providers page
- Migrate the courses list for each training provider

### Guidance to review

Export to CSV is handled in a separate ticket

Original implementation - https://qa.publish-teacher-training-courses.service.gov.uk/organisations/B25/2022/training-providers

Migrated version - https://teacher-training-api-pr-2593.london.cloudapps.digital/publish/organisations/B25/2022/training-providers

Check that the training provider list for the accredited provider from old publish matches the same on new publish (and their courses)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
