### PR TITLE
Add data corruption to DR docs

### DIFF
--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -4,12 +4,17 @@
 This documentation covers one scenario:
 
 - [Loss of database instance](#loss-of-database-instance)
+- [Data loss](#data-loss)
 
 In case of any above database disaster, please do the following:
 
 ### Freeze pipeline
 
 Alert all developers that no one should merge to main branch.
+
+### Local Dependencies
+
+You will need the [az](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli) and [cf](https://docs.cloudfoundry.org/cf-cli/install-go-cli.html) CLIs installed as well as [make](https://www.gnu.org/software/make/) and either [Terraform](https://learn.hashicorp.com/tutorials/terraform/install-cli) or [tfenv](https://github.com/tfutils/tfenv#installation).
 
 ### Maintenance mode
 
@@ -68,3 +73,82 @@ make production restore-data-from-nightly-backup CONFIRM_PRODUCTION=YES CONFIRM_
 ```
 
 This will download the latest daily backup from Azure Storage and then populate the new database with data.  If more than one backup has been created on the date specified the script will select the most recent from that date.
+
+## Data Loss
+
+In the case of a data loss, we need to recover the data as soon as possible in order to resume normal service. Declare a major incident and document the incident timelines as you go along.
+
+The application's database is a postgres instance, which resides on PaaS. This provides a point-in-time backup with the resolution of 1 second, available between 5min and 7days. We can use terraform to create a new database instance and use a point-in-time backup from the corrupted instance to restore the data.  This will be done in a single terraform apply operation.
+
+### Make note of database failure time
+
+Make note of the time the database failure occurred, and then use this to calculate when the integrity of the data in the database was still viable. For instance, if data loss or corruption happened at 1200hrs, use this to work out what snapshot time is best for the product (consult with the PM if you are unsure what would be best from the product perspective). This would determine the value of `SNAPSHOT_TIME` env.
+
+Important: You should convert the time to UTC before actually using it. When you record the time, note what timezone you are using. Especially during BST (British Summer Time).
+
+### Get affected postgres database ID
+
+Use the makefile's get-postgres-instance-guid to get the database guid, use the following command:
+
+```
+make <env> get-postgres-instance-guid [CONFIRM_PRODUCTION=true]
+```
+env is the target environment e.g. production
+
+
+### Rename postgres database instance service
+
+Rename the affected database instance so a new database can be recreated with the production name. To achieve this, run the following make command
+
+```
+make <env> rename-postgres-service passcode=xxxx [CONFIRM_PRODUCTION=true]
+```
+this renames the database by appending "-old" to the database name, env is the target environment e.g. production, obtain a passcode from [GOV.UK PaaS one-time passcode](https://login.london.cloud.service.gov.uk/passcode)
+
+### Remove affected postgres database instance from terraform state file
+
+In order for terraform to be able to create a new database instance, the existing database reference needs to be removed from the state file. This is to ensure it is no longer managed by terraform, otherwise, terraform would revert our changes. To achieve this, use the makefile target -
+
+```
+az login # authenticate to Azure because statefile is in an Azure Storage Container
+make <env> remove-postgres-tf-state [CONFIRM_PRODUCTION=true]
+```
+env is the target environment e.g. production
+
+### Restore postgres database instance
+
+The following variables need to be set: DB_INSTANCE_GUID (the output of the 'Get affected postgres instance guid' step, SNAPSHOT_TIME ("2021-09-14 16:00:00" IMPORTANT - this is UTC time!), passcode (a passcode from [GOV.UK PaaS one-time passcode](https://login.london.cloud.service.gov.uk/passcode)), CONFIRM_PRODUCTION (true) and tag (the docker tag for the application image).
+
+The following commands combine the makefile recipes above to initiate the restore process by using the approriate variable values:
+
+```
+# env is the target environment in the make file e.g. 'production'
+# space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
+az login
+cf login -o dfe -s <space> -u my.name@digital.education.gov.uk
+PASSCODE=xxxx # obtain from https://login.london.cloud.service.gov.uk/passcode
+DB_INSTANCE_GUID=$(make <env> get-postgres-instance-guid)
+TAG=$(make <env> get-image-tag)
+make <env> rename-postgres-service PASSCODE=${PASSCODE} CONFIRM_PRODUCTION=true
+make <env> remove-postgres-tf-state PASSCODE=${PASSCODE} CONFIRM_PRODUCTION=true
+make <env> restore-postgres DB_INSTANCE_GUID=${DB_INSTANCE_GUID} SNAPSHOT_TIME="yyyy-mm-dd HH:MM:ss" PASSCODE=${PASSCODE} IMAGE_TAG=${TAG} CONFIRM_PRODUCTION=true
+```
+
+You will be prompted to review the terraform plan.  Check for the following:
+- the `cloudfoundry_app.docker_image` tags are **not** changing
+- a new database instance is being created using a point-in-time database backup of corrupted database
+- new service keys are created
+
+The restore process should take ~25 min.  Terraform should write logs to the console with progress, the bulk of the time will be spent recreating the postgres instance.
+
+### PaaS documentation
+
+Gov UK PaaS Documentation on Point-in-time database recovery can be found [here](https://docs.cloud.service.gov.uk/deploying_services/postgresql/#restoring-a-postgresql-service-from-a-point-in-time)
+
+### Tidy up
+
+Once the database has been successfully restored, the corrupted database instance should be deleted.
+
+```
+cf delete-service teacher-training-api-postgres-<env>-old -f
+```

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -59,6 +59,8 @@ module paas {
   redis_service_plan        = var.paas_redis_service_plan
   app_environment_variables = local.paas_app_environment_variables
   publish_gov_uk_host_names = var.publish_gov_uk_host_names
+  restore_from_db_guid      = var.paas_restore_from_db_guid
+  db_backup_before_point_in_time = var.paas_db_backup_before_point_in_time
 }
 
 module statuscake {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,14 @@ variable paas_worker_app_stopped { default = false }
 
 variable paas_app_config_file { default = "./workspace_variables/app_config.yml" }
 
+variable paas_restore_from_db_guid {
+  default = ""
+}
+
+variable paas_db_backup_before_point_in_time {
+  default = ""
+}
+
 variable key_vault_name {}
 
 variable key_vault_resource_group {}


### PR DESCRIPTION
### Context

A DR process is required to handle a data corruption.

https://trello.com/c/wx5ad9MF

### Changes proposed in this pull request

- Extend the DR documentation to cover data corruption scenario
- Add make recipes to execute process and modify terraform template to support this process

### Guidance to review
- The code block in [this section](https://github.com/DFE-Digital/teacher-training-api/blob/add-data-corruption-dr-process/docs/disaster-recovery.md#restore-postgres-database-instance) has been tested against QA.  You can repeat this test after checking with #twd_publish_tech

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
