### PR TITLE
[854] Migrate the PE allocations section confirmed state

### DIFF
--- a/app/controllers/publish/providers/allocations_controller.rb
+++ b/app/controllers/publish/providers/allocations_controller.rb
@@ -1,0 +1,26 @@
+module Publish
+  module Providers
+    class AllocationsController < PublishController
+      def index
+        authorize(Allocation)
+
+        previous_recruitment_cycle = recruitment_cycle.previous
+        previous_recruitment_cycle_year = previous_recruitment_cycle.year.to_i
+
+        allocations = Allocation
+                        .includes(:provider, :accredited_body, :allocation_uplift)
+                        .where(accredited_body_code: provider.provider_code, recruitment_cycle: [previous_recruitment_cycle, recruitment_cycle])
+                        .all
+                        .group_by { |a| a.provider.recruitment_cycle_year }
+
+        @training_providers = (allocations[previous_recruitment_cycle_year] || []).filter_map { |a|
+          a.provider if a.request_type != AllocationsView::RequestType::DECLINED
+        }.sort_by(&:provider_name)
+
+        @allocations_view = AllocationsView.new(
+          allocations: allocations[Settings.allocation_cycle_year.to_s] || [], training_providers: @training_providers,
+        )
+      end
+    end
+  end
+end

--- a/app/view_objects/allocations_view.rb
+++ b/app/view_objects/allocations_view.rb
@@ -1,0 +1,215 @@
+class AllocationsView
+  include ActionView::Helpers::TextHelper
+
+  module Status
+    REQUESTED = "REQUESTED".freeze
+    NOT_REQUESTED = "NOT REQUESTED".freeze
+    YET_TO_REQUEST = "YET TO REQUEST".freeze
+    NO_REQUEST_SENT = "NO REQUEST SENT".freeze
+  end
+
+  module Colour
+    GREEN = "green".freeze
+    RED = "red".freeze
+    GREY = "grey".freeze
+  end
+
+  module Requested
+    YES = "yes".freeze
+    NO = "no".freeze
+  end
+
+  module RequestType
+    INITIAL = "initial".freeze
+    REPEAT = "repeat".freeze
+    DECLINED = "declined".freeze
+  end
+
+  def initialize(training_providers:, allocations:)
+    @training_providers = training_providers
+    @allocations = allocations
+  end
+
+  def repeat_allocation_statuses
+    filtered_training_providers.map do |training_provider|
+      matching_allocation = find_matching_allocation(training_provider, repeat_allocations)
+      build_repeat_allocations(matching_allocation, training_provider)
+    end
+  end
+
+  def initial_allocation_statuses
+    statuses = initial_allocations.map do |allocation|
+      build_initial_allocations(allocation, allocation.provider)
+    end
+
+    statuses.compact
+  end
+
+  def requested_allocations_statuses
+    statuses = requested_allocations.map do |allocation|
+      build_requested_allocations(allocation, allocation.provider)
+    end
+
+    statuses.compact.sort_by! { |hsh| hsh[:training_provider_name] }
+  end
+
+  def confirmed_allocation_places
+    statuses = confirmed_allocations.map do |allocation|
+      build_confirmed_allocations(allocation, allocation.provider)
+    end
+
+    statuses.compact.sort_by! { |hsh| hsh[:training_provider_name] }
+  end
+
+  def not_requested_allocations_statuses
+    statuses = filtered_training_providers.map do |training_provider|
+      matching_allocation = find_matching_allocation(training_provider, not_requested_allocations)
+      build_not_requested_allocations(matching_allocation, training_provider)
+    end
+
+    statuses.compact.sort_by! { |hsh| hsh[:training_provider_name] }
+  end
+
+private
+
+  def filtered_training_providers
+    # When displaying 'repeat allocation statuses'
+    # we need to first filter out those training providers
+    # who will be allocated places for the first time (i.e. where the accredited provider)
+    # has made initial allocation requests on their behalf)
+    training_provider_provider_codes = initial_allocations.map { |allocation| allocation.provider.provider_code }
+    @training_providers.reject { |tp| training_provider_provider_codes.include?(tp.provider_code) }
+  end
+
+  def repeat_allocations
+    @allocations.reject { |allocation| allocation.request_type == RequestType::INITIAL }
+  end
+
+  def initial_allocations
+    @allocations.select { |allocation| allocation.request_type == RequestType::INITIAL }
+  end
+
+  def requested_allocations
+    @allocations.select { |allocation| allocation.request_type.in?([RequestType::INITIAL, RequestType::REPEAT]) }
+  end
+
+  def confirmed_allocations
+    @allocations.select { |allocation| allocation.request_type.in?([RequestType::INITIAL, RequestType::REPEAT]) }
+  end
+
+  def not_requested_allocations
+    @allocations.select { |allocation| allocation.request_type == RequestType::DECLINED }
+  end
+
+  def find_matching_allocation(training_provider, allocations)
+    allocations.find { |allocation| allocation.provider.provider_code == training_provider.provider_code }
+  end
+
+  def build_repeat_allocations(matching_allocation, training_provider)
+    allocation_status = {
+      training_provider_name: training_provider.provider_name,
+      training_provider_code: training_provider.provider_code,
+    }
+
+    if yet_to_request?(matching_allocation)
+      allocation_status[:status] = Status::YET_TO_REQUEST
+      allocation_status[:status_colour] = Colour::GREY
+    end
+
+    if requested?(matching_allocation)
+      allocation_status[:status] = Status::REQUESTED
+      allocation_status[:status_colour] = Colour::GREEN
+      allocation_status[:requested] = Requested::YES
+    end
+
+    if not_requested?(matching_allocation)
+      allocation_status[:status] = Status::NOT_REQUESTED
+      allocation_status[:status_colour] = Colour::RED
+      allocation_status[:requested] = Requested::NO
+    end
+
+    if matching_allocation
+      allocation_status[:id] = matching_allocation.id
+      allocation_status[:request_type] = matching_allocation.request_type
+    end
+
+    if matching_allocation&.accredited_body
+      allocation_status[:accredited_body_code] = matching_allocation.accredited_body.provider_code
+    end
+
+    allocation_status
+  end
+
+  def build_initial_allocations(matching_allocation, training_provider)
+    return if matching_allocation.nil?
+
+    hash = {
+      training_provider_name: training_provider.provider_name,
+      training_provider_code: training_provider.provider_code,
+      status_colour: Colour::GREEN,
+      requested: Requested::YES,
+      request_type: matching_allocation.request_type,
+      status: "#{pluralize(matching_allocation.number_of_places, 'place')} requested".upcase,
+    }
+
+    hash[:id] = matching_allocation.id if matching_allocation.id
+
+    hash
+  end
+
+  def build_confirmed_allocations(allocation, training_provider)
+    return if allocation.nil?
+
+    {
+      training_provider_name: training_provider.provider_name,
+      number_of_places: allocation.number_of_places,
+      confirmed_number_of_places: allocation.confirmed_number_of_places,
+      uplifts: allocation.allocation_uplift&.uplifts,
+      total: allocation.confirmed_number_of_places.to_i + allocation.allocation_uplift&.uplifts.to_i,
+    }
+  end
+
+  def build_requested_allocations(allocation, training_provider)
+    return if allocation.nil?
+
+    {
+      training_provider_name: training_provider.provider_name,
+      training_provider_code: training_provider.provider_code,
+      status_colour: Colour::GREEN,
+      status: Status::REQUESTED,
+    }
+  end
+
+  def build_not_requested_allocations(allocation, training_provider)
+    return if training_provider.provider_name.in?(requested_allocations_statuses.map { |tp| tp[:training_provider_name] })
+
+    allocation_status = {
+      training_provider_name: training_provider.provider_name,
+      training_provider_code: training_provider.provider_code,
+    }
+
+    if yet_to_request?(allocation)
+      allocation_status[:status] = "NO REQUEST SENT"
+      allocation_status[:status_colour] = Colour::GREY
+    end
+
+    if not_requested?(allocation)
+      allocation_status[:status] = Status::NOT_REQUESTED
+      allocation_status[:status_colour] = Colour::RED
+    end
+
+    allocation_status
+  end
+
+  def not_requested?(matching_allocation)
+    matching_allocation && matching_allocation[:request_type] == RequestType::DECLINED
+  end
+
+  def requested?(matching_allocation)
+    matching_allocation && matching_allocation[:request_type] == RequestType::REPEAT
+  end
+
+  def yet_to_request?(matching_allocation)
+    matching_allocation.nil?
+  end
+end

