### PR TITLE
[877] Port the rollover recruitment interruption screen

### DIFF
--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -27,8 +27,8 @@ module Publish
         redirect_to publish_accept_terms_path
       elsif show_rollover_page?
         redirect_to publish_rollover_path
-        # elsif show_rollover_recruitment_page?
-        #   redirect_to rollover_recruitment_path
+      elsif show_rollover_recruitment_page?
+        redirect_to publish_rollover_recruitment_path
       elsif use_redirect_back_to
         redirect_to session[:redirect_back_to] if session[:redirect_back_to].present?
         session.delete(:redirect_back_to)
@@ -37,6 +37,11 @@ module Publish
 
     def show_rollover_page?
       FeatureService.enabled?("rollover.can_edit_current_and_next_cycles") && current_user.current_rollover_acceptance.blank?
+    end
+
+    def show_rollover_recruitment_page?
+      FeatureService.enabled?("rollover.show_next_cycle_allocation_recruitment_page") &&
+        current_user.current_rollover_recruitment_acceptance.blank?
     end
   end
 end

--- a/app/controllers/publish/rollover_controller.rb
+++ b/app/controllers/publish/rollover_controller.rb
@@ -9,7 +9,7 @@ module Publish
         page: "rollover",
       )
 
-      redirect_to root_path
+      redirect_to publish_root_path
     end
   end
 end

--- a/app/controllers/publish/rollover_recruitment_controller.rb
+++ b/app/controllers/publish/rollover_recruitment_controller.rb
@@ -1,0 +1,15 @@
+module Publish
+  class RolloverRecruitmentController < ApplicationController
+    def new; end
+
+    def create
+      InterruptPageAcknowledgement.find_or_create_by!(
+        user: current_user,
+        recruitment_cycle: RecruitmentCycle.current,
+        page: "rollover_recruitment",
+      )
+
+      redirect_to root_path
+    end
+  end
+end

--- a/app/controllers/publish/rollover_recruitment_controller.rb
+++ b/app/controllers/publish/rollover_recruitment_controller.rb
@@ -9,7 +9,7 @@ module Publish
         page: "rollover_recruitment",
       )
 
-      redirect_to root_path
+      redirect_to publish_root_path
     end
   end
 end

--- a/app/controllers/publish/terms_controller.rb
+++ b/app/controllers/publish/terms_controller.rb
@@ -10,7 +10,7 @@ module Publish
       @accept_terms_form = Interruption::AcceptTermsForm.new(current_user, params: accept_term_params)
 
       if @accept_terms_form.save!
-        redirect_to root_path
+        redirect_to publish_root_path
       else
         render :edit
       end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,8 +77,11 @@ class User < ApplicationRecord
   end
 
   def current_rollover_acceptance
-    interrupt_page_acknowledgements
-      .includes(:recruitment_cycle).find_by(page: "rollover", recruitment_cycle: { year: Settings.current_recruitment_cycle_year })
+    current_page_acknowledgement_for("rollover")
+  end
+
+  def current_rollover_recruitment_acceptance
+    current_page_acknowledgement_for("rollover_recruitment")
   end
 
 private
@@ -87,5 +90,10 @@ private
     if email.present? && email.downcase != email
       errors.add(:email, "must be lowercase")
     end
+  end
+
+  def current_page_acknowledgement_for(page)
+    interrupt_page_acknowledgements
+      .includes(:recruitment_cycle).find_by(page: page, recruitment_cycle: { year: Settings.current_recruitment_cycle_year })
   end
 end

--- a/app/views/publish/rollover_recruitment/new.html.erb
+++ b/app/views/publish/rollover_recruitment/new.html.erb
@@ -7,7 +7,9 @@
     </h1>
 
     <p class="govuk-body">
-      You are now able to request permission to recruit for fee-funded PE for the <%= next_recruitment_cycle_period_text %> cycle.</p>
+      You are now able to request permission to recruit for fee-funded PE for the <%= next_recruitment_cycle_period_text %> cycle.
+    </p>
+
     <p class="govuk-body">
       You do not need to request permission to recruit in Publish for any courses other than fee-funded PE.
       Accredited bodies should request fee-funded PE by <%= l(Settings.allocations_close_date) %>.

--- a/app/views/publish/rollover_recruitment/new.html.erb
+++ b/app/views/publish/rollover_recruitment/new.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Recruiting for the #{next_recruitment_cycle_period_text} cycle" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">
+      Requesting permission to recruit for the <%= next_recruitment_cycle_period_text %> cycle
+    </h1>
+
+    <p class="govuk-body">
+      You are now able to request permission to recruit for fee-funded PE for the <%= next_recruitment_cycle_period_text %> cycle.</p>
+    <p class="govuk-body">
+      You do not need to request permission to recruit in Publish for any courses other than fee-funded PE.
+      Accredited bodies should request fee-funded PE by <%= l(Settings.allocations_close_date) %>.
+    </p>
+
+    <%= govuk_button_to "Continue", publish_rollover_recruitment_path, method: :post %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Rails.application.routes.draw do
     get "/organisations", to: "providers#index", as: :root
     get "/rollover", to: "rollover#new", as: :rollover
     post "/rollover", to: "rollover#create"
