### PR TITLE
[904] Fix accredited body search step

### DIFF
--- a/app/controllers/publish/courses/accredited_body_controller.rb
+++ b/app/controllers/publish/courses/accredited_body_controller.rb
@@ -20,7 +20,7 @@ module Publish
           render :new
         elsif other_selected_with_no_autocompleted_code?(code)
           redirect_to(
-            search_new_provider_recruitment_cycle_courses_accredited_body_path(
+            search_new_publish_provider_recruitment_cycle_courses_accredited_body_path(
               query: @accredited_body,
               course: course_params,
             ),
@@ -32,6 +32,8 @@ module Publish
       end
 
       def search_new
+        authorize(provider, :can_create_course?)
+
         # These are not before_action hooks as they conflict with hooks
         # defined within the CourseBasicDetailConcern and cannot be overridden
         # without causing failures in other routes in this controller
@@ -39,9 +41,7 @@ module Publish
         build_provider
         build_previous_course_creation_params
         @query = params[:query]
-        @provider_suggestions = ProviderSuggestion.suggest_any_accredited_body(@query)
-      rescue JsonApiClient::Errors::ClientError => e
-        @errors = e
+        @provider_suggestions = recruitment_cycle.providers.with_findable_courses.provider_search(@query).limit(10)
       end
 
       def update
@@ -65,9 +65,7 @@ module Publish
       def search
         build_course
         @query = params[:query]
-        @provider_suggestions = ProviderSuggestion.suggest_any_accredited_body(@query)
-      rescue JsonApiClient::Errors::ClientError => e
-        @errors = e
+        @provider_suggestions = recruitment_cycle.providers.with_findable_courses.provider_search(@query).limit(10)
       end
 
     private

--- a/app/controllers/publish/courses/applications_open_controller.rb
+++ b/app/controllers/publish/courses/applications_open_controller.rb
@@ -33,6 +33,7 @@ module Publish
             :accredited_body_code,
           )
           .permit(
+            :start_date,
             :applications_open_from,
             :day,
             :month,

--- a/app/views/publish/courses/accredited_body/search_new.html.erb
+++ b/app/views/publish/courses/accredited_body/search_new.html.erb
@@ -11,7 +11,7 @@
     <p class="govuk-body">You searched for ‘<%= @query %>’.</p>
 
     <%= form_with model: course,
-                  url: continue_provider_recruitment_cycle_courses_accredited_body_path(
+                  url: continue_publish_provider_recruitment_cycle_courses_accredited_body_path(
                     @provider.provider_code,
                     @provider.recruitment_cycle_year,
                   ),


### PR DESCRIPTION
### Context

https://trello.com/c/orO2PVAV/904-fix-wrong-search-path

### Changes proposed in this pull request

Fixes this Sentry error https://sentry.io/organizations/dfe-teacher-services/issues/3210660165/?environment=production&project=1377944&query=is%3Aunresolved

### Guidance to review

Create a new course under this provider https://teacher-training-api-pr-2621.london.cloudapps.digital/publish/organisations/5E4/2022/courses (should allow you to search for an accredited body successfully)

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
