### PR TITLE
[954] Fix breadcrumbs in new publish

### DIFF
--- a/app/helpers/breadcrumb_helper.rb
+++ b/app/helpers/breadcrumb_helper.rb
@@ -15,7 +15,7 @@ module BreadcrumbHelper
 
   # rubocop:disable Rails/HelperInstanceVariable
   def organisations_breadcrumb
-    @has_multiple_providers ? { "Organisations" => providers_path } : {}
+    current_user.has_multiple_providers? ? { "Organisations" => root_path } : {}
   end
 
   def provider_breadcrumb
@@ -33,57 +33,57 @@ module BreadcrumbHelper
   end
 
   def courses_breadcrumb
-    path = provider_recruitment_cycle_courses_path(@provider.provider_code)
+    path = publish_provider_recruitment_cycle_courses_path(@provider.provider_code)
     recruitment_cycle_breadcrumb.merge({ "Courses" => path })
   end
 
   def course_breadcrumb
-    path = provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
+    path = publish_provider_recruitment_cycle_course_path(@provider.provider_code, course.recruitment_cycle_year, course.course_code)
     courses_breadcrumb.merge({ course.name_and_code => path })
   end
 
   def sites_breadcrumb
-    path = provider_recruitment_cycle_sites_path(@provider.provider_code, @recruitment_cycle.year)
+    path = publish_provider_recruitment_cycle_locations_path(@provider.provider_code, @recruitment_cycle.year)
     recruitment_cycle_breadcrumb.merge({ "Locations" => path })
   end
 
   def organisation_details_breadcrumb
-    path = details_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
+    path = details_publish_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
     recruitment_cycle_breadcrumb.merge({ "About your organisation" => path })
   end
 
   def users_breadcrumb
-    path = details_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
+    path = details_publish_provider_recruitment_cycle_path(@provider.provider_code, @recruitment_cycle.year)
     recruitment_cycle_breadcrumb.merge({ "Users" => path })
   end
 
   def edit_site_breadcrumb
-    path = edit_provider_recruitment_cycle_site_path(@provider.provider_code, @site.recruitment_cycle_year, @site.id)
-    sites_breadcrumb.merge({ @site_name_before_update => path })
+    path = edit_publish_provider_recruitment_cycle_location_path(@provider.provider_code, @recruitment_cycle.year, @site.id)
+    sites_breadcrumb.merge({ @site.location_name.dup => path })
   end
 
   def new_site_breadcrumb
-    path = new_provider_recruitment_cycle_site_path(@provider.provider_code)
+    path = new_publish_provider_recruitment_cycle_location_path(@provider.provider_code)
     sites_breadcrumb.merge({ "Add a location" => path })
   end
 
   def training_providers_breadcrumb
-    path = training_providers_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    path = publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)
     provider_breadcrumb.merge({ "Courses as an accredited body" => path })
   end
 
   def training_provider_courses_breadcrumb
-    path = training_provider_courses_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year, @training_provider.provider_code)
+    path = publish_provider_recruitment_cycle_training_provider_courses_path(@provider.provider_code, @provider.recruitment_cycle_year, @training_provider.provider_code)
     training_providers_breadcrumb.merge({ "#{@training_provider.provider_name}’s courses" => path })
   end
 
   def allocations_breadcrumb
-    path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    path = publish_provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
     provider_breadcrumb.merge({ "Request PE courses for #{next_allocation_cycle_period_text}" => path })
   end
 
   def allocations_closed_breadcrumb
-    path = provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
+    path = publish_provider_recruitment_cycle_allocations_path(@provider.provider_code, @provider.recruitment_cycle_year)
     provider_breadcrumb.merge({ "PE courses for #{next_allocation_cycle_period_text}" => path })
   end
   # rubocop:enable Rails/HelperInstanceVariable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -84,6 +84,10 @@ class User < ApplicationRecord
     current_page_acknowledgement_for("rollover_recruitment")
   end
 
+  def has_multiple_providers?
+    providers.count > 1
+  end
+
 private
 
   def email_is_lowercase

