### PR TITLE
106 allow admins to use the org switcher

### DIFF
--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -2,7 +2,9 @@
 <%= content_for :before_content, render_breadcrumbs(:courses) %>
 
 <h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  <% unless @provider.rolled_over? && FeatureService.enabled?(:new_publish_navigation) %>
+    <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  <% end %>
   Courses
 </h1>
 

--- a/app/views/publish/providers/details.html.erb
+++ b/app/views/publish/providers/details.html.erb
@@ -24,7 +24,9 @@
 <% end %>
 
 <h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  <% unless @provider.rolled_over? && FeatureService.enabled?(:new_publish_navigation) %>
+    <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+  <% end %>
   About your organisation
 </h1>
 

--- a/app/views/publish/providers/locations/index.html.erb
+++ b/app/views/publish/providers/locations/index.html.erb
@@ -6,7 +6,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">
-      <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+      <% unless @provider.rolled_over? && FeatureService.enabled?(:new_publish_navigation) %>
+        <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+      <% end %>
       <%= page_title %>
     </h1>
 

--- a/app/views/publish/training_providers/index.html.erb
+++ b/app/views/publish/training_providers/index.html.erb
@@ -1,20 +1,36 @@
-<% content_for :page_title, "Courses as an accredited body" %>
+<% if FeatureService.enabled?(:new_publish_navigation) %>
+  <% content_for :page_title, "Training partners" %>
+<% else %>
+  <% content_for :page_title, "Courses as an accredited body" %>
+<% end %>
+
 <%= content_for :before_content, render_breadcrumbs(:training_providers) %>
 
-<h1 class="govuk-heading-l">
-  <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
-  Courses as an accredited body
-</h1>
+  <h1 class="govuk-heading-l">
+    <% unless @provider.rolled_over? && FeatureService.enabled?(:new_publish_navigation) %>
+      <span class="govuk-caption-l"><%= @recruitment_cycle.title %></span>
+    <% end %>
+
+    <% if FeatureService.enabled?(:new_publish_navigation) %>
+      Training partners
+    <% else %>
+      Courses as an accredited body
+    <% end %>
+  </h1>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body">Use this section to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>see who lists you as their accredited body</li>
-      <li>see which courses you’re the accredited body for</li>
-    </ul>
+    <% unless FeatureService.enabled?(:new_publish_navigation) %>
+      <p class="govuk-body">Use this section to:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>see who lists you as their accredited body</li>
+        <li>see which courses you’re the accredited body for</li>
+      </ul>
+    <% end %>
 
-    <h2 class="govuk-heading-m">Training providers</h2>
+    <% unless FeatureService.enabled?(:new_publish_navigation) %>
+      <h2 class="govuk-heading-m">Training providers</h2>
+    <% end %>
     <ul class="govuk-list" data-qa="provider__training_providers_list">
       <% @training_providers.each do |training_provider| %>
         <li data-qa="training_provider">

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -116,4 +116,3 @@ features:
     # state: open # Users can make requests for allocations
     # state: closed # Readonly - Users can see if they have or have not made request (does not show number of places)
     state: confirmed # final allocation places are displayed to users in a readonly state
-  new_publish_navigation: false


### PR DESCRIPTION
### Context

As part of the new publish navigation, we are reworking the `Training partners` page and removing recruitment cycle text.

### Changes proposed in this pull request

- Remove guidance text
- Rename H2
- Remove recruitment cycle text from all nav bar sections unless we are in rollover
- Keep these changes behind the feature flag

### Guidance to review

I've activated the feature flag in the review app, so look at the nav bar on that and see if everthing still looks ok.