--- a/app/views/publish/providers/allocations/allocation_report/_confirmed_state.html.erb
+++ b/app/views/publish/providers/allocations/allocation_report/_confirmed_state.html.erb
@@ -1,0 +1,37 @@
+<table class="govuk-table">
+  <caption class="govuk-visually-hidden">A list of confirmed allocations for <%= next_allocation_cycle_period_text %></caption>
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header govuk-!-width-two-thirds" scope="col">
+        Organisation
+      </th>
+      <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
+        Allocation (granted)
+      </th>
+      <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
+        Uplift (granted)
+      </th>
+      <th class="govuk-table__header govuk-!-width-one-quarter" scope="col">
+        Total places (granted)
+      </th>
+    </tr>
+  </thead>
+  <tbody class="govuk-table__body">
+  <% confirmed_allocations.each do |allocation| %>
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" data-qa="provider-name" scope="row">
+        <%= allocation[:training_provider_name] %>
+      </th>
+      <td class="govuk-table__cell" data-qa="confirmed-places">
+        <%= allocation[:confirmed_number_of_places] %>
+      </td>
+      <td class="govuk-table__cell" data-qa="uplifts">
+        <%= allocation[:uplifts] %>
+      </td>
+      <td class="govuk-table__cell">
+        <%= allocation[:total] %>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/publish/providers/allocations/allocation_request/_confirmed_state.html.erb
+++ b/app/views/publish/providers/allocations/allocation_request/_confirmed_state.html.erb
@@ -1,0 +1,63 @@
+
+<% content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(
+    old_publish_link_for(
+      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    )
+  ) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">PE allocations for <%= next_allocation_cycle_period_text %></h1>
+
+    <% if @allocations_view.confirmed_allocation_places.any? %>
+      <p class="govuk-body">
+        Organisations that offered fee-funded PE last year will receive the same amount of places for <%= next_allocation_cycle_period_text %>.
+      </p>
+
+      <p class="govuk-body">
+        Organisations that are offering PE for the first time in <%= next_allocation_cycle_period_text %> will receive 50% of their request.
+      </p>
+
+      <p class="govuk-body">
+        DfE expects providers to recruit in line with their allocation. If you determine that there is an additional need for PE trainees, you may request an uplift to the number of PE (fee-funded) places your organisation has been allocated.
+      </p>
+
+      <p class="govuk-body">
+        Requests for an uplift can be made via this form from 9am on Tuesday 5 October: <%= govuk_link_to "Request an uplift.", "https://docs.google.com/forms/d/e/1FAIpQLSd2lAc7kTV0daQqJKkbMacHQzVzqhrXHmjLzHYsGKwyhOeKnQ/viewform?usp=sf_link" %>
+      </p>
+
+      <p class="govuk-body">
+        The team will review your request and you’ll be notified of the outcome via email.
+        We do not expect providers to submit multiple requests throughout the cycle so any requests should be mindful of likely need throughout ITT2022.
+        Please be aware that DfE will be closely monitoring PE recruitment and reserves the right to stop PE recruitment at any time.
+      </p>
+
+      <p class="govuk-body">
+        Organisations can now also publish PE with EBacc subject courses, and make them available for candidates to view on <%= govuk_link_to "Find postgraduate teacher training.", "https://www.gov.uk/find-postgraduate-teacher-training-courses"%>
+      </p>
+
+      <p class="govuk-body">
+        Contact us at <%= bat_contact_mail_to %> if you have any questions.
+      </p>
+
+      <%= render partial: "publish/providers/allocations/allocation_report/confirmed_state", locals: {
+                 confirmed_allocations: @allocations_view.confirmed_allocation_places,
+               } %>
+    <% else %>
+      <p class="govuk-body">
+        You did not request any allocations for fee-funded PE courses for <%= next_allocation_cycle_period_text %>.
+      </p>
+
+      <p class="govuk-body">
+        Any current PE courses (<%= current_allocation_cycle_period_text %>) that you have not requested allocations for will not run in <%= next_allocation_cycle_period_text %>.
+      </p>
+
+      <p class="govuk-body">
+        Contact us at <%= bat_contact_mail_to %> if you have any questions.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/publish/providers/allocations/index.html.erb
+++ b/app/views/publish/providers/allocations/index.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "publish/providers/allocations/allocation_request/#{Settings.features.allocations.state}_state" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,8 @@ Rails.application.routes.draw do
           put "/contact", on: :member, to: "contacts#update"
           get "/visas", on: :member, to: "visas#edit"
           put "/visas", on: :member, to: "visas#update"
