### PR TITLE
458  Update rollover code so that user permissions are correctly maintained across cycles

### DIFF
--- a/app/services/providers/copy_to_recruitment_cycle_service.rb
+++ b/app/services/providers/copy_to_recruitment_cycle_service.rb
@@ -24,6 +24,7 @@ module Providers
             rolled_over_provider.contacts << provider.contacts.map(&:dup)
             rolled_over_provider.recruitment_cycle = new_recruitment_cycle
             rolled_over_provider.skip_geocoding = true
+            rolled_over_provider.users << provider.users
             rolled_over_provider.save!
           end
 

--- a/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
+++ b/spec/services/providers/copy_to_recruitment_cycle_service_spec.rb
@@ -17,6 +17,7 @@ describe Providers::CopyToRecruitmentCycleService do
     }
     let(:provider) {
       create :provider,
+             :with_users,
              sites: [site],
              ucas_preferences: ucas_preferences,
              contacts: contacts
@@ -111,6 +112,12 @@ describe Providers::CopyToRecruitmentCycleService do
       service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
 
       expect(new_provider.organisation).to eq provider.organisation
+    end
+
+    it "assigns the new provider to users" do
+      service.execute(provider: provider, new_recruitment_cycle: new_recruitment_cycle)
+
+      expect(new_provider.users).to eq provider.users
     end
 
     it "copies over the ucas_preferences" do


### PR DESCRIPTION
### Context
At rollover we create new provider records. Now that we've updated the user permissions model, we need to ensure that permissions are correctly sustained across cycles.

What needs to be done
Update the relevant rollover code to re-create or update user_permissions records so that they point to the new provider records.
### Changes proposed in this pull request
Add users to the new rolled over providers in `copy_to_recuitment_cycle_service.rb`
### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
