### PR TITLE
Increase rollover app memory to 3G

### DIFF
--- a/terraform/workspace_variables/rollover.tfvars.json
+++ b/terraform/workspace_variables/rollover.tfvars.json
@@ -3,7 +3,7 @@
     "paas_app_environment": "rollover",
     "paas_web_app_host_name": "rollover",
     "paas_web_app_instances": 2,
-    "paas_web_app_memory": 1536,
+    "paas_web_app_memory": 3072,
     "paas_worker_app_instances": 1,
     "paas_worker_app_memory": 512,
     "paas_postgres_service_plan": "small-11",


### PR DESCRIPTION
### Context

Rollover env requires larger app memory 

### Changes proposed in this pull request

Increase from 1.5G to 3G

### Guidance to review

Deployed manually

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