+
+          resources :allocations, only: %i[index], on: :member, param: :training_provider_code
         end
       end
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -104,3 +104,7 @@ features:
     has_current_cycle_started?: true
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: false
+  allocations:
+    # state: open # Users can make requests for allocations
+    # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
+    state: confirmed # final allocation places are displayed to users in a readonly state

--- a/docs/allocations.md
+++ b/docs/allocations.md
@@ -1,0 +1,81 @@
+# Allocations
+
+## What is Allocations?
+
+Each year, around the same time as [Rollover](./rollover.md), providers request
+places for some over-supplied courses. This is to limit the number of applicants 
+for these courses. This process is called 'Allocations'.
+
+Providers request places for courses one academic year in advance. For example,
+when allocations opened in 2021, providers requested places for courses for the
+academic year 2022/23.
+
+## How does it work?
+
+### When allocations are open
+
+Accredited bodies should be able to request allocations.
+
+They should see:
+
+1. A button to request allocations for a new provider.
+2. A table of previously-requested providers with the tag 'Yet to request' and a link to re-request for this current cycle. They can then choose to either:
+
+    a) re-request for this cycle, or
+
+    b) request no allocations
+
+These two forms do the following:
+
+| Action | Allocation enum | Data changes |
+|--------|-----------------|--------------|
+| 1. Requesting for a new provider | `"initial"` | A new allocation is created for the current cycle with a `"initial" request_type` with their requested `number_of_places`. |
+| 2a. Re-requesting for a provider | `"repeat"` | A new allocation is created for the current cycle with a `"repeat" request_type`. The `number_of_places` is set to the `confirmed_number_of_places` for the previous recruitment cycle's allocation. |
+| 2b. Requesting no allocations for a provider | `"declined"` | A new allocation is created for the current cycle with a `"declined" request_type`. The `number_of_places` is set to `0` |
+
+_There is no need to manually copy allocations from the previous year to the_
+_current cycle. The allocations are created and pre-populated for the current_
+_cycle via the above forms._
+
+### When allocations are closed
+
+Accredited bodies should be able to see what providers they have
+requested allocations for, but not the numbers requested.
+
+During this time allocations are internally decided upon and providers may or
+may not receive the numbers they requested. Once finalised, these numbers are
+inserted into the `confirmed_number_of_places` column of the `allocation` table.
+
+### When allocations are confirmed
+
+Accredited bodies should be able to view the confirmed number of places for each
+provider they requested.
+
+## What do we need to do?
+
+This document lists the changes needed to be made to the Publish codebase and
+the timings for these changes.
+
+### Before (or on) Allocations open date
+
+- Update the setting `allocations_close_date` to reflect the date on which
+  Allocations are closed.
+
+### On Allocations open date
+
+- Set feature flag `allocations: state: open`.
+- Set feature flag `show_next_cycle_allocation_recruitment_page: true` so that
+  users are shown the interrupt screen when they first sign in.
+- Increment the setting `allocation_cycle_year`.
+- Increment the setting `allocation_cycle_year` in the Teacher Training API.
+  This should match what you've set here in Publish.
+
+### On Allocations close date
+
+- Set feature flag `allocations: state: closed`
+- Set feature flag `show_next_cycle_allocation_recruitment_page: false` to turn
+  off the interrupt page.
+
+### On Allocations confirmed date
+
+- Set feature flag `allocations: state: confirmed`

