### PR TITLE
[846] Update support playbook for attaching user to provider

### DIFF
--- a/docs/support_playbook.md
+++ b/docs/support_playbook.md
@@ -67,5 +67,6 @@ user = User.find(email: "jon@email.com")
 # Find the provider
 provider = RecruitmentCycle.current.providers.find_by(provider_code: "2E1")
 
-user.providers << provider
+# Use the user association service to link the two as it also deals with notifications
+UserAssociationsService::Create.call(user: user, provider: provider)
 ```


### PR DESCRIPTION
### Context

- https://trello.com/c/7DTRabhQ/846-notification-email-investigate-on-by-default

We've been manually adding a user to a provider but not handling the notification preferences. I've tested the `UserAssociationService::Create` and it seems to do the job. 

### Changes proposed in this pull request

Update support playbook to show how to correctly link a user to provider.