--- a/app/views/publish/courses/details.html.erb
+++ b/app/views/publish/courses/details.html.erb
@@ -1,9 +1,5 @@
 <% content_for :page_title, "#{course.name_and_code} - Courses" %>
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_course_path(@provider.provider_code, @provider.recruitment_cycle_year)
-  ) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= course.description %></span>

--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, @provider.rolled_over? ? "Courses – #{@recruitment_cycle.title}" : "Courses" %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:courses) %>
 
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>

--- a/app/views/publish/courses/show.html.erb
+++ b/app/views/publish/courses/show.html.erb
@@ -1,9 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("#{course.name_and_code} - Courses", @errors.present?) %>
-<%= content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year)
-  ) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:course) %>
 
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">

--- a/app/views/publish/providers/allocations/allocation_request/_closed_state.html.erb
+++ b/app/views/publish/providers/allocations/allocation_request/_closed_state.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-    old_publish_link_for(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  ) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/allocations/allocation_request/_confirmed_state.html.erb
+++ b/app/views/publish/providers/allocations/allocation_request/_confirmed_state.html.erb
@@ -1,12 +1,6 @@
 
 <% content_for :page_title, "PE courses for #{next_allocation_cycle_period_text}" %>
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-    old_publish_link_for(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  ) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs("allocations_closed") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/allocations/allocation_request/_open_state.html.erb
+++ b/app/views/publish/providers/allocations/allocation_request/_open_state.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, "Request PE courses for #{next_allocation_cycle_period_text}" %>
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-    old_publish_link_for(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  ) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs("allocations") %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, title_with_error_prefix("About your organisation", @errors.present?) %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:organisation_details) %>
 
 <% if @errors.present? %>
   <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary" data-ga-event-form="error">

--- a/app/views/publish/providers/locations/edit.html.erb
+++ b/app/views/publish/providers/locations/edit.html.erb
@@ -1,9 +1,6 @@
 <% page_title = @location_form.site.location_name %>
 <% content_for :page_title, title_with_error_prefix(page_title, @location_form.errors.any?) %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_locations_path(@location_form.provider_code, @location_form.recruitment_cycle_year)) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:edit_site) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/locations/index.html.erb
+++ b/app/views/publish/providers/locations/index.html.erb
@@ -1,13 +1,7 @@
 <% page_title = "Locations" %>
 
 <% content_for :page_title, page_title %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:sites) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/locations/new.html.erb
+++ b/app/views/publish/providers/locations/new.html.erb
@@ -1,9 +1,6 @@
 <% page_title = "Add a location" %>
 <% content_for :page_title, title_with_error_prefix(page_title, @location_form.errors.any?) %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_locations_path(@location_form.provider_code, @location_form.recruitment_cycle_year)) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:new_site) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/publish/providers/show.html.erb
+++ b/app/views/publish/providers/show.html.erb
@@ -1,5 +1,6 @@
 <% content_for :page_title, @provider.provider_name %>
-<% if @has_multiple_providers %>
+
+<% if current_user.has_multiple_providers? %>
   <%= content_for :before_content, render_breadcrumbs(:provider) %>
 <% end %>
 

--- a/app/views/publish/training_providers/courses/index.html.erb
+++ b/app/views/publish/training_providers/courses/index.html.erb
@@ -1,8 +1,5 @@
 <% content_for :page_title, @provider.provider_name %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, @provider.recruitment_cycle_year)) %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:training_provider_courses) %>
 
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l">Training provider</span>

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -1,11 +1,5 @@
 <% content_for :page_title, "Courses as an accredited body" %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-      publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-    )
-  %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
 <h1 class="govuk-heading-l">
   <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>

--- a/app/views/publish/users/index.html.erb
+++ b/app/views/publish/users/index.html.erb
@@ -1,11 +1,5 @@
 <% page_title = "Users" %>
-
-<% content_for :before_content do %>
-  <%= govuk_back_link_to(
-        publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year)
-      )
-  %>
-<% end %>
+<%= content_for :before_content, render_breadcrumbs(:users) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
### Context

- https://trello.com/c/NEORiD07/954-enable-breadcrumbs-on-new-publish

### Changes proposed in this pull request

- Make the breadcrumbs work for the same pages in old publish

### Guidance to review

https://teacher-training-api-pr-2652.london.cloudapps.digital/

Login as Mary and click around different sections

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