--- a/spec/features/publish/allocations/view_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_allocation_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.feature "PE allocations" do
+  before do
+    allow(Settings.features.allocations).to receive(:state).and_return("confirmed")
+    allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+    given_i_am_authenticated(user: user_with_accredited_bodies)
+    and_there_is_a_previous_recruitment_cycle
+  end
+
+  context "when a provider does not have allocations assigned to them" do
+    scenario "an accredited body views PE allocations page" do
+      when_i_visit_allocations_page(accredited_body_with_no_allocation)
+      then_it_has_the_correct_no_allocations_message
+    end
+  end
+
+  context "When a provider has allocations assigned to them" do
+    scenario "an accredited body views PE allocations page" do
+      and_an_allocation_exists_assigned_to_accredited_body
+      when_i_visit_allocations_page(accredited_body_with_allocation)
+      then_it_has_the_correct_allocations_content
+    end
+  end
+
+private
+
+  def and_there_is_a_previous_recruitment_cycle
+    find_or_create(:recruitment_cycle, :previous)
+  end
+
+  def current_recruitment_cycle
+    @current_recruitment_cycle ||= find_or_create(:recruitment_cycle)
+  end
+
+  def accredited_body_with_allocation
+    @accredited_body ||= build(:provider, :accredited_body,
+                               recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def accredited_body_with_no_allocation
+    @accredited_body_with_no_allocation ||= build(:provider, :accredited_body,
+                                                  recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def training_provider
+    @training_provider ||= build(:provider, recruitment_cycle: current_recruitment_cycle)
+  end
+
+  def user_with_accredited_bodies
+    @user_with_accredited_bodies ||= create(:user, providers:
+      [accredited_body_with_allocation, accredited_body_with_no_allocation])
+  end
+
+  def next_allocation_cycle_period_text
+    "#{Settings.allocation_cycle_year + 1} to #{Settings.allocation_cycle_year + 2}"
+  end
+
+  def and_an_allocation_exists_assigned_to_accredited_body
+    allocation
+  end
+
+  def when_i_visit_allocations_page(provider)
+    allocations_page.load(provider_code: provider.provider_code,
+                          recruitment_cycle_year: provider.recruitment_cycle_year)
+  end
+
+  def then_it_has_the_correct_no_allocations_message
+    expect(allocations_page).to have_content("You did not request any allocations for fee-funded PE courses for #{next_allocation_cycle_period_text}")
+  end
+
+  def then_it_has_the_correct_allocations_content
+    expect(allocations_page.rows.first.provider_name.text).to eq(training_provider.provider_name)
+    expect(allocations_page.rows.first.allocation_number.text.to_i).to eq(allocation.confirmed_number_of_places)
+    expect(allocations_page.rows.first.uplift_number.text.to_i).to eq(allocation.allocation_uplift.uplifts)
+  end
+
+  def allocation
+    @allocation ||= create(
+      :allocation,
+      :with_allocation_uplift,
+      :repeat,
+      accredited_body: accredited_body_with_allocation,
+      provider: training_provider,
+      number_of_places: 3,
+      confirmed_number_of_places: 10,
+    )
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -183,5 +183,9 @@ module FeatureHelpers
     def training_provider_courses_page
       @training_provider_courses_page ||= PageObjects::Publish::TrainingProviders::CourseIndex.new
     end
+
+    def allocations_page
+      @allocations_page ||= PageObjects::Publish::Allocations::AllocationsPage.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/allocations/allocations_page.rb
+++ b/spec/support/page_objects/publish/allocations/allocations_page.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative "../../sections/errorlink"
+
+module PageObjects
+  module Publish
+    module Allocations
+      class AllocationsPage < PageObjects::Base
+        set_url "/publish/organisations/{provider_code}/{recruitment_cycle_year}/allocations"
+
+        sections :rows, "tbody tr" do
+          element :provider_name, '[data-qa="provider-name"]'
+          element :status, "td[:nth-child(1)"
+          element :actions, "td[:nth-child(2)"
+          element :allocation_number, '[data-qa="confirmed-places"]'
+          element :uplift_number, '[data-qa="uplifts"]'
+        end
+      end
+    end
+  end
+end

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -1,0 +1,368 @@
+require "rails_helper"
+
+describe AllocationsView do
+  let(:training_provider) { build(:provider, provider_name: "Training Provider 1") }
+  let(:another_training_provider) { build(:provider, provider_name: "Training Provider 2") }
+  let(:accredited_body) { build(:provider) }
+  let(:training_providers) { [training_provider, another_training_provider] }
+
+  describe "#allocation_renewals" do
+    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).repeat_allocation_statuses }
+
+    context "Accrediting provider has re-requested an allocation for a training provider" do
+      let(:repeat_allocation) do
+        build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+      end
+      let(:initial_allocation) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 3)
+      end
+      let(:allocations) { [repeat_allocation, initial_allocation] }
+
+      it {
+        expect(subject).to eq([
+          {
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            accredited_body_code: accredited_body.provider_code,
+            status: AllocationsView::Status::REQUESTED,
+            status_colour: AllocationsView::Colour::GREEN,
+            requested: AllocationsView::Requested::YES,
+            id: repeat_allocation.id,
+            request_type: AllocationsView::RequestType::REPEAT,
+          },
+        ])
+      }
+    end
+
+    context "Accredited body has declined an allocation for a training provider" do
+      let(:declined_allocation) { build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0) }
+      let(:initial_allocation) do
+        build(:allocation, :initial, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 3)
+      end
+      let(:allocations) { [declined_allocation, initial_allocation] }
+
+      it {
+        expect(subject).to eq([
+          {
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            accredited_body_code: accredited_body.provider_code,
+            status: AllocationsView::Status::NOT_REQUESTED,
+            status_colour: AllocationsView::Colour::RED,
+            requested: AllocationsView::Requested::NO,
+            id: declined_allocation.id,
+            request_type: AllocationsView::RequestType::DECLINED,
+          },
+        ])
+      }
+    end
+
+    context "Accredited body is yet to repeat or decline an allocation for a training provider" do
+      let(:allocations) { [] }
+
+      it {
+        expect(subject).to eq([
+          {
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            status: AllocationsView::Status::YET_TO_REQUEST,
+            status_colour: AllocationsView::Colour::GREY,
+          },
+          {
+            training_provider_name: another_training_provider.provider_name,
+            training_provider_code: another_training_provider.provider_code,
+            status: AllocationsView::Status::YET_TO_REQUEST,
+            status_colour: AllocationsView::Colour::GREY,
+          },
+        ])
+      }
+    end
+  end
+
+  describe "#initial_allocations" do
+    subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).initial_allocation_statuses }
+
+    context "Accredited body has requested an initial allocation for a training provider" do
+      context "more than 1 place requested" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 3)
+        end
+
+        let(:repeat_allocation) do
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 4)
+        end
+
+        let(:allocations) { [initial_allocation, repeat_allocation] }
+
+        it {
+          expect(subject).to eq([
+            {
+              training_provider_name: training_provider.provider_name,
+              training_provider_code: training_provider.provider_code,
+              status: "3 PLACES REQUESTED",
+              status_colour: AllocationsView::Colour::GREEN,
+              requested: AllocationsView::Requested::YES,
+              request_type: AllocationsView::RequestType::INITIAL,
+            },
+          ])
+        }
+      end
+
+      context "1 place requested" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+
+        let(:allocations) { [initial_allocation] }
+
+        it "correctly pluralizes the status" do
+          expect(subject.first[:status]).to eq("1 PLACE REQUESTED")
+        end
+      end
+    end
+
+    context "Accredited body has not requested initial allocations for any training provider" do
+      let(:repeat_allocation) do
+        build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 4)
+      end
+
+      let(:allocations) { [repeat_allocation] }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  context "allocations are confirmed" do
+    describe "#confirmed_allocation_places" do
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).confirmed_allocation_places }
+
+      context "returns confirmed repeat and initial allocations with number of places" do
+        let(:confirmed_repeat_allocation) do
+          build(:allocation, :repeat, :with_allocation_uplift, accredited_body: accredited_body,
+                                                               provider: training_provider,
+                                                               number_of_places: 1,
+                                                               confirmed_number_of_places: 3)
+        end
+
+        let(:confirmed_initial_allocation) do
+          build(:allocation, :initial, :with_allocation_uplift, accredited_body: accredited_body,
+                                                                provider: another_training_provider,
+                                                                number_of_places: 2,
+                                                                confirmed_number_of_places: 4)
+        end
+
+        let(:allocations) { [confirmed_repeat_allocation, confirmed_initial_allocation] }
+
+        it {
+          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
+                                   number_of_places: confirmed_repeat_allocation.number_of_places,
+                                   confirmed_number_of_places: confirmed_repeat_allocation.confirmed_number_of_places,
+                                   uplifts: confirmed_repeat_allocation.allocation_uplift.uplifts,
+                                   total: confirmed_repeat_allocation.confirmed_number_of_places + confirmed_repeat_allocation.allocation_uplift.uplifts },
+                                 { training_provider_name: another_training_provider.provider_name,
+                                   number_of_places: confirmed_initial_allocation.number_of_places,
+                                   confirmed_number_of_places: confirmed_initial_allocation.confirmed_number_of_places,
+                                   uplifts: confirmed_initial_allocation.allocation_uplift.uplifts,
+                                   total: confirmed_initial_allocation.confirmed_number_of_places + confirmed_initial_allocation.allocation_uplift.uplifts }])
+        }
+      end
+
+      context "no confirmed declined allocations are returned" do
+        let(:confirmed_declined_allocation) do
+          build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0)
+        end
+
+        let(:allocations) { [confirmed_declined_allocation] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+
+      context "no allocations are returned if their status is 'YET TO REQUEST'" do
+        let(:allocations) { [] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+    end
+  end
+
+  context "allocation period is closed" do
+    describe "#requested_allocations" do
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).requested_allocations_statuses }
+
+      context "returns allocations if their status is 'REPEATED'" do
+        let(:repeat_allocation) do
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+        let(:allocations) { [repeat_allocation] }
+
+        it {
+          expect(subject).to eq([{
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            status_colour: AllocationsView::Colour::GREEN,
+            status: AllocationsView::Status::REQUESTED,
+          }])
+        }
+      end
+
+      context "returns allocations if their status is 'INITIAL'" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+        let(:allocations) { [initial_allocation] }
+
+        it {
+          expect(subject).to eq([{
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            status_colour: AllocationsView::Colour::GREEN,
+            status: AllocationsView::Status::REQUESTED,
+          }])
+        }
+
+        it "does not display number of requested places in the status" do
+          expect(subject.first[:status]).to eq("REQUESTED")
+        end
+      end
+
+      context "no allocations are returned if their status is 'DECLINED'" do
+        let(:declined_allocation) do
+          build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0)
+        end
+        let(:training_providers) { [training_provider] }
+        let(:allocations) { [declined_allocation] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+
+      context "no allocations are returned if their status is 'YET TO REQUEST'" do
+        let(:training_providers) { [training_provider] }
+        let(:allocations) { [] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+
+      describe "allocation ordering" do
+        let(:initial_allocation) do
+          training_provider.provider_name = "Training Provider A"
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+        let(:repeat_allocation) do
+          another_training_provider.provider_name = "Training Provider B"
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: another_training_provider, number_of_places: 0)
+        end
+
+        let(:allocations) { [initial_allocation, repeat_allocation] }
+
+        it "is sorted by the provider name" do
+          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
+                                   training_provider_code: training_provider.provider_code,
+                                   status_colour: AllocationsView::Colour::GREEN,
+                                   status: AllocationsView::Status::REQUESTED },
+                                 { training_provider_name: another_training_provider.provider_name,
+                                   training_provider_code: another_training_provider.provider_code,
+                                   status_colour: AllocationsView::Colour::GREEN,
+                                   status: AllocationsView::Status::REQUESTED }])
+        end
+
+        it "does not display number of requested places in the status" do
+          expect(subject.first[:status]).to eq("REQUESTED")
+        end
+      end
+    end
+
+    describe "#not_requested_allocations" do
+      subject { AllocationsView.new(training_providers: training_providers, allocations: allocations).not_requested_allocations_statuses }
+
+      context "returns allocations where status is 'NOT REQUESTED'" do
+        let(:declined_allocation) { build(:allocation, :declined, accredited_body: accredited_body, provider: training_provider, number_of_places: 0) }
+
+        let(:training_providers) { [training_provider] }
+
+        let(:allocations) { [declined_allocation] }
+
+        it {
+          expect(subject).to eq([{
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            status: AllocationsView::Status::NOT_REQUESTED,
+            status_colour: AllocationsView::Colour::RED,
+          }])
+        }
+      end
+
+      context "returns allocations where status is 'YET TO REQUEST'" do
+        let(:allocations) { [] }
+
+        let(:training_providers) { [training_provider] }
+
+        it {
+          expect(subject).to eq([{
+            training_provider_name: training_provider.provider_name,
+            training_provider_code: training_provider.provider_code,
+            status: AllocationsView::Status::NO_REQUEST_SENT,
+            status_colour: AllocationsView::Colour::GREY,
+          }])
+        }
+      end
+
+      context "no allocations are returned if their status is 'REQUESTED" do
+        let(:repeat_allocation) do
+          build(:allocation, :repeat, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+
+        let(:allocations) { [repeat_allocation] }
+
+        let(:training_providers) { [training_provider] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+
+      context "no allocations are returned if their status is 'INITIAL'" do
+        let(:initial_allocation) do
+          build(:allocation, :initial, accredited_body: accredited_body, provider: training_provider, number_of_places: 1)
+        end
+
+        let(:allocations) { [initial_allocation] }
+
+        let(:training_providers) { [training_provider] }
+
+        it {
+          expect(subject).to eq([])
+        }
+      end
+
+      describe "allocation ordering" do
+        before do
+          training_provider.provider_name = "Training Provider A"
+          another_training_provider.provider_name = "Training Provider B"
+        end
+
+        let(:allocations) { [] }
+
+        it "is sorted by the provider name" do
+          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
+                                   training_provider_code: training_provider.provider_code,
+                                   status: AllocationsView::Status::NO_REQUEST_SENT,
+                                   status_colour: AllocationsView::Colour::GREY },
+                                 {
+                                   training_provider_name: another_training_provider.provider_name,
+                                   training_provider_code: another_training_provider.provider_code,
+                                   status: AllocationsView::Status::NO_REQUEST_SENT,
+                                   status_colour: AllocationsView::Colour::GREY,
+                                 }])
+        end
+      end
+    end
+  end
+end

