### PR TITLE
[909] Mark site and site status relationship correctly

### DIFF
--- a/app/forms/publish/course_location_form.rb
+++ b/app/forms/publish/course_location_form.rb
@@ -11,6 +11,15 @@ module Publish
       super
     end
 
+    def save_action
+      model.transaction do
+        assign_attributes_to_model
+        update_site_statuses
+        after_successful_save_action
+        true
+      end
+    end
+
   private
 
     attr_reader :previous_site_names
@@ -27,6 +36,15 @@ module Publish
 
     def updated_site_names
       @updated_site_names ||= course.sites.map(&:location_name)
+    end
+
+    def update_site_statuses
+      model.site_statuses.each do |site_status|
+        site_status.update!(
+          publish: :published,
+          status: :running,
+        )
+      end
     end
 
     def compute_fields


### PR DESCRIPTION
### Context

https://trello.com/c/GQZV3WRF/909-issue-with-locations-l142-1fn

### Changes proposed in this pull request

When locations are selected in the course's locations edit view, the `site_ids` are assigned to the course but their corresponding `site_statuses` records are set to the defaults `{ status: :new_status, published: :unpublished }` and don't appear in the course's vacancies list as it only queries running sites. 

This change fixes by marking the site statuses attributes for the chosen site ids correctly.

### Guidance to review

If you view this course's locations https://teacher-training-api-pr-2622.london.cloudapps.digital/publish/organisations/1FN/2022/courses/L142/details, Queen Elizabeth's Grammar School will be listed but not appear in the vacancies list: https://teacher-training-api-pr-2622.london.cloudapps.digital/publish/organisations/1FN/2022/courses/L142/vacancies

Update the locations list (save uncheck and save checked again) and then assert the new location is shown in the vacancy list.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
