### PR TITLE
[67] Migrate the access requests section

### DIFF
--- a/app/controllers/publish/access_requests_controller.rb
+++ b/app/controllers/publish/access_requests_controller.rb
@@ -1,5 +1,7 @@
 module Publish
   class AccessRequestsController < PublishController
+    before_action -> { authorize(access_request) }, except: :index
+
     def index
       authorize(AccessRequest)
 
@@ -7,24 +9,16 @@ module Publish
     end
 
     def approve
-      authorize(access_request)
-
       access_request.approved!
       flash[:success] = "Successfully approved request"
       redirect_to inform_publisher_publish_access_request_path
     end
 
-    def inform_publisher
-      authorize(access_request)
-    end
+    def inform_publisher; end
 
-    def confirm
-      authorize(access_request)
-    end
+    def confirm; end
 
     def destroy
-      authorize(access_request)
-
       access_request.destroy
       flash[:success] = "Successfully deleted the Access Request"
       redirect_to publish_access_requests_path

--- a/app/controllers/publish/access_requests_controller.rb
+++ b/app/controllers/publish/access_requests_controller.rb
@@ -1,0 +1,39 @@
+module Publish
+  class AccessRequestsController < PublishController
+    def index
+      authorize(AccessRequest)
+
+      @access_requests = AccessRequest.requested.includes(:requester)
+    end
+
+    def approve
+      authorize(access_request)
+
+      access_request.approved!
+      flash[:success] = "Successfully approved request"
+      redirect_to inform_publisher_publish_access_request_path
+    end
+
+    def inform_publisher
+      authorize(access_request)
+    end
+
+    def confirm
+      authorize(access_request)
+    end
+
+    def destroy
+      authorize(access_request)
+
+      access_request.destroy
+      flash[:success] = "Successfully deleted the Access Request"
+      redirect_to publish_access_requests_path
+    end
+
+  private
+
+    def access_request
+      @access_request ||= AccessRequest.includes(:requester, requester: [:organisations]).find(params[:id])
+    end
+  end
+end

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -4,4 +4,8 @@ module UserHelper
   def full_name(user)
     [user.first_name, user.last_name].join(" ")
   end
+
+  def user_details(user)
+    "#{user[:first_name]} #{user[:last_name]} <#{user[:email]}>"
+  end
 end

--- a/app/policies/access_request_policy.rb
+++ b/app/policies/access_request_policy.rb
@@ -16,5 +16,7 @@ class AccessRequestPolicy
   alias_method :new?, :create?
   alias_method :index?, :approve?
   alias_method :show?, :approve?
+  alias_method :inform_publisher?, :approve?
+  alias_method :confirm?, :approve?
   alias_method :destroy?, :approve?
 end

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -3,6 +3,14 @@
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <div class="govuk-footer__meta-custom">
+          <% if current_user.present? && current_user.admin? && current_user.accepted_terms? %>
+            <h2 class="govuk-heading-m" id="admin">Support tools</h2>
+            <ul class="govuk-footer__inline-list govuk-!-margin-bottom-6">
+              <li class="govuk-footer__inline-list-item">
+                <%= link_to "Access Requests (#{AccessRequest.requested.count})", publish_access_requests_path, class: "govuk-footer__link", data: { qa: "access_requests_link" } %>
+              </li>
+            </ul>
+          <% end %>
           <h2 class="govuk-heading-m">Get support</h2>
           <ul class="govuk-footer__meta-custom govuk-list govuk-!-font-size-16 govuk-!-margin-bottom-8">
             <li>Email: <%= bat_contact_mail_to subject: "Publish teacher training courses support", class: "govuk-footer__link" %></li>

--- a/app/views/publish/access_requests/_access_request.html.erb
+++ b/app/views/publish/access_requests/_access_request.html.erb
@@ -1,0 +1,14 @@
+<tr class="govuk-table__row" data-qa="access-request">
+  <td class="govuk-table__cell" data-qa="access-request__id"><%= access_request.id %></td>
+  <td class="govuk-table__cell" data-qa="access-request__request_date"><%= access_request.request_date_utc&.to_date.to_s(:long) %></td>
+  <td class="govuk-table__cell" data-qa="access-request__requester"><%= user_details(access_request.requester) %></td>
+  <td class="govuk-table__cell" data-qa="access-request__recipient">
+    <%= access_request.first_name %>
+    <%= access_request.last_name %>
+    &lt;<%= access_request.email_address %>&gt;
+  </td>
+  <td class="govuk-table__cell">
+    <%= govuk_button_link_to "View Request", confirm_publish_access_request_path(access_request.id), class: "govuk-!-margin-bottom-1", data: { qa: "access-request__view_request" } %>
+  </td>
+  <td class="govuk-table__cell" data-qa="access-request__organisation"><%= access_request.organisation %></td>
+</tr>

