### PR TITLE
Delete GitHub environment

### DIFF
--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -2,8 +2,6 @@ name: deploy
 description: deploys application
 
 inputs:
-  actions-api-access-token:
-    required: true
   arm-access-key:
     required: true
   azure-credentials:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -166,7 +166,6 @@ jobs:
         id: deploy_review
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           arm-access-key: ${{ secrets.ARM_ACCESS_KEY_REVIEW }}
           azure-credentials: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
           environment: review
@@ -188,14 +187,14 @@ jobs:
 
   deploy-all:
     name: Deployment To All
-    environment: 
+    environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app.outputs.deploy-url }}
     if: ${{ success() && github.ref == 'refs/heads/master' }}
     needs: [test]
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
+      matrix:
         environment: [qa,staging,production,sandbox]
       max-parallel: 1
     steps:
@@ -206,7 +205,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', matrix.environment)] }}
           azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', matrix.environment)] }}
           environment: ${{ matrix.environment }}

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -5,6 +5,9 @@ on:
     types: [closed]
     branches: [master]
 
+permissions:
+  deployments: write
+
 jobs:
   delete-review-app:
     name: Delete Review App ${{ github.event.pull_request.number }}
@@ -70,9 +73,18 @@ jobs:
           AZURE_STORAGE_CONNECTION_STRING: ${{ secrets.AZURE_STORAGE_CONNECTION_STRING_REVIEW }}
 
       - name: Update ${{ matrix.environment }} status
+        id: deactivate-env
         if:   ${{ always() && env.TF_STATE_EXISTS == 'true' }}
         uses: bobheadxi/deployments@v0.4.3
         with:
           step:   deactivate-env
           token:  ${{ secrets.GITHUB_TOKEN }}
+          env:    review-${{ env.PR_NUMBER }}
+
+      - name: Delete review-${{ env.PR_NUMBER }} environment
+        if:   always() && (steps.deactivate-env.outcome == 'success')
+        uses: bobheadxi/deployments@v1
+        with:
+          step:   delete-env
+          token:  ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           env:    review-${{ env.PR_NUMBER }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,6 @@ jobs:
         id: deploy_app
         uses: ./.github/actions/deploy/
         with:
-          actions-api-access-token: ${{ secrets.ACTIONS_API_ACCESS_TOKEN }}
           arm-access-key: ${{ secrets[format('ARM_ACCESS_KEY_{0}', github.event.inputs.environment)] }}
           azure-credentials: ${{ secrets[format('AZURE_CREDENTIALS_{0}', github.event.inputs.environment)] }}
           environment: ${{ github.event.inputs.environment }}


### PR DESCRIPTION
### Context
A GitHub environment is created for each review app that is deployed, this environment persists after the review app is deleted.

### Changes proposed in this pull request
- Removed unneeded references to `API_TOKEN_FOR_GITHUB_ACTION` secret, this is now only used for the step below
- Add a step to the delete-review-app workflow to delete the environment

### Guidance to review
- Close PR to test delete process, reopen PR once tested

### Trello card
https://trello.com/c/ybnYhCK3

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
