### PR TITLE
[568] Migrate the notifications page

### DIFF
--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -10,7 +10,7 @@
       <% header.navigation_item(text: "Sign out", href: sign_out_path) %>
     <% else %>
       <% if current_user.associated_with_accredited_body? %>
-        <% header.navigation_item(text: "Notifications", href: old_publish_notifications_path, active: current_page?(old_publish_notifications_path)) %>
+        <% header.navigation_item(text: "Notifications", href: publish_notifications_path, active: current_page?(publish_notifications_path)) %>
       <% end %>
       <% header.navigation_item(text: "Sign out", href: sign_out_path) %>
       <% header.navigation_item(text: "(#{current_user.first_name} #{current_user.last_name})", href: Settings.dfe_signin.profile) %>

--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -1,5 +1,5 @@
 <%= govuk_header(
-  homepage_url: old_publish_homepage_path,
+  homepage_url: publish_root_path,
   classes: "govuk-!-display-none-print app-header app-header--wide-logo #{environment_header_class}",
   navigation_classes: "govuk-header__navigation--end") do |header| %>
 

--- a/app/components/header/view.rb
+++ b/app/components/header/view.rb
@@ -14,16 +14,4 @@ class Header::View < GovukComponent::Base
   def environment_header_class
     "app-header--#{Settings.environment.name}"
   end
-
-  # TODO: replace this with the notifications path helper once notifications
-  # have been migrated from Old Publish.
-  def old_publish_notifications_path
-    "#{Settings.publish_url}/notifications"
-  end
-
-  # TODO: replace this with the root path of the Publish interface as one of
-  # the last steps in migrating Publish functionality into this codebase.
-  def old_publish_homepage_path
-    Settings.publish_url
-  end
 end

--- a/app/controllers/publish/notifications_controller.rb
+++ b/app/controllers/publish/notifications_controller.rb
@@ -1,0 +1,47 @@
+module Publish
+  class NotificationsController < PublishController
+    skip_before_action :check_interrupt_redirects
+
+    def index
+      authorize(current_user, :index?)
+
+      @notifications_view = NotificationsView.new(request: request, current_user: current_user)
+      @notification_form = NotificationForm.new(current_user)
+    end
+
+    def update
+      authorize(current_user, :update?)
+
+      @notification_form = NotificationForm.new(current_user, params: notification_params)
+
+      if @notification_form.save!
+        flash[:success] = "Email notification preferences for #{current_user.email} have been saved."
+
+        redirect_to redirect_to_path
+      else
+        @notifications_view = NotificationsView.new(request: request, current_user: current_user)
+        render(:index)
+      end
+    end
+
+  private
+
+    def redirect_to_path
+      if permitted_params[:provider_code].present?
+        publish_provider_path(permitted_params[:provider_code])
+      else
+        root_path
+      end
+    end
+
+    def permitted_params
+      params.require(:publish_notification_form).permit(*NotificationForm::FIELDS, :provider_code)
+    end
+
+    def notification_params
+      permitted_params.except(:provider_code).transform_values do |value|
+        ActiveModel::Type::Boolean.new.cast(value)
+      end
+    end
+  end
+end

--- a/app/forms/publish/notification_form.rb
+++ b/app/forms/publish/notification_form.rb
@@ -1,0 +1,37 @@
+module Publish
+  class NotificationForm < BaseModelForm
+    alias_method :user, :model
+
+    FIELDS = %i[
+      explicitly_enabled
+    ].freeze
+
+    attr_accessor(*FIELDS)
+
+    validates :explicitly_enabled, inclusion: { in: [true, false], message: "Please select one option" }
+
+    def save!
+      if valid?
+        user_notification_preferences.update(enable_notifications: explicitly_enabled)
+      else
+        false
+      end
+    end
+
+  private
+
+    def compute_fields
+      { explicitly_enabled: preference_selected? }.merge(new_attributes).symbolize_keys
+    end
+
+    def user_notification_preferences
+      @user_notification_preferences ||= UserNotificationPreferences.new(user_id: user.id)
+    end
+
+    def preference_selected?
+      return nil if user_notification_preferences.updated_at.blank?
+
+      user_notification_preferences.enabled?
+    end
+  end
+end

--- a/app/view_objects/notifications_view.rb
+++ b/app/view_objects/notifications_view.rb
@@ -1,0 +1,36 @@
+class NotificationsView
+  ORGANISATION_URL_PATTERN = /\/organisations\/(\S+)\/?/.freeze
+
+  def initialize(
+    request:,
+    current_user:
+  )
+    @request = request
+    @current_user = current_user
+  end
+
+  def user_id
+    current_user.id
+  end
+
+  def user_email
+    current_user.email
+  end
+
+  def back_link_path
+    return Rails.application.routes.url_helpers.root_path if ORGANISATION_URL_PATTERN.match(request.referer).nil?
+
+    URI(request.referer).path
+  end
+
+  def provider_code
+    matches = ORGANISATION_URL_PATTERN.match(request.referer)
+    return if matches.nil?
+
+    matches[1]
+  end
+
+private
+
+  attr_reader :request, :current_user
+end

