### PR TITLE
[876] Port over rollover interruption screen

### DIFF
--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -25,16 +25,18 @@ module Publish
     def check_interrupt_redirects(use_redirect_back_to: true)
       if !current_user.accepted_terms?
         redirect_to publish_accept_terms_path
-        # elsif user_state_to_redirect_paths[user_from_session.aasm.current_state]
-        #   redirect_to user_state_to_redirect_paths[user_from_session.aasm.current_state]
-        # elsif show_rollover_page?
-        #   redirect_to rollover_path
+      elsif show_rollover_page?
+        redirect_to publish_rollover_path
         # elsif show_rollover_recruitment_page?
         #   redirect_to rollover_recruitment_path
       elsif use_redirect_back_to
         redirect_to session[:redirect_back_to] if session[:redirect_back_to].present?
         session.delete(:redirect_back_to)
       end
+    end
+
+    def show_rollover_page?
+      FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") && current_user.current_rollover_acceptance.blank?
     end
   end
 end

--- a/app/controllers/publish/rollover_controller.rb
+++ b/app/controllers/publish/rollover_controller.rb
@@ -5,7 +5,7 @@ module Publish
     def create
       InterruptPageAcknowledgement.find_or_create_by!(
         user: current_user,
-        recruitment_cycle: RecruitmentCycle.current
+        recruitment_cycle: RecruitmentCycle.current,
         page: "rollover",
       )
 

--- a/app/controllers/publish/rollover_controller.rb
+++ b/app/controllers/publish/rollover_controller.rb
@@ -5,7 +5,7 @@ module Publish
     def create
       InterruptPageAcknowledgement.find_or_create_by!(
         user: current_user,
-        recruitment_cycle: RecruitmentCycle.find_by!(year: Settings.current_recruitment_cycle_year),
+        recruitment_cycle: RecruitmentCycle.current
         page: "rollover",
       )
 

--- a/app/controllers/publish/rollover_controller.rb
+++ b/app/controllers/publish/rollover_controller.rb
@@ -1,0 +1,15 @@
+module Publish
+  class RolloverController < ApplicationController
+    def new; end
+
+    def create
+      InterruptPageAcknowledgement.find_or_create_by!(
+        user: current_user,
+        recruitment_cycle: RecruitmentCycle.find_by!(year: Settings.current_recruitment_cycle_year),
+        page: "rollover",
+      )
+
+      redirect_to root_path
+    end
+  end
+end

--- a/app/helpers/recruitment_cycle_helper.rb
+++ b/app/helpers/recruitment_cycle_helper.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module RecruitmentCycleHelper
+  def current_recruitment_cycle_period_text
+    "#{Settings.current_recruitment_cycle_year} to #{Settings.current_recruitment_cycle_year + 1}"
+  end
+
+  def next_recruitment_cycle_period_text
+    "#{Settings.current_recruitment_cycle_year + 1} to #{Settings.current_recruitment_cycle_year + 2}"
+  end
+
+  def previous_recruitment_cycle_period_text
+    "#{Settings.current_recruitment_cycle_year - 1} to #{Settings.current_recruitment_cycle_year}"
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -76,6 +76,11 @@ class User < ApplicationRecord
     accept_terms_date_utc.present?
   end
 
+  def current_rollover_acceptance
+    interrupt_page_acknowledgements
+      .includes(:recruitment_cycle).find_by(page: "rollover", recruitment_cycle: { year: Settings.current_recruitment_cycle_year })
+  end
+
 private
 
   def email_is_lowercase