--- a/app/views/publish/access_requests/confirm.html.erb
+++ b/app/views/publish/access_requests/confirm.html.erb
@@ -1,0 +1,29 @@
+<% content_for :page_title, "Approve access request" %>
+
+<h1 class="govuk-heading-l">Approve new access for <%= @access_request.recipient.full_name %></h1>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Recipient</th>
+          <td class="govuk-table__cell "><%= user_details(@access_request.recipient) if @access_request.recipient %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Will receive access to</th>
+          <td class="govuk-table__cell "><%= @access_request.requester.providers.map(&:provider_name).join(", ") %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<div class="govuk-button-group">
+  <%= govuk_button_to("Approve", approve_publish_access_request_path(@access_request.id), data: { qa: "access-request__approve" }) %>
+  <%= govuk_button_to("Delete",
+    publish_access_request_path(@access_request.id),
+    method: :delete,
+    class: "govuk-button govuk-button--warning",
+    data: { qa: "access-request__delete" })%>
+</div>

--- a/app/views/publish/access_requests/index.html.erb
+++ b/app/views/publish/access_requests/index.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "Access requests" %>
+
+<h1 class="govuk-heading-l">
+  Open access requests (<%= @access_requests.count %>)
+</h1>
+
+<table class="govuk-table">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <th class="govuk-table__header" scope="col">Request #</th>
+      <th class="govuk-table__header" scope="col">Made at</th>
+      <th class="govuk-table__header" scope="col">Requester</th>
+      <th class="govuk-table__header" scope="col">Recipient</th>
+      <th class="govuk-table__header" scope="col">Actions</th>
+      <th class="govuk-table__header" scope="col">Organisation</th>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body">
+    <%= render partial: "access_request", collection: @access_requests %>
+  </tbody>
+</table>

--- a/app/views/publish/access_requests/inform_publisher.html.erb
+++ b/app/views/publish/access_requests/inform_publisher.html.erb
@@ -1,0 +1,21 @@
+<% page_title = "Inform the publisher" %>
+<% content_for :page_title, page_title %>
+
+<h1 class="govuk-heading-l"><%= page_title %></h1>
+
+<p class="govuk-body">
+  Inform the publisher about the change to their access:
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Check whether <%= govuk_link_to "they already have a DfE Sign-in account", "#{Settings.dfe_signin.user_search_url}?criteria=#{@access_request.email_address}", data: { qa: "dfe_signin_search_link" } %></li>
+    <li>In <%= govuk_link_to "GOV.UK Notify", Settings.notify.service_url, data: { qa: "notify_service_link" } %>, send an email to <strong><%= @recipient_email_address %></strong> using:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the <%= govuk_link_to "REGISTERED template", Settings.notify.registered_user_template_url, data: { qa: "registered_user_link" } %> if they have a DfE Sign-in account</li>
+        <li>the <%= govuk_link_to "UNREGISTERED template", Settings.notify.unregistered_user_template_url, data: { qa: "unregistered_user_link" } %> if they don’t</li>
+      </ul>
+  </ol>
+</p>
+
+<p class="govuk-body">
+  <%= govuk_button_link_to "Done", publish_access_requests_path, class: "govuk-!-margin-bottom-0", data: { qa: "done_link" } %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,15 @@ Rails.application.routes.draw do
 
     resources :notifications, path: "/notifications", controller: "notifications", only: %i[index update]
 
+    resources :access_requests, path: "/access-requests", controller: "access_requests", only: %i[new index create] do
+      member do
+        post :approve
+        delete :destroy
+        get :confirm
+        get "/inform-publisher", to: "access_requests#inform_publisher"
+      end
+    end
+
     resources :providers, path: "organisations", param: :code, only: [:show] do
       get "/users", on: :member, to: "users#index"
       get "/request-access", on: :member, to: "providers/access_requests#new"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -5,6 +5,10 @@ support_email: becomingateacher@digital.education.gov.uk
 
 search_ui:
   base_url: https://localhost:5000
+notify:
+  service_url: https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534
+  unregistered_user_template_url: https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/templates/9ecac443-8cfd-49ac-ac59-e7ffa0ab6278
+  registered_user_template_url: https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534/templates/4da327dd-907a-4619-abe6-45f348bb2fa3
 
 # URL of this app for the callback after sigining in
 base_url: https://localhost:3001

