### PR TITLE
Revert "Bump omniauth from 1.9.1 to 2.1.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem "govuk-components"
 gem "govuk_design_system_formbuilder"
 
 # DfE Sign-In
-gem "omniauth", "~> 2.1"
+gem "omniauth", "~> 1.9"
 gem "omniauth_openid_connect", "~> 0.4"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,10 +348,9 @@ GEM
     notifications-ruby-client (5.3.0)
       jwt (>= 1.5, < 3)
     oj (3.13.11)
-    omniauth (2.1.0)
+    omniauth (1.9.1)
       hashie (>= 3.4.6)
-      rack (>= 2.2.3)
-      rack-protection
+      rack (>= 1.6.2, < 3)
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
@@ -416,8 +415,6 @@ GEM
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (2.2.0)
-      rack
     rack-proxy (0.7.0)
       rack
     rack-test (1.1.0)
@@ -677,7 +674,7 @@ DEPENDENCIES
   launchy
   listen (>= 3.0.5, < 3.8)
   oj
-  omniauth (~> 2.1)
+  omniauth (~> 1.9)
   omniauth-rails_csrf_protection
   omniauth_openid_connect (~> 0.4)
   open_api-rswag-api


### PR DESCRIPTION
Reverts DFE-Digital/teacher-training-api#2610