--- a/spec/view_objects/allocations_view_spec.rb
+++ b/spec/view_objects/allocations_view_spec.rb
@@ -18,7 +18,7 @@ describe AllocationsView do
       end
       let(:allocations) { [repeat_allocation, initial_allocation] }
 
-      it {
+      it do
         expect(subject).to eq([
           {
             training_provider_name: training_provider.provider_name,
@@ -31,7 +31,7 @@ describe AllocationsView do
             request_type: AllocationsView::RequestType::REPEAT,
           },
         ])
-      }
+      end
     end
 
     context "Accredited body has declined an allocation for a training provider" do
@@ -41,7 +41,7 @@ describe AllocationsView do
       end
       let(:allocations) { [declined_allocation, initial_allocation] }
 
-      it {
+      it do
         expect(subject).to eq([
           {
             training_provider_name: training_provider.provider_name,
@@ -54,13 +54,13 @@ describe AllocationsView do
             request_type: AllocationsView::RequestType::DECLINED,
           },
         ])
-      }
+      end
     end
 
     context "Accredited body is yet to repeat or decline an allocation for a training provider" do
       let(:allocations) { [] }
 
-      it {
+      it do
         expect(subject).to eq([
           {
             training_provider_name: training_provider.provider_name,
@@ -75,7 +75,7 @@ describe AllocationsView do
             status_colour: AllocationsView::Colour::GREY,
           },
         ])
-      }
+      end
     end
   end
 