--- a/app/views/publish/rollover/new.html.erb
+++ b/app/views/publish/rollover/new.html.erb
@@ -1,0 +1,49 @@
+<% content_for :page_title, "Prepare for the next cycle" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Prepare for the next cycle
+    </h1>
+
+    <p class="govuk-body">
+      Your courses, locations and details have been copied.
+    </p>
+
+    <p class="govuk-body">
+      Courses for the next cycle will be published on <%= l(Settings.next_cycle_open_date) %>.
+    </p>
+
+    <p class="govuk-body">
+      Before then, you can:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
+      <li>add new courses</li>
+      <li>delete courses</li>
+      <li>edit the details of your courses</li>
+    </ul>
+
+    <h2 class="govuk-heading-m">New for the <%= next_recruitment_cycle_period_text %> cycle</h2>
+
+    <p class="govuk-body">
+      All applications will be made via Apply for teaching training, not UCAS.
+    </p>
+
+    <p class="govuk-body">
+      You will need to confirm:
+    </p>
+
+    <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-4">
+      <li>degree requirements</li>
+      <li>GCSE requirements</li>
+      <li>if candidates can get visa sponsorship</li>
+      <li>locations of school placements</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> for each school course location</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="UK Provider Reference Number">UKPRN</abbr> for your organisation</li>
+      <li>the <abbr class="app-!-text-decoration-underline-dotted" title="Unique Reference Number">URN</abbr> if your organisation is a lead school</li>
+    </ul>
+
+    <%= govuk_button_to "Continue", publish_rollover_path, method: :post %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,9 @@ Rails.application.routes.draw do
 
   namespace :publish, as: :publish do
     get "/organisations", to: "providers#index", as: :root
+    get "/rollover", to: "rollover#new", as: :rollover
+    post "/rollover", to: "rollover#create"
+
     get "/accept-terms", to: "terms#edit", as: :accept_terms
     patch "/accept-terms", to: "terms#update"
 

--- a/spec/features/publish/accepting_rollover_spec.rb
+++ b/spec/features/publish/accepting_rollover_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Accepting rollover" do
+  before do
+    enable_features("rollover.can_edit_current_and_next_cycles")
+    given_i_am_a_user_who_has_not_accepted_rollover
+    when_i_visit_the_publish_service
+  end
+
+  after do
+    disable_features("rollover.can_edit_current_and_next_cycles")
+  end
+
+  scenario "i can accept the rollover interruption" do
+    then_i_am_taken_to_the_rollover_page
+    when_i_accept_rollover
+    then_i_should_be_returned_to_the_publish_service_page
+    and_the_user_is_marked_as_accepting_rollover
+  end
+
+  def given_i_am_a_user_who_has_not_accepted_rollover
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def when_i_visit_the_publish_service
+    visit(publish_root_path)
+  end
+
+  def then_i_am_taken_to_the_rollover_page
+    expect(rollover_page).to be_displayed
+  end
+
+  def when_i_accept_rollover
+    rollover_page.submit.click
+  end
+
+  def then_i_should_be_returned_to_the_publish_service_page
+    expect(page).to have_current_path("/")
+  end
+
+  def and_the_user_is_marked_as_accepting_rollover
+    expect(@current_user.reload.current_rollover_acceptance).to be_present
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -269,4 +269,31 @@ describe User, type: :model do
       end
     end
   end
+
+  describe "#current_rollover_acceptance" do
+    let(:current_rollover_acceptance) do
+      create(:interrupt_page_acknowledgement, user: subject, recruitment_cycle: create(:recruitment_cycle))
+    end
+
+    let(:previous_rollover_acceptance) do
+      create(:interrupt_page_acknowledgement, user: subject, recruitment_cycle: create(:recruitment_cycle, :previous))
+    end
+
+    context "when there is no current rollover acceptance" do
+      it "returns nil" do
+        expect(subject.current_rollover_acceptance).to be_nil
+      end
+    end
+
+    context "when there is a current rollover acceptance" do
+      before do
+        previous_rollover_acceptance
+        current_rollover_acceptance
+      end
+
+      it "returns the current rollover acceptance" do
+        expect(subject.current_rollover_acceptance).to eq(current_rollover_acceptance)
+      end
+    end
+  end
 end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -191,5 +191,9 @@ module FeatureHelpers
     def terms_and_conditions_page
       @terms_and_conditions_page ||= PageObjects::Publish::Terms.new
     end
+
+    def rollover_page
+      @rollover_page ||= PageObjects::Publish::Rollover.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/rollover.rb
+++ b/spec/support/page_objects/publish/rollover.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class Rollover < PageObjects::Base
+      set_url "/publish/rollover"
+
+      element :submit, 'input.govuk-button[type="submit"]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/EvjQZECF/876-migrate-the-interruption-pages-rollover

### Changes proposed in this pull request

- Rework and simplify the rollover interruption screen logic
- Drives logic from the `InterruptPageAcknowledgement` rather than storing acceptance in session
- Changing the cycle year will naturally trigger the interruption for the next cycle (providing flag is also turned on)

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
