### PR TITLE
Remove rollover deploy from merge to master

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [qa,staging,production,sandbox,rollover]
+        environment: [qa,staging,production,sandbox]
       max-parallel: 1
     steps:
       - name: Checkout


### PR DESCRIPTION
### Context

rollover will be deployed manually from deploy workflow,
and not automatically on merge to master

### Changes proposed in this pull request

remove from env list in build-and-deploy deploy-all step

### Guidance to review

Check yaml
Confirm rollover not updated on merge

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
