### PR TITLE
[xxxx] Fixed punit warnings

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,7 +1,7 @@
 class APIController < ActionController::API
   include EmitsRequestEvents
   include ActionController::HttpAuthentication::Token::ControllerMethods
-  include Pundit
+  include Pundit::Authorization
 
   # child must define authenticate method
   before_action :authenticate

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   helper_method :current_user
   before_action :authenticate
 
-  include Pundit
+  include Pundit::Authorization
 
   before_action :enforce_basic_auth, if: -> { BasicAuthenticable.required? }
 


### PR DESCRIPTION
:shipit: 

Get rids of 

`DEPRECATION WARNING: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.`