### PR TITLE
Remove redundant comment

### DIFF
--- a/app/models/course_enrichment.rb
+++ b/app/models/course_enrichment.rb
@@ -55,7 +55,7 @@ class CourseEnrichment < ApplicationRecord
             if: :is_fee_based?
 
   # Requirements and qualifications
-  # TODO: POST MIGRATION: Move out of this as it's handled in the form object
+
   validates :required_qualifications, presence: true, on: :publish, if: :required_qualifications_needed?
   validates :required_qualifications, words_count: { maximum: 100 }
 


### PR DESCRIPTION
### Context

Removing this comment as there isn't an equivalent validation in the form object.