--- a/app/views/publish/notifications/index.html.erb
+++ b/app/views/publish/notifications/index.html.erb
@@ -1,0 +1,41 @@
+<% content_for :page_title, title_with_error_prefix("Manage notifications", @notification_form.errors.any?) %>
+
+<% content_for :before_content do %>
+  <%= govuk_back_link_to(@notifications_view.back_link_path) %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with(
+      model: @notification_form,
+      url: publish_notification_path(current_user.id),
+    ) do |f| %>
+
+      <%= f.govuk_error_summary %>
+
+      <h1 class="govuk-heading-l" data-qa="page-heading">
+        <span class="govuk-caption-l">Notifications for accredited bodies</span>
+        Changes to courses
+      </h1>
+
+      <p class="govuk-body">
+        We’ll tell you when a training provider:
+      </p>
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-6">
+        <li>publishes a new course on Find postgraduate teacher training</li>
+        <li>makes a change to an existing course</li>
+        <li>withdraws a course</li>
+        <li>changes the vacancy status of a course</li>
+      </ul>
+
+      <%= f.hidden_field :provider_code, value: @notifications_view.provider_code %>
+
+      <%= f.govuk_radio_buttons_fieldset(:explicitly_enabled, legend: { text: "Would you like to receive email notifications?", size: "m" }) do %>
+        <%= f.govuk_radio_button(:explicitly_enabled, true, label: { text: "Yes, send me notifications" }, link_errors: true) %>
+        <%= f.govuk_radio_button(:explicitly_enabled, false, label: { text: "No" }) %>
+      <% end %>
+
+      <%= f.govuk_submit "Save", data: { qa: "notifications__save" } %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,6 +51,8 @@ Rails.application.routes.draw do
     get "/accept-terms", to: "terms#edit", as: :accept_terms
     patch "/accept-terms", to: "terms#update"
 
+    resources :notifications, path: "/notifications", controller: "notifications", only: %i[index update]
+
     resources :providers, path: "organisations", param: :code, only: [:show] do
       get "/users", on: :member, to: "users#index"
       get "/request-access", on: :member, to: "providers/access_requests#new"

--- a/spec/components/header/view_spec.rb
+++ b/spec/components/header/view_spec.rb
@@ -4,6 +4,8 @@ require "rails_helper"
 
 module Header
   describe View do
+    include Rails.application.routes.url_helpers
+
     alias_method :component, :page
 
     it "renders Service's name" do
@@ -11,9 +13,9 @@ module Header
       expect(component.find(".govuk-header__product-name")).to have_text("Test Service")
     end
 
-    it "links to Old Publish homepage" do
+    it "links to the homepage" do
       render_inline(described_class.new(service_name: "Test Service"))
-      expect(page.has_link?(nil, href: Settings.publish_url)).to be true
+      expect(page.has_link?(nil, href: publish_root_path)).to be true
     end
 
     it "doesn't contain a sign out link if no current user" do
@@ -35,13 +37,13 @@ module Header
     end
 
     context "for a non-admin user" do
-      it "links to Old Publish notifications section if associated_with_accredited_body" do
+      it "links to the notifications section if associated_with_accredited_body" do
         user = build(:user)
         allow(user).to receive(:associated_with_accredited_body?).and_return true
 
         render_inline(described_class.new(service_name: "Test Service", current_user: user))
 
-        expect(page.has_link?("Notifications", href: "#{Settings.publish_url}/notifications")).to be true
+        expect(page.has_link?("Notifications", href: publish_notifications_path)).to be true
       end
     end
   end