@@ -94,7 +94,7 @@ describe AllocationsView do
 
         let(:allocations) { [initial_allocation, repeat_allocation] }
 
-        it {
+        it do
           expect(subject).to eq([
             {
               training_provider_name: training_provider.provider_name,
@@ -105,7 +105,7 @@ describe AllocationsView do
               request_type: AllocationsView::RequestType::INITIAL,
             },
           ])
-        }
+        end
       end
 
       context "1 place requested" do
@@ -153,18 +153,20 @@ describe AllocationsView do
 
         let(:allocations) { [confirmed_repeat_allocation, confirmed_initial_allocation] }
 
-        it {
-          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
-                                   number_of_places: confirmed_repeat_allocation.number_of_places,
-                                   confirmed_number_of_places: confirmed_repeat_allocation.confirmed_number_of_places,
-                                   uplifts: confirmed_repeat_allocation.allocation_uplift.uplifts,
-                                   total: confirmed_repeat_allocation.confirmed_number_of_places + confirmed_repeat_allocation.allocation_uplift.uplifts },
-                                 { training_provider_name: another_training_provider.provider_name,
-                                   number_of_places: confirmed_initial_allocation.number_of_places,
-                                   confirmed_number_of_places: confirmed_initial_allocation.confirmed_number_of_places,
-                                   uplifts: confirmed_initial_allocation.allocation_uplift.uplifts,
-                                   total: confirmed_initial_allocation.confirmed_number_of_places + confirmed_initial_allocation.allocation_uplift.uplifts }])
-        }
+        it do
+          expect(subject).to eq([
+            { training_provider_name: training_provider.provider_name,
+              number_of_places: confirmed_repeat_allocation.number_of_places,
+              confirmed_number_of_places: confirmed_repeat_allocation.confirmed_number_of_places,
+              uplifts: confirmed_repeat_allocation.allocation_uplift.uplifts,
+              total: confirmed_repeat_allocation.confirmed_number_of_places + confirmed_repeat_allocation.allocation_uplift.uplifts },
+            { training_provider_name: another_training_provider.provider_name,
+              number_of_places: confirmed_initial_allocation.number_of_places,
+              confirmed_number_of_places: confirmed_initial_allocation.confirmed_number_of_places,
+              uplifts: confirmed_initial_allocation.allocation_uplift.uplifts,
+              total: confirmed_initial_allocation.confirmed_number_of_places + confirmed_initial_allocation.allocation_uplift.uplifts },
+          ])
+        end
       end
 
       context "no confirmed declined allocations are returned" do