+    get "/rollover-recruitment", to: "rollover_recruitment#new", as: :rollover_recruitment
+    post "/rollover-recruitment", to: "rollover_recruitment#create"
 
     get "/accept-terms", to: "terms#edit", as: :accept_terms
     patch "/accept-terms", to: "terms#update"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -106,6 +106,7 @@ features:
     has_current_cycle_started?: true
     # During rollover providers should be able to edit current & next recruitment cycle courses
     can_edit_current_and_next_cycles: false
+    show_next_cycle_allocation_recruitment_page: false
   allocations:
     # state: open # Users can make requests for allocations
     # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)

--- a/spec/features/publish/accepting_rollover_recruitment_spec.rb
+++ b/spec/features/publish/accepting_rollover_recruitment_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Accepting rollover" do
+  before do
+    enable_features("rollover.show_next_cycle_allocation_recruitment_page")
+    given_i_am_a_user_who_has_not_accepted_rollover_recruitment
+    when_i_visit_the_publish_service
+  end
+
+  after do
+    disable_features("rollover.show_next_cycle_allocation_recruitment_page")
+  end
+
+  scenario "i can accept the rollover interruption" do
+    then_i_am_taken_to_the_rollover_recruitment_page
+    when_i_accept_rollover_recruitment
+    then_i_should_be_returned_to_the_publish_service_page
+    and_the_user_is_marked_as_accepting_rollover_recruitment
+  end
+
+  def given_i_am_a_user_who_has_not_accepted_rollover_recruitment
+    given_i_am_authenticated(user: create(:user, :with_provider))
+  end
+
+  def when_i_visit_the_publish_service
+    visit(publish_root_path)
+  end
+
+  def then_i_am_taken_to_the_rollover_recruitment_page
+    expect(rollover_recruitment_page).to be_displayed
+  end
+
+  def when_i_accept_rollover_recruitment
+    rollover_recruitment_page.submit.click
+  end
+
+  def then_i_should_be_returned_to_the_publish_service_page
+    expect(page).to have_current_path("/")
+  end
+
+  def and_the_user_is_marked_as_accepting_rollover_recruitment
+    expect(@current_user.reload.current_rollover_recruitment_acceptance).to be_present
+  end
+end

--- a/spec/features/publish/accepting_rollover_recruitment_spec.rb
+++ b/spec/features/publish/accepting_rollover_recruitment_spec.rb
@@ -37,7 +37,7 @@ feature "Accepting rollover" do
   end
 
   def then_i_should_be_returned_to_the_publish_service_page
-    expect(page).to have_current_path("/")
+    expect(page).to have_current_path(publish_root_path)
   end
 
   def and_the_user_is_marked_as_accepting_rollover_recruitment

--- a/spec/features/publish/accepting_rollover_spec.rb
+++ b/spec/features/publish/accepting_rollover_spec.rb
@@ -37,7 +37,7 @@ feature "Accepting rollover" do
   end
 
   def then_i_should_be_returned_to_the_publish_service_page
-    expect(page).to have_current_path("/")
+    expect(page).to have_current_path(publish_root_path)
   end
 
   def and_the_user_is_marked_as_accepting_rollover

--- a/spec/features/publish/accepting_terms_spec.rb
+++ b/spec/features/publish/accepting_terms_spec.rb
@@ -38,7 +38,7 @@ feature "Accepting terms" do
   end
 
   def then_i_should_be_returned_to_the_publish_service_page
-    expect(page).to have_current_path("/")
+    expect(page).to have_current_path(publish_root_path)
   end
 
   def and_the_user_is_marked_as_accepting_the_terms

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -195,5 +195,9 @@ module FeatureHelpers
     def rollover_page
       @rollover_page ||= PageObjects::Publish::Rollover.new
     end
+
+    def rollover_recruitment_page
+      @rollover_recruitment_page ||= PageObjects::Publish::RolloverRecruitment.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/rollover_recruitment.rb
+++ b/spec/support/page_objects/publish/rollover_recruitment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class RolloverRecruitment < PageObjects::Base
+      set_url "/publish/rollover-recruitment"
+
+      element :submit, 'input.govuk-button[type="submit"]'
+    end
+  end
+end


### PR DESCRIPTION
### Context

https://trello.com/c/dypIiSV0/877-migrate-the-interruption-pages-rollover-recruitment

### Changes proposed in this pull request

Similar to https://github.com/DFE-Digital/teacher-training-api/pull/2613 but for the rollover recruitment interruption screen.

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