--- a/spec/features/publish/editing_notification_preference_spec.rb
+++ b/spec/features/publish/editing_notification_preference_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Opting into notifications" do
+  before do
+    given_i_am_authenticated_as_an_accredited_body_user
+    when_i_visit_accredited_body_page
+    and_i_click_on_notifications_link
+    then_the_notifications_page_is_displayed
+    and_the_notifications_link_has_an_active_state
+    then_neither_radio_button_is_selected
+  end
+
+  scenario "user sets notification preferences for the first time" do
+    and_i_select_yes
+    then_i_should_see_my_preferences_have_been_saved
+    and_the_users_preference_is_set
+  end
+
+  scenario "user is shown an error if they submit without selection" do
+    and_i_submit
+    then_i_should_see_an_error_message
+  end
+
+  def given_i_am_authenticated_as_an_accredited_body_user
+    given_i_am_authenticated(user: create(:user, providers: [create(:provider, :accredited_body)]))
+  end
+
+  def when_i_visit_accredited_body_page
+    publish_providers_show_page.load(id: accrediting_provider.provider_code)
+  end
+
+  def and_i_click_on_notifications_link
+    header.notifications_preference_link.click
+  end
+
+  def then_the_notifications_page_is_displayed
+    expect(notifications_page).to be_displayed
+  end
+
+  def and_the_notifications_link_has_an_active_state
+    expect(header).to have_active_notifications_preference_link
+  end
+
+  def then_neither_radio_button_is_selected
+    expect(notifications_page.opt_in_radio).not_to be_checked
+    expect(notifications_page.opt_out_radio).not_to be_checked
+  end
+
+  def and_i_select_yes
+    notifications_page.opt_in_radio.choose
+    and_i_submit
+  end
+
+  def then_i_should_see_my_preferences_have_been_saved
+    expect(publish_providers_show_page)
+      .to have_content("Email notification preferences for #{@current_user.email} have been saved")
+  end
+
+  def and_the_users_preference_is_set
+    expect(notification_preference.enabled?).to be(true)
+  end
+
+  def and_i_submit
+    notifications_page.submit.click
+  end
+
+  def then_i_should_see_an_error_message
+    expect(publish_course_study_mode_page.error_messages).to include(
+      "Please select one option",
+    )
+  end
+
+  def accrediting_provider
+    @current_user.providers.first
+  end
+
+  def notification_preference
+    @notification_preference ||= UserNotificationPreferences.new(user_id: @current_user.id)
+  end
+end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -207,5 +207,13 @@ module FeatureHelpers
     def rollover_recruitment_page
       @rollover_recruitment_page ||= PageObjects::Publish::RolloverRecruitment.new
     end
+
+    def notifications_page
+      @notifications_page ||= PageObjects::Publish::Notification.new
+    end
+
+    def header
+      @header ||= PageObjects::Publish::Header.new
+    end
   end
 end

--- a/spec/support/page_objects/publish/header.rb
+++ b/spec/support/page_objects/publish/header.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class Header < PageObjects::Base
+      element :notifications_preference_link, "a.govuk-header__link", text: "Notifications"
+      element :active_notifications_preference_link, "li.govuk-header__navigation-item--active a.govuk-header__link", text: "Notifications"
+    end
+  end
+end

--- a/spec/support/page_objects/publish/notification.rb
+++ b/spec/support/page_objects/publish/notification.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require_relative "../sections/errorlink"
+
+module PageObjects
+  module Publish
+    class Notification < PageObjects::Base
+      set_url "/publish/notifications"
+
+      sections :errors, Sections::ErrorLink, ".govuk-error-summary__list li>a"
+
+      element :opt_in_radio, "#publish-notification-form-explicitly-enabled-true-field"
+      element :opt_out_radio, "#publish-notification-form-explicitly-enabled-field"
+
+      element :submit, 'button.govuk-button[type="submit"]'
+
+      def error_messages
+        errors.map(&:text)
+      end
+    end
+  end
+end

--- a/spec/view_objects/notifications_view_spec.rb
+++ b/spec/view_objects/notifications_view_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe NotificationsView do
+  subject do
+    described_class.new(
+      request: request,
+      current_user: current_user,
+    )
+  end
+
+  let(:request) { double(referer: referer_url) }
+  let(:current_user) { double(id: user_id, email: user_email) }
+  let(:user_id) { "123" }
+  let(:user_email) { "dave@example.com" }
+  let(:referer_url) { "https://www.example.com#{referer_path}" }
+  let(:referer_path) { "/organisations/B20" }
+
+  describe "#user_id" do
+    it "returns the current_user['user_id']" do
+      expect(subject.user_id).to eq(user_id)
+    end
+  end
+
+  describe "#user_email" do
+    it "returns the current_user['info']['email']" do
+      expect(subject.user_email).to eq(user_email)
+    end
+  end
+
+  describe "#back_link_path" do
+    context "referer is organisation page" do
+      it "returns the referer path" do
+        expect(subject.back_link_path).to eq(referer_path)
+      end
+    end
+
+    context "referer is not an organisation page" do
+      let(:referer_path) { "/interruption_screen_path" }
+
+      it "returns root_path" do
+        expect(subject.back_link_path).to eq(Rails.application.routes.url_helpers.root_path)
+      end
+    end
+  end
+
+  describe "#provider_code" do
+    context "referer is organisation page" do
+      it "returns the referer provider code" do
+        expect(subject.provider_code).to eq("B20")
+      end
+    end
+
+    context "referer is not an organisation page" do
+      let(:referer_path) { "/interruption_screen_path" }
+
+      it "returns nil" do
+        expect(subject.provider_code).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/g71F5Ssn/568-migrate-the-notifications-page

### Changes proposed in this pull request

- Migrate and refactor the notifications preference page

### Guidance to review

- Sign in as one of the accrediting body personas
- Click notifications link
- Update notifications

Original implementation: https://qa.publish-teacher-training-courses.service.gov.uk/notifications

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