@@ -174,17 +176,13 @@ describe AllocationsView do
 
         let(:allocations) { [confirmed_declined_allocation] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
 
       context "no allocations are returned if their status is 'YET TO REQUEST'" do
         let(:allocations) { [] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
     end
   end
@@ -199,14 +197,14 @@ describe AllocationsView do
         end
         let(:allocations) { [repeat_allocation] }
 
-        it {
+        it do
           expect(subject).to eq([{
             training_provider_name: training_provider.provider_name,
             training_provider_code: training_provider.provider_code,
             status_colour: AllocationsView::Colour::GREEN,
             status: AllocationsView::Status::REQUESTED,
           }])
-        }
+        end
       end
 
       context "returns allocations if their status is 'INITIAL'" do
@@ -215,14 +213,14 @@ describe AllocationsView do
         end
         let(:allocations) { [initial_allocation] }
 
-        it {
+        it do
           expect(subject).to eq([{
             training_provider_name: training_provider.provider_name,
             training_provider_code: training_provider.provider_code,
             status_colour: AllocationsView::Colour::GREEN,
             status: AllocationsView::Status::REQUESTED,
           }])
-        }
+        end
 
         it "does not display number of requested places in the status" do
           expect(subject.first[:status]).to eq("REQUESTED")
@@ -236,18 +234,14 @@ describe AllocationsView do
         let(:training_providers) { [training_provider] }
         let(:allocations) { [declined_allocation] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
 
       context "no allocations are returned if their status is 'YET TO REQUEST'" do
         let(:training_providers) { [training_provider] }
         let(:allocations) { [] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
 
       describe "allocation ordering" do
@@ -263,14 +257,16 @@ describe AllocationsView do
         let(:allocations) { [initial_allocation, repeat_allocation] }
 
         it "is sorted by the provider name" do
-          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
-                                   training_provider_code: training_provider.provider_code,
-                                   status_colour: AllocationsView::Colour::GREEN,
-                                   status: AllocationsView::Status::REQUESTED },
-                                 { training_provider_name: another_training_provider.provider_name,
-                                   training_provider_code: another_training_provider.provider_code,
-                                   status_colour: AllocationsView::Colour::GREEN,
-                                   status: AllocationsView::Status::REQUESTED }])
+          expect(subject).to eq([
+            { training_provider_name: training_provider.provider_name,
+              training_provider_code: training_provider.provider_code,
+              status_colour: AllocationsView::Colour::GREEN,
+              status: AllocationsView::Status::REQUESTED },
+            { training_provider_name: another_training_provider.provider_name,
+              training_provider_code: another_training_provider.provider_code,
+              status_colour: AllocationsView::Colour::GREEN,
+              status: AllocationsView::Status::REQUESTED },
+          ])
         end
 
         it "does not display number of requested places in the status" do
@@ -289,14 +285,14 @@ describe AllocationsView do
 
         let(:allocations) { [declined_allocation] }
 
-        it {
+        it do
           expect(subject).to eq([{
             training_provider_name: training_provider.provider_name,
             training_provider_code: training_provider.provider_code,
             status: AllocationsView::Status::NOT_REQUESTED,
             status_colour: AllocationsView::Colour::RED,
           }])
-        }
+        end
       end
 
       context "returns allocations where status is 'YET TO REQUEST'" do
@@ -304,14 +300,14 @@ describe AllocationsView do
 
         let(:training_providers) { [training_provider] }
 
-        it {
+        it do
           expect(subject).to eq([{
             training_provider_name: training_provider.provider_name,
             training_provider_code: training_provider.provider_code,
             status: AllocationsView::Status::NO_REQUEST_SENT,
             status_colour: AllocationsView::Colour::GREY,
           }])
-        }
+        end
       end
 
       context "no allocations are returned if their status is 'REQUESTED" do
@@ -323,9 +319,7 @@ describe AllocationsView do
 
         let(:training_providers) { [training_provider] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
 
       context "no allocations are returned if their status is 'INITIAL'" do
@@ -337,9 +331,7 @@ describe AllocationsView do
 
         let(:training_providers) { [training_provider] }
 
-        it {
-          expect(subject).to eq([])
-        }
+        it { expect(subject).to eq([]) }
       end
 
       describe "allocation ordering" do
@@ -351,16 +343,18 @@ describe AllocationsView do
         let(:allocations) { [] }
 
         it "is sorted by the provider name" do
-          expect(subject).to eq([{ training_provider_name: training_provider.provider_name,
-                                   training_provider_code: training_provider.provider_code,
-                                   status: AllocationsView::Status::NO_REQUEST_SENT,
-                                   status_colour: AllocationsView::Colour::GREY },
-                                 {
-                                   training_provider_name: another_training_provider.provider_name,
-                                   training_provider_code: another_training_provider.provider_code,
-                                   status: AllocationsView::Status::NO_REQUEST_SENT,
-                                   status_colour: AllocationsView::Colour::GREY,
-                                 }])
+          expect(subject).to eq([
+            { training_provider_name: training_provider.provider_name,
+              training_provider_code: training_provider.provider_code,
+              status: AllocationsView::Status::NO_REQUEST_SENT,
+              status_colour: AllocationsView::Colour::GREY },
+            {
+              training_provider_name: another_training_provider.provider_name,
+              training_provider_code: another_training_provider.provider_code,
+              status: AllocationsView::Status::NO_REQUEST_SENT,
+              status_colour: AllocationsView::Colour::GREY,
+            },
+          ])
         end
       end
     end


### PR DESCRIPTION
### Context
PE allocations section confirmed state

### Changes proposed in this pull request
Migrate the PE allocations section confirmed state

### Guidance to review
This is `confirmed state`, one of 3 states.

#### With allocations
https://teacher-training-api-pr-2597.london.cloudapps.digital/publish/organisations/24P/2022/allocations

vs

https://qa.publish-teacher-training-courses.service.gov.uk/organisations/24P/2022/allocations

#### Without allocations

https://teacher-training-api-pr-2597.london.cloudapps.digital/publish/organisations/S17/2022/allocations

vs

https://qa.publish-teacher-training-courses.service.gov.uk/organisations/S17/2022/allocations

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
