### PR TITLE
[85] Application start date is causing issues

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -197,7 +197,7 @@ class CourseDecorator < ApplicationDecorator
       "As soon as the course is on Find (recommended)"
     else
       year = recruitment_cycle.year.to_i
-      day_month = Date.parse(recruitment_cycle.application_start_date).strftime("%-d %B")
+      day_month = recruitment_cycle.application_start_date.strftime("%-d %B")
       "On #{day_month} when applications for the #{year} to #{year + 1} cycle open"
     end
   end
@@ -340,6 +340,10 @@ class CourseDecorator < ApplicationDecorator
 
   def about_accrediting_body
     object.accrediting_provider_description
+  end
+
+  def has_physical_education_subject?
+    subjects.map(&:subject_name).include?("Physical education")
   end
 
 private

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -16,7 +16,7 @@ module Courses
         new_course.uuid = nil
         new_course.provider = new_provider
         year_differential = new_course.recruitment_cycle.year.to_i - course.recruitment_cycle.year.to_i
-        new_course.applications_open_from = course.applications_open_from + year_differential.year
+        new_course.applications_open_from = adjusted_applications_open_from_date(course, year_differential)
         new_course.start_date = course.start_date + year_differential.year
         new_course.subjects = course.subjects
         new_course.save!(validate: false)
@@ -43,6 +43,16 @@ module Courses
       return if last_enrichment.blank?
 
       @enrichments_copy_to_course.execute(enrichment: last_enrichment, new_course: new_course)
+    end
+
+    def adjusted_applications_open_from_date(course, year_differential)
+      next_cycle = RecruitmentCycle.next_recruitment_cycle
+
+      if course.applications_open_from + year_differential.year >= next_cycle.application_start_date
+        course.applications_open_from + year_differential.year
+      else
+        next_cycle.application_start_date
+      end
     end
   end
 end

--- a/spec/services/courses/copy_to_provider_service_spec.rb
+++ b/spec/services/courses/copy_to_provider_service_spec.rb
@@ -46,10 +46,24 @@ RSpec.describe Courses::CopyToProviderService do
     expect(new_course.open_for_applications?).to be_falsey
   end
 
-  it "updates the applications_open_from and start date attributes" do
-    service.execute(course: course, new_provider: new_provider)
-    expect(new_course.start_date).to eq course.start_date + 1.year
-    expect(new_course.applications_open_from).to eq course.applications_open_from + 1.year
+  context "applications open from date" do
+    it "updates the applications_open_from and start date attributes" do
+      service.execute(course: course, new_provider: new_provider)
+      expect(new_course.start_date).to eq course.start_date + 1.year
+      expect(new_course.applications_open_from).to eq course.applications_open_from + 1.year
+    end
+
+    context "when the original course's date is before the next cycle's start date" do
+      before do
+        course.applications_open_from = Date.new(provider.recruitment_cycle.year.to_i - 1, 10, 1)
+      end
+
+      it "sets the new course's applications open from date correctly" do
+        service.execute(course: course, new_provider: new_provider)
+
+        expect(new_course.applications_open_from).to eq(new_recruitment_cycle.application_start_date)
+      end
+    end
   end
 
   it "leaves the existing course alone" do


### PR DESCRIPTION
### Context

- https://trello.com/c/YSy4Ef3g/85-application-start-date-is-causing-issues

### Changes proposed in this pull request

Some courses can have their `applications_open_from_date` less than the next cycle's applications start date. This PR handles this scenario by adjusting them to the next cycle's date.

Also (perhaps controversially) I've introduced two new settings to keep track of the next cycle's applications start/end date. These dates seem to be floated around internally across conversations but it might be a good idea to have them concretely defined in the application. The tradeoff is another a pair of properties to change each time rollover comes around but i think it's worth it to catch & handle edge cases like the above. 

Also fixed another issue when creating a course with a method missing in the course decorator.

### Guidance to review

- This issue occurs in the rollover environment. Load the same url in the review app `publish/organisations/2CG/2023/courses/D730/outcome` and attempt to save. It errors in the rollover env but saves in the review app.

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
