### PR TITLE
SPIKE add Google Tag Manager config

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,11 +17,12 @@
     <%= favicon_link_tag asset_pack_path("media/images/govuk-apple-touch-icon-180x180.png"), rel: "apple-touch-icon", type: "image/png", size: "180x180" %>
     <%= stylesheet_pack_tag "application", media: "all" %>
     <%= javascript_pack_tag "application", defer: true %>
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-TSK2T46');</script>
   </head>
 
   <body class="govuk-template__body <%= yield :body_class %>">
     <noscript>
-      <iframe title="Google Tag Manager" src="https://www.googletagmanager.com/ns.html?id=GTM-PD8MFNL" height="0" width="0" style="display:none;visibility:hidden"></iframe>
+      <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSK2T46" height="0" width="0" style="display:none;visibility:hidden"></iframe>
     </noscript>
     <script>
       document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');


### PR DESCRIPTION
### Context
https://trello.com/c/mmx8JnUU/47-ga-spike-add-a-new-course-custom-event

I've started, but not really finished, spiking out GA (Google Analytics) and GTM (Google Tag Manager) integrations for the app. GA is the main place where all the data is sent - and GTM is used to join up in-app events with the analytics platform, which are fed through to GA. 

I've had to get access to GA, and with this I was able to create a GTM account specifically for Publish. I'm not entirely sure what access to the GTM access looks like though, and it might need to be recreated to so that people other than me can make changes to it. 

I've added a basic GA-all-pages tag, as shown in the GTM screenshot below. With the new config in the `app/views/layouts/application.html.erb`, this will emit events to GA that show which pages are accessed. 
<img width="2223" alt="image" src="https://user-images.githubusercontent.com/25597009/169561259-0daaeb92-571f-4bb7-86dd-a0f0affc2191.png">

The aim of the spike, however, was to get specific button events tracked, which I haven't managed to do yet. This should be a matter of creating custom event triggers in GTM, and connecting those up to the required elements in the app.

It would also be great if we could segment these events by environment, so that there's no cross-contamination from testing and production. This is possible in GTM (I think) by using different containers for each environment, and adding some config that points to the appropriate container depending on the env.

Thanks to @defong and @AbigailMcP for pointing me in good directions. When testing, make sure you don't have something blocking your browser from sending out JS script stuff (like uBlock). There are a set of GTM PRs on Register which I've used as reference, [take a look at them here](https://github.com/DFE-Digital/register-trainee-teachers/pulls?q=is%3Apr+GTM)
