### PR TITLE
[80 & 81] A couple of rollover snags

### DIFF
--- a/app/controllers/publish/publish_controller.rb
+++ b/app/controllers/publish/publish_controller.rb
@@ -15,7 +15,7 @@ module Publish
     end
 
     def recruitment_cycle
-      cycle_year = params[:recruitment_cycle_year] || Settings.current_recruitment_cycle_year
+      cycle_year = params[:recruitment_cycle_year] || params[:year] || Settings.current_recruitment_cycle_year
 
       @recruitment_cycle ||= RecruitmentCycle.find_by!(year: cycle_year)
     end

--- a/app/views/publish/recruitment_cycles/_provider_info.html.erb
+++ b/app/views/publish/recruitment_cycles/_provider_info.html.erb
@@ -3,8 +3,7 @@
 <%= render partial: "publish/recruitment_cycles/courses_info", locals: { provider: provider, year: year } %>
 <%= render partial: "publish/recruitment_cycles/courses_accredited_body", locals: { provider: provider, year: year } %>
 
+<!-- Remove this once the current cycle is set to 2023 -->
 <% if recruitment_cycle.current? %>
   <%= render partial: "publish/recruitment_cycles/allocations", locals: { provider: provider, year: year } %>
-<% elsif recruitment_cycle.next? %>
-  <%= render partial: "publish/recruitment_cycles/allocations", locals: { provider: provider.from_previous_recruitment_cycle, year: year.to_i.pred } %>
 <% end %>


### PR DESCRIPTION
### Context

- https://trello.com/c/4FjAdm3P/81-next-cycle-about-your-organisation-page-showing-current-cycle-instead
- https://trello.com/c/xcg5ZtMx/80-publish-next-cycle-2023-to-2024-is-broken-due-to-allocations

### Changes proposed in this pull request

Fixes the snags listed above.

[80] - Remove allocations link for next cycle as it's going away
[81] - RecruitmentCycle year can be set under `params[:year]` for locations view so we need to check for that too

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased master
- [x] Cleaned commit history
- [x] Tested by running locally
