### PR TITLE
Remove breadcrumbs

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,7 +43,9 @@
         <%= render PhaseBanner::View.new %>
         <%= yield :navigation_bar %>
         <%= yield :breadcrumbs %>
-        <%= yield :before_content %>
+        <% unless FeatureService.enabled?(:new_publish_navigation) %>
+          <%= yield :before_content %>
+        <% end %>
       </div>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-width-container">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -115,3 +115,4 @@ features:
     # state: open # Users can make requests for allocations
     # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
     state: confirmed # final allocation places are displayed to users in a readonly state
+    new_publish_navigation: false

--- a/config/settings/review.yml
+++ b/config/settings/review.yml
@@ -20,3 +20,4 @@ allocations_close_date: 2022-07-02
 features:
   allocations:
     state: confirmed
+  new_publish_navigation: true


### PR DESCRIPTION
### Context

As a follow up from #2668 where the new navigation bar is created and #2679 where the organisation switcher is implemented. This PR removes the breadcrumbs if the `new_publish_navigation` feature flag is activated, as those are now redundant.

### Guidance to review

- Review app is deployed with the flag on. Compare with prototype. 