### PR TITLE
Update asdf config for azure-cli

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,6 +5,6 @@ nodejs 16.14.0
 terraform 0.13.5
 adr-tools 3.0.0
 cf 7.4.0
-az 2.36.0
+azure-cli 2.36.0
 jq 1.6
 make 4.2.1


### PR DESCRIPTION
### Context

When setting up the repo, the `asdf` config had trouble when trying to find the `az` plugin. It looks like this exists under the name `azure-cli` instead, where `az` is just the command line term to start azure stuff. 

I've been able to install and run the whole `.tool-versions` file with `asdf` at this point