### PR TITLE
48 remove or fix pending specs

### DIFF
--- a/spec/models/course_spec.rb
+++ b/spec/models/course_spec.rb
@@ -2534,23 +2534,6 @@ describe Course, type: :model do
         expect(subject.bursary_requirements).to eql(["a degree of 2:2 or above in any subject"])
       end
     end
-
-    # NOTE: There is currently no finanical incentives for `primary with maths`.
-    xcontext "when primary with maths" do
-      subject do
-        create(
-          :course,
-          level: "primary",
-          name: "Primary with mathematics",
-          course_code: "AAAA",
-          subjects: [find_or_create(:primary_subject, :primary_with_mathematics)],
-        )
-      end
-
-      it "includes additional requirements" do
-        expect(subject.bursary_requirements).to eql(["a degree of 2:2 or above in any subject", "at least grade B in maths A-level (or an equivalent)"])
-      end
-    end
   end
 
   describe "rollable?" do

--- a/spec/requests/api/v2/users/generate_and_send_magic_link_spec.rb
+++ b/spec/requests/api/v2/users/generate_and_send_magic_link_spec.rb
@@ -13,20 +13,6 @@ describe "PATCH /api/v2/users/generate_and_send_magic_link", type: :request do
     )
   end
 
-  context "when unauthenticated" do
-    let(:payload) { { email: "foo@bar" } }
-
-    before do
-      perform_request
-    end
-
-    subject { response }
-
-    xit { is_expected.to have_http_status(:ok) }
-
-    xit "should send an email to the user saying they don't have an account"
-  end
-
   context "when authenticated and authorised" do
     it "returns the status OK" do
       perform_request

--- a/spec/serializers/api/v2/serializable_course_spec.rb
+++ b/spec/serializers/api/v2/serializable_course_spec.rb
@@ -178,28 +178,6 @@ describe API::V2::SerializableCourse do
     end
   end
 
-  # TODO: level now drives the valid subjects that can be assigned to a
-  #       given course
-  # TODO: bursary and scholarship info should now live in the database
-  # TODO: chase up FINANCIAL_SUPPORT
-  xcontext "subjects & level" do
-    let(:course) { create(:course, subjects: subjects) }
-
-    describe "are taken from the course" do
-      let(:subjects) { [find_or_create(:primary_subject, :primary)] }
-
-      it { expect(subject["attributes"]).to include("level" => "primary") }
-      it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
-    end
-
-    describe "determine bursary and scholarship info" do
-      let(:subjects) { [find_or_create(:ucas_subject, :secondary), find_or_create(:ucas_subject, subject_name: "Russian")] }
-
-      it { expect(subject["attributes"]).to include("has_bursary?" => true) }
-      it { expect(subject["attributes"]).to include("has_scholarship_and_bursary?" => false) }
-    end
-  end
-
   describe "attributes retrieved from enrichments" do
     context "there's more than one enrichment" do
       let!(:latest_enrichment) { create_list(:course_enrichment, 2, course: course).last }

--- a/spec/serializers/api/v2/serializable_subject_spec.rb
+++ b/spec/serializers/api/v2/serializable_subject_spec.rb
@@ -21,15 +21,12 @@ describe API::V2::SerializableSubject do
     it { is_expected.to have_attribute(:subject_knowledge_enhancement_course_available).with_value(nil) }
   end
 
-  # NOTE: There is no longer any bursary subject with subject knowledge
-  #       enhancement course available
-  xcontext "when a bursary subject with subject knowledge enhancement course available" do
+  context "when a bursary subject with subject knowledge enhancement course available" do
     let(:bursary_subject) { find_or_create(:secondary_subject, :mathematics) }
     let(:resource) { API::V2::SerializableSubject.new object: bursary_subject }
 
     it { is_expected.to have_attribute(:bursary_amount).with_value(bursary_subject.financial_incentive.bursary_amount) }
     it { is_expected.to have_attribute(:early_career_payments).with_value(bursary_subject.financial_incentive.early_career_payments) }
     it { is_expected.to have_attribute(:scholarship).with_value(bursary_subject.financial_incentive.scholarship) }
-    it { is_expected.to have_attribute(:subject_knowledge_enhancement_course_available).with_value(true) }
   end
 end

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -171,28 +171,6 @@ describe API::V3::SerializableCourse do
     end
   end
 
-  # TODO: level now drives the valid subjects that can be assigned to a
-  #       given course
-  # TODO: bursary and scholarship info should now live in the database
-  # TODO: chase up FINANCIAL_SUPPORT
-  xcontext "subjects & level" do
-    let(:course) { create(:course, subjects: subjects) }
-
-    describe "are taken from the course" do
-      let(:subjects) { [find_or_create(:primary_subject, :primary)] }
-
-      it { expect(subject["attributes"]).to include("level" => "primary") }
-      it { expect(subject["attributes"]).to include("subjects" => %w[Primary]) }
-    end
-
-    describe "determine bursary and scholarship info" do
-      let(:subjects) { [find_or_create(:ucas_subject, :secondary), find_or_create(:ucas_subject, subject_name: "Russian")] }
-
-      it { expect(subject["attributes"]).to include("has_bursary?" => true) }
-      it { expect(subject["attributes"]).to include("has_scholarship_and_bursary?" => false) }
-    end
-  end
-
   describe "attributes retrieved from enrichments" do
     subject { parsed_json["data"]["attributes"] }
 


### PR DESCRIPTION
### Context

There are some pending specs in the codebase. These add additional noise (both in files and in test output). They mainly look redundant, so we are removing these. 