### PR TITLE
Add disaster recovery docs

### DIFF
--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -eu
+
+BACKUP_STORAGE_SECRET_NAME=$1
+KEY_VAULT_NAME=$2
+AZURE_BACKUP_STORAGE_CONTAINER_NAME=$3
+BACKUP_FILENAME_PREFIX=$4
+BACKUP_DATE=$5 #yyyy-mm-dd
+
+
+if [[ -z "${BACKUP_STORAGE_SECRET_NAME}" ]]; then
+  echo "BACKUP_STORAGE_SECRET_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${KEY_VAULT_NAME}" ]]; then
+  echo "KEY_VAULT_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${AZURE_BACKUP_STORAGE_CONTAINER_NAME}" ]]; then
+  echo "AZURE_BACKUP_STORAGE_CONTAINER_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_FILENAME_PREFIX}" ]]; then
+  echo "BACKUP_FILENAME_PREFIX environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_DATE}" ]]; then
+  echo "BACKUP_DATE environment variable not set"
+  exit 1
+fi
+
+STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
+
+BACKUP_ARCHIVE_FILENAME=$(az storage blob list --connection-string ${STORAGE_CONN_STR} --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
+if [[ -z "${BACKUP_ARCHIVE_FILENAME}" ]]; then
+  echo "There are no files found matching the prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} in container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME}"
+  exit 1
+else
+  az storage blob download --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --output none
+fi
+
+echo ${BACKUP_ARCHIVE_FILENAME}

--- a/bin/restore-nightly-backup
+++ b/bin/restore-nightly-backup
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eu
+
+CF_ORG_NAME='dfe'
+SPACE=$1
+POSTGRES_DATABASE_NAME=$2
+BACKUP_ARCHIVE_FILENAME=$3
+
+if [[ -z "${SPACE}" ]]; then
+  echo "SPACE environment variable not set"
+  exit 1
+fi
+
+BACKUP_FILENAME=$(tar -xvzf "${BACKUP_ARCHIVE_FILENAME}")
+
+if [[ ! -f "${BACKUP_FILENAME}" ]]; then
+  echo "${BACKUP_FILENAME} does not exist."
+  exit 1
+else
+  echo "Restoring ${BACKUP_FILENAME} to ${POSTGRES_DATABASE_NAME} in ${CF_ORG_NAME}/${SPACE}"
+  cf target -o "${CF_ORG_NAME}" -s "${SPACE}"
+  cf conduit ${POSTGRES_DATABASE_NAME} -- psql < "${BACKUP_FILENAME}"
+fi

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -1,0 +1,70 @@
+# Disaster recovery
+
+
+This documentation covers one scenario:
+
+- [Loss of database instance](#loss-of-database-instance)
+
+In case of any above database disaster, please do the following:
+
+### Freeze pipeline
+
+Alert all developers that no one should merge to main branch.
+
+### Maintenance mode
+
+If the database is unavailable then the API application will return a 500 response.
+
+In the instance of data loss, if the application is unavailable, ##TO DO: find out what the application does
+If the application is still available and there is a risk of users adding data, enable [Maintenance mode](maintenance-mode.md).
+
+### Set up a virtual meeting
+
+Set up virtual meeting via Zoom, Slack, Teams or Google Hangout, inviting all the relevant technical stakeholders. Regularly provide updates on
+the #twd_publish Slack channel to keep product owners abreast of developments.
+
+### Internet Connection
+
+Ensure whoever is executing the process has a reliable and reasonably fast Internet connection.
+
+## Loss of database instance
+
+In case the database instance is lost, the objectives are:
+
+- Recreate the lost postgres database instance
+- Restore data from nightly backup stored in Azure.  The point-in-time and snapshot backups created by the PaaS Postgres service will not be available if it's been deleted.
+
+### Recreate the lost postgres database instance
+
+Please note, this process should take about 5 mins* to complete. In case the database service is deleted or in an inconsistent state we must recreate it and repopulate it.
+First make sure it is fully gone by running
+
+```
+cf services | grep teacher-training-api
+# check output for lost or corrupted instance
+cf delete-service <instance-name>
+```
+Then recreate the lost postgres database instance using the following make recipes `deploy-plan` and `deploy`.  To see the proposed changes:
+
+```
+TAG=$(cf app teacher-training-api-prod | grep -Po "docker image:\s+\S+:\K\w+")
+make <env> deploy-plan passcode=<my-passcode> IMAGE_TAG=${TAG}
+```
+To apply proposed changes i.e. create new database instance:
+```
+TAG=$(cf app teacher-training-api-prod | grep -Po "docker image:\s+\S+:\K\w+")
+make <env> deploy-plan passcode=<my-passcode> CONFIRM_RESTORE=YES IMAGE_TAG=${TAG}
+```
+This will create a new postgres database instance as described in the terraform configuration file.
+
+\* based on ~2 min restore time of sanitised db and ~5 min restore time when testing process in QA
+
+### Restore Data From Nightly Backup
+
+Once the lost database instance has been recreated, the last nightly backup will need to be restored. To achieve this, use the following makefile recipe: `restore-data-from-nightly-backup`. The following will need to be set: `passcode` (a [GOV.UK PaaS one-time passcode](https://login.london.cloud.service.gov.uk/passcode)), `CONFIRM_PRODUCTION=YES`,  `CONFIRM_RESTORE=YES` and `BACKUP_DATE="yyyy-mm-dd"`.  You will need to be logged into GovUK PaaS and Azure using the `az` and `cf` CLIs.
+
+```
+make production restore-data-from-nightly-backup CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES BACKUP_DATE="yyyy-mm-dd"
+```
+
+This will download the latest daily backup from Azure Storage and then populate the new database with data.  If more than one backup has been created on the date specified the script will select the most recent from that date.

--- a/docs/maintenance-mode.md
+++ b/docs/maintenance-mode.md
@@ -1,0 +1,13 @@
+# Maintenance mode
+
+The repo includes a simple service unavailable page page that can be pushed to a cf app.  Traffic can be rerouted to it instead of the main application. This is handy in case of a critical bug being discovered where we need to take the service offline, or in case of maintenance where we want to avoid users interacting with the service.
+
+When enabled, all requests will receive the [service unavailable page](/service_unavailable_page/web/public/internal/index.html).
+
+### Enable Maintenance mode
+
+Login to PaaS: `cf login --sso` or `cf login -o dfe -u my.name@digital.education.gov.uk`
+
+Run the make command: `make prod enable-maintenance CONFIRM_PRODUCTION=y`
+
+To bring the application back up: `make prod disable-maintenance CONFIRM_PRODUCTION=y`

--- a/docs/maintenance-mode.md
+++ b/docs/maintenance-mode.md
@@ -2,7 +2,7 @@
 
 The repo includes a simple service unavailable page page that can be pushed to a cf app.  Traffic can be rerouted to it instead of the main application. This is handy in case of a critical bug being discovered where we need to take the service offline, or in case of maintenance where we want to avoid users interacting with the service.
 
-When enabled, all requests will receive the [service unavailable page](/service_unavailable_page/web/public/internal/index.html).
+When enabled, all requests, except requests to `/api` will receive the [service unavailable page](/service_unavailable_page/web/public/internal/index.html).  API requests will receive an empty 503 response.
 
 ### Enable Maintenance mode
 

--- a/service_unavailable_page/web/nginx.conf
+++ b/service_unavailable_page/web/nginx.conf
@@ -23,13 +23,18 @@ http {
     # Request to / returns 403 (directory index forbidden)
     # Request to anything else than /internal return 404 not found
     # The maintenance page is served as error page
-    # And the response code is changed to 500
-    error_page 403 404 =500 /internal/index.html;
+    # And the response code is changed to 503
+    error_page 403 404 =503 /internal/index.html;
 
     # Assets are relative to the URL. We capture the prefix and filename
     # and serve them from the right files
     location ~ /(stylesheets|assets|javascript)/(.*)$ {
       alias public/internal/$1/$2;
+    }
+
+    # API requests receive an empty 503 response
+    location ~ ^/api/? {
+      return 503;
     }
   }
 }


### PR DESCRIPTION
### Context

A DR process is required to handle a lost of the database instance.

https://trello.com/c/eh8Tgmu9

### Changes proposed in this pull request
- Add a DR process to docs and supporting make recipe and scripts to execute it
- Document the maintenance page process
- Modify the maintenance page process to return a more appropriate response for API requests

### Guidance to review
Ensure the process meets the requirements in [technical guidance](https://technical-guidance.education.gov.uk/infrastructure/disaster-recovery/#loss-of-database-instance).

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