--- a/spec/features/support/access_requests/managing_requests_spec.rb
+++ b/spec/features/support/access_requests/managing_requests_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+feature "Viewing and approving requests" do
+  before do
+    given_i_am_authenticated(user: admin)
+    and_there_are_access_requests
+  end
+
+  scenario "admin can view the requests" do
+    when_i_visit_the_root_page
+    then_i_should_see_a_link_to_view_the_requests
+    when_i_click_on_the_link
+    then_i_see_the_requests
+  end
+
+  scenario "admin can approve a request" do
+    when_i_view_the_first_request
+    and_i_approve_the_request
+    then_the_request_should_be_approved
+    and_i_should_see_steps_to_inform_the_publisher
+  end
+
+  scenario "admin can delete a request" do
+    when_i_view_the_first_request
+    and_i_delete_the_request
+    then_the_request_should_be_deleted
+  end
+
+private
+
+  def and_there_are_access_requests
+    create_list(:access_request, 2, :requested)
+  end
+
+  def when_i_visit_the_root_page
+    visit(root_path)
+  end
+
+  def then_i_should_see_a_link_to_view_the_requests
+    expect(footer).to have_access_requests_link
+    expect(footer.access_requests_link).to have_text("Access Requests (2)")
+  end
+
+  def when_i_click_on_the_link
+    footer.access_requests_link.click
+  end
+
+  def then_i_see_the_requests
+    expect(access_requests_page).to be_displayed
+    expect(access_requests_page.requests.size).to eq(2)
+  end
+
+  def when_i_view_the_first_request
+    access_requests_page.load
+    access_requests_page.requests.first.view_request.click
+    expect(access_requests_confirm_page).to be_displayed
+  end
+
+  def and_i_approve_the_request
+    access_requests_confirm_page.approve.click
+  end
+
+  def and_i_delete_the_request
+    access_requests_confirm_page.delete.click
+  end
+
+  def then_the_request_should_be_approved
+    expect(page).to have_text("Successfully approved request")
+  end
+
+  def then_the_request_should_be_deleted
+    expect(access_requests_page).to have_text("Successfully deleted the Access Request")
+    expect(access_requests_page.requests.size).to eq(1)
+  end
+
+  def and_i_should_see_steps_to_inform_the_publisher
+    expect(page).to have_text("Inform the publisher")
+  end
+
+  def admin
+    @admin ||= create(:user, :admin)
+  end
+end

--- a/spec/serializers/api/v3/serializable_course_spec.rb
+++ b/spec/serializers/api/v3/serializable_course_spec.rb
@@ -56,9 +56,8 @@ describe API::V3::SerializableCourse do
     it { is_expected.to have_relationship(:provider) }
 
     it "includes the provider" do
-      expect(parsed_json["included"])
-        .to(include(have_type("providers")
-          .and(have_id(provider.id.to_s))))
+      expect(parsed_json["included"]).to(include(have_type("providers")))
+      expect(parsed_json["included"].first["id"]).to eq(provider.id.to_s)
     end
   end
 

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -263,5 +263,9 @@ module FeatureHelpers
     def primary_nav
       @primary_nav ||= PageObjects::Publish::PrimaryNav.new
     end
+    
+    def footer
+      @footer ||= PageObjects::Publish::Footer.new
+    end
   end
 end

--- a/spec/support/feature_helpers/publish_pages.rb
+++ b/spec/support/feature_helpers/publish_pages.rb
@@ -263,7 +263,7 @@ module FeatureHelpers
     def primary_nav
       @primary_nav ||= PageObjects::Publish::PrimaryNav.new
     end
-    
+
     def footer
       @footer ||= PageObjects::Publish::Footer.new
     end

--- a/spec/support/feature_helpers/support_pages.rb
+++ b/spec/support/feature_helpers/support_pages.rb
@@ -78,6 +78,14 @@ module FeatureHelpers
       @allocation_uplift_new_page ||= PageObjects::Support::AllocationUpliftNew.new
     end
 
+    def access_requests_page
+      @access_requests_page ||= PageObjects::Support::AccessRequests::Index.new
+    end
+
+    def access_requests_confirm_page
+      @access_requests_confirm_page ||= PageObjects::Support::AccessRequests::Confirm.new
+    end
+
     def sign_in_page
       @sign_in_page ||= PageObjects::SignIn.new
     end

--- a/spec/support/page_objects/publish/footer.rb
+++ b/spec/support/page_objects/publish/footer.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Publish
+    class Footer < PageObjects::Base
+      element :access_requests_link, '[data-qa="access_requests_link"]'
+    end
+  end
+end

--- a/spec/support/page_objects/support/access_requests/confirm.rb
+++ b/spec/support/page_objects/support/access_requests/confirm.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    module AccessRequests
+      class Confirm < PageObjects::Base
+        set_url "/publish/access-requests/{id}/confirm"
+
+        element :approve, '[data-qa="access-request__approve"]'
+        element :delete, '[data-qa="access-request__delete"]'
+      end
+    end
+  end
+end

--- a/spec/support/page_objects/support/access_requests/index.rb
+++ b/spec/support/page_objects/support/access_requests/index.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Support
+    module AccessRequests
+      class Index < PageObjects::Base
+        set_url "/publish/access-requests"
+
+        sections :requests, '[data-qa="access-request"]' do
+          element :id, '[data-qa="access-request__id"]'
+          element :date, '[data-qa="access-request__request_date"]'
+          element :requester, '[data-qa="access-request__requester"]'
+          element :recipient, '[data-qa="access-request__recipient"]'
+          element :view_request, '[data-qa="access-request__view_request"]'
+          element :organisation, '[data-qa="access-request__organisation"]'
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Context

- https://trello.com/c/cbHZEGfy/67-migrate-access-requests-section

### Changes proposed in this pull request

- Migrate the access requests index/confirm/delete functionality from the old support tool

### Guidance to review

- Sign in as a non admin persona and request access for a user
- Sign out and sign back in as an admin persona and view access requests (link in the footer should be visible)
- Assert you can view the request, assert you can approve/delete the request

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
