### PR TITLE
Dr doc refinements

### DIFF
--- a/.github/workflows/database-restore.yml
+++ b/.github/workflows/database-restore.yml
@@ -1,13 +1,19 @@
 name: Database Backup and Restore
 
 on:
-  schedule: # 03:00 UTC Mon-Fri
-    - cron: '0 3 * * 1-5'
+  schedule: # 03:00 UTC
+    - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      overwriteThisMorningsBackup:
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   backup:
     name: Sanitise Production Database Backup
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.overwriteThisMorningsBackup == 'true') }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -36,7 +42,7 @@ jobs:
 
       - name: Backup Teacher Training API Prod Database
         run: |
-          now=$(date +"%F-%H-%M-%S")
+          now=$(date +"%F")
           PROD_BACKUP=prod_backup-$now.sql
           cf conduit teacher-training-api-postgres-prod -- pg_dump --encoding utf8 --clean --no-owner --if-exists -f $PROD_BACKUP
           tar -cvzf ${PROD_BACKUP}.tar.gz ${PROD_BACKUP}

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ bin/fetch_config.rb
 /.devcontainer/*
 
 # Ignore sanitised production data dump
+*.sql.tar.gz
 *.sql.gz
 *.sql
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,7 @@ yarn 1.22.4
 nodejs 16.14.0
 terraform 0.13.5
 adr-tools 3.0.0
+cf 7.4.0
+az 2.36.0
+jq 1.6
+make 4.2.1

--- a/Makefile
+++ b/Makefile
@@ -155,9 +155,9 @@ disable-maintenance: ## make qa disable-maintenance / make prod disable-maintena
 	cf delete -rf ttapi-unavailable
 
 restore-data-from-nightly-backup: read-deployment-config read-keyvault-config # make production restore-data-from-nightly-backup CONFIRM_PRODUCTION=YES CONFIRM_RESTORE=YES BACKUP_DATE="yyyy-mm-dd"
-	$(eval BACKUP_ARCHIVE_FILENAME=$(shell bin/download-nightly-backup ${backup_storage_secret_name} ${key_vault_name} ${paas_env}-db-backup ${paas_env}_backup- ${BACKUP_DATE}))
+	bin/download-nightly-backup ${backup_storage_secret_name} ${key_vault_name} ${paas_env}-db-backup ${paas_env}_backup- ${BACKUP_DATE}
 	$(if $(CONFIRM_RESTORE), , $(error Restore can only run with CONFIRM_RESTORE))
-	bin/restore-nightly-backup ${space} ${postgres_database_name} ${BACKUP_ARCHIVE_FILENAME}
+	bin/restore-nightly-backup ${space} ${postgres_database_name} ${paas_env}_backup- ${BACKUP_DATE}
 
 get-image-tag:
 	$(eval export TAG=$(shell cf target -s ${space} 1> /dev/null && cf app teacher-training-api-${paas_env} | grep -Po "docker image:\s+\S+:\K\w+"))

--- a/bin/download-nightly-backup
+++ b/bin/download-nightly-backup
@@ -36,11 +36,10 @@ fi
 STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
 
 BACKUP_ARCHIVE_FILENAME=$(az storage blob list --connection-string ${STORAGE_CONN_STR} --container-name ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} --output json --query [-1].name | jq -r)
-if [[ -z "${BACKUP_ARCHIVE_FILENAME}" ]]; then
+if [[ -z ${BACKUP_ARCHIVE_FILENAME} ]]; then
   echo "There are no files found matching the prefix ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE} in container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME}"
   exit 1
 else
+  echo "Downloading ${BACKUP_ARCHIVE_FILENAME} ..."
   az storage blob download --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --output none
 fi
-
-echo ${BACKUP_ARCHIVE_FILENAME}

--- a/bin/restore-nightly-backup
+++ b/bin/restore-nightly-backup
@@ -4,20 +4,23 @@ set -eu
 CF_ORG_NAME='dfe'
 SPACE=$1
 POSTGRES_DATABASE_NAME=$2
-BACKUP_ARCHIVE_FILENAME=$3
+BACKUP_FILENAME_PREFIX=$3
+BACKUP_DATE=$4 #yyyy-mm-dd
 
 if [[ -z "${SPACE}" ]]; then
   echo "SPACE environment variable not set"
   exit 1
 fi
 
-BACKUP_FILENAME=$(tar -xvzf "${BACKUP_ARCHIVE_FILENAME}")
+BACKUP_ARCHIVE_FILENAME=${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql.tar.gz
+echo "File(s) extracted from ${BACKUP_ARCHIVE_FILENAME}:"
+tar -xvzf ${BACKUP_ARCHIVE_FILENAME}
 
-if [[ ! -f "${BACKUP_FILENAME}" ]]; then
-  echo "${BACKUP_FILENAME} does not exist."
+if [[ ! -f "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql" ]]; then
+  echo "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql does not exist."
   exit 1
 else
-  echo "Restoring ${BACKUP_FILENAME} to ${POSTGRES_DATABASE_NAME} in ${CF_ORG_NAME}/${SPACE}"
+  echo "Restoring ${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql to ${POSTGRES_DATABASE_NAME} in ${CF_ORG_NAME}/${SPACE}"
   cf target -o "${CF_ORG_NAME}" -s "${SPACE}"
-  cf conduit ${POSTGRES_DATABASE_NAME} -- psql < "${BACKUP_FILENAME}"
+  cf conduit ${POSTGRES_DATABASE_NAME} -- psql < "${BACKUP_FILENAME_PREFIX}${BACKUP_DATE}.sql"
 fi


### PR DESCRIPTION
### Context
Demoing the DR process to the publish team identified some refinements and fixes that could be made to the DR process.

https://trello.com/c/wx5ad9MF

### Changes proposed in this pull request
- Remove dependency on output from one script to execute another, this maintains compatibility across Linux distributions
- Replaces `grep` with `awk` to maintain compatibility across Linux distributions
- Fixed incorrect file permissions introduced by WSL

### Guidance to review
- The solution was developed on a Windows machine running Ubuntu 20 in WSL.  It should tested on MacOS ideally or another distribution.  A minimal test would be:
  - execute the `deploy-plan` command documented in [recreate-the-lost-postgres-database-instance](https://github.com/DFE-Digital/teacher-training-api/blob/dr-doc-refinements/docs/disaster-recovery.md#recreate-the-lost-postgres-database-instance)
  - execute the commands in [restore-data-from-nightly-backup](https://github.com/DFE-Digital/teacher-training-api/blob/dr-doc-refinements/docs/disaster-recovery.md#restore-data-from-nightly-backup).  This can be done against QA with agreement from the publish team or against the review app by replacing `${paas_env}` on [line 116](https://github.com/DFE-Digital/teacher-training-api/blob/6678c7123f3d0956c067d60cb97cd5328e293561/Makefile#L116) of the make file with `pr-2651`

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
