### PR TITLE
108 css tweaks to and around the nav bar

### DIFF
--- a/app/components/header/style.scss
+++ b/app/components/header/style.scss
@@ -13,30 +13,36 @@
   }
 }
 
-.govuk-header__container {
-  .app-header--development & {
-    border-bottom-color: govuk-colour("dark-grey");
-  }
 
-  .app-header--qa & {
-    border-bottom-color: govuk-colour("orange");
-  }
+.app-header--development .govuk-header__container,
+.app-header--development.app-header--full-border, {
+  border-bottom-color: govuk-colour("dark-grey");
+}
 
-  .app-header--review & {
-    border-bottom-color: govuk-colour("purple");
-  }
+.app-header--qa .govuk-header__container,
+.app-header--qa.app-header--full-border {
+  border-bottom-color: govuk-colour("orange");
+}
 
-  .app-header--rollover & {
-    border-bottom-color: govuk-colour("turquoise");
-  }
+.app-header--review .govuk-header__container,
+.app-header--review.app-header--full-border,
+.app-header--sandbox .govuk-header__container,
+.app-header--sandbox.app-header--full-border {
+  border-bottom-color: govuk-colour("purple");
+}
 
-  .app-header--staging & {
-    border-bottom-color: govuk-colour("red");
-  }
+.app-header--rollover .govuk-header__container,
+.app-header--rollover.app-header--full-border {
+  border-bottom-color: govuk-colour("turquoise");
+}
 
-  .app-header--sandbox & {
-    border-bottom-color: govuk-colour("purple");
-  }
+.app-header--staging .govuk-header__container,
+.app-header--staging.app-header--full-border {
+  border-bottom-color: govuk-colour("red");
+}
+
+.app-header--production.app-header--full-border {
+  border-bottom-color: govuk-colour("blue");
 }
 
 .govuk-header__navigation-list {

--- a/app/components/header/view.html.erb
+++ b/app/components/header/view.html.erb
@@ -1,6 +1,6 @@
 <%= govuk_header(
   homepage_url: publish_root_path,
-  classes: "govuk-!-display-none-print app-header app-header--wide-logo #{environment_header_class}",
+  classes: "govuk-!-display-none-print app-header--full-border app-header--wide-logo #{environment_header_class}",
   navigation_classes: "govuk-header__navigation--end") do |header| %>
 
   <% header.product_name(name: service_name) %>

--- a/app/components/navigation_bar/view.html.erb
+++ b/app/components/navigation_bar/view.html.erb
@@ -1,5 +1,5 @@
  <% if user_signed_in? %>
-  <div class="moj-primary-navigation govuk-!-margin-top-4">
+  <div class="moj-primary-navigation">
     <div class="moj-primary-navigation__container">
       <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -23,6 +23,6 @@ class NavigationBar::View < GovukComponent::Base
 private
 
   def show_current_link?(item)
-    item.fetch(:current, false) || current_path == item.fetch(:url)
+    item.fetch(:current, false) || current_path.include?(item.fetch(:url))
   end
 end

--- a/app/components/navigation_bar/view.rb
+++ b/app/components/navigation_bar/view.rb
@@ -23,6 +23,6 @@ class NavigationBar::View < GovukComponent::Base
 private
 
   def show_current_link?(item)
-    item.fetch(:current, false) || current_path.include?(item.fetch(:url))
+    item.fetch(:current, false) || [item.fetch(:url), item[:additional_url]].compact.any? { |url| current_path.include?(url) }
   end
 end

--- a/app/components/phase_banner/script.js
+++ b/app/components/phase_banner/script.js
@@ -1,0 +1,1 @@
+import './style.scss'

--- a/app/components/phase_banner/style.scss
+++ b/app/components/phase_banner/style.scss
@@ -1,0 +1,5 @@
+.app-phase-banner--no-border {
+  .govuk-phase-banner {
+    border-bottom: 0;
+  }
+}

--- a/app/components/phase_banner/view.html.erb
+++ b/app/components/phase_banner/view.html.erb
@@ -1,4 +1,4 @@
-<div class="app-phase-banner<%= @no_border ? ' app-phase-banner--no-border' : '' %> ">
+<div class="app-phase-banner<%= @no_border ? ' app-phase-banner--no-border' : '' %> govuk-!-display-none-print">
   <%= govuk_phase_banner(
     tag: {
       text: environment_label,

--- a/app/components/phase_banner/view.html.erb
+++ b/app/components/phase_banner/view.html.erb
@@ -1,12 +1,14 @@
-<%= govuk_phase_banner(
-  tag: {
-    text: environment_label,
-    colour: environment_colour,
-  },
-) do %>
-  <% if sandbox_mode? %>
-    This is a test version of Publish for providers and software vendors
-  <% else %>
-    This is a new service – your <%= govuk_link_to "feedback", feedback_link_to %> will help us to improve it.
+<div class="app-phase-banner<%= @no_border ? ' app-phase-banner--no-border' : '' %> ">
+  <%= govuk_phase_banner(
+    tag: {
+      text: environment_label,
+      colour: environment_colour,
+    },
+  ) do %>
+    <% if sandbox_mode? %>
+      This is a test version of Publish for providers and software vendors
+    <% else %>
+      This is a new service – your <%= govuk_link_to "feedback", feedback_link_to %> will help us to improve it.
+    <% end %>
   <% end %>
-<% end %>
+</div>

--- a/app/components/phase_banner/view.rb
+++ b/app/components/phase_banner/view.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
 class PhaseBanner::View < ViewComponent::Base
+  def initialize(no_border: false)
+    super
+    @no_border = no_border
+  end
+
   def environment_label
     Settings.environment.label
   end

--- a/app/components/title_bar/view.html.erb
+++ b/app/components/title_bar/view.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <p class="govuk-heading-s title-bar-inline"><%= title %></p>
+    <p class="govuk-heading-s title-bar-inline govuk-!-margin-bottom-2"><%= title %></p>
     <%= link %>
   </div>
 </div>

--- a/app/controllers/publish/providers/access_requests_controller.rb
+++ b/app/controllers/publish/providers/access_requests_controller.rb
@@ -1,6 +1,8 @@
 module Publish
   module Providers
     class AccessRequestsController < PublishController
+      before_action :provider
+
       def new
         authorize AccessRequest
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -64,7 +64,11 @@ module ApplicationHelper
       end
     end
   end
-# rubocop:enable Rails/HelperInstanceVariable
+  # rubocop:enable Rails/HelperInstanceVariable
+
+  def display_phase_banner_border?(user)
+    user && !user.admin? && (user.providers_via_organisations.where recruitment_cycle: RecruitmentCycle.current).one?
+  end
 
 private
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,7 +67,7 @@ module ApplicationHelper
   # rubocop:enable Rails/HelperInstanceVariable
 
   def display_phase_banner_border?(user)
-    user && !user.admin? && (user.providers_via_organisations.where recruitment_cycle: RecruitmentCycle.current).one?
+    user && !user.admin? && user.providers.where(recruitment_cycle: RecruitmentCycle.current).one?
   end
 
 private

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,7 +39,7 @@
     <% end %>
 
       <div class="govuk-width-container">
-        <% if display_phase_banner_border?(current_user) %>
+        <% if display_phase_banner_border?(current_user) && FeatureService.enabled?(:new_publish_navigation) %>
           <%= render PhaseBanner::View.new(no_border: true) %>
         <% else  %>
           <%= render PhaseBanner::View.new %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -47,7 +47,6 @@
         <% end %>
         <%= yield :navigation_bar %>
         <%= yield :breadcrumbs %>
-        <%= yield :before_content %>
       </div>
 
     <% if FeatureService.enabled?(:new_publish_navigation) %>
@@ -67,6 +66,7 @@
     <% end %>
 
     <div class="govuk-width-container">
+      <%= yield :before_content %>
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-width-container">
           <%= render(FlashBanner::View.new(flash: flash)) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,6 +53,7 @@
          <%= render TitleBar::View.new(title: @provider.provider_name) %>
         <% end %>
       <% end %>
+    </div>
 
       <% if render_navigation_bar?(@provider) && @provider.accredited_body? %>
           <%= render partial: "publish/shared/navigation_bar_with_training_partners" %>
@@ -61,6 +62,7 @@
       <% end %>
     <% end %>
 
+    <div class="govuk-width-container">
       <main class="govuk-main-wrapper " id="main-content" role="main">
         <div class="govuk-width-container">
           <%= render(FlashBanner::View.new(flash: flash)) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,11 @@
 
     <div class="govuk-width-container">
       <div class="govuk-width-container">
-        <%= render PhaseBanner::View.new %>
+        <% if display_phase_banner_border?(current_user) %>
+          <%= render PhaseBanner::View.new(no_border: true) %>
+        <% else  %>
+          <%= render PhaseBanner::View.new %>
+        <% end %>
         <%= yield :navigation_bar %>
         <%= yield :breadcrumbs %>
         <%= yield :before_content %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,12 +50,13 @@
 
     <% if FeatureService.enabled?(:new_publish_navigation) %>
 
-      <% if current_user %>
-        <% if (current_user.has_multiple_providers_in_current_recruitment_cycle? || current_user.admin?) && @provider && !request.path.include?('support') %>
-         <%= render TitleBar::View.new(title: @provider.provider_name) %>
+      <div class="govuk-width-container">
+        <% if current_user %>
+          <% if (current_user.has_multiple_providers_in_current_recruitment_cycle? || current_user.admin?) && @provider && !request.path.include?('support') %>
+           <%= render TitleBar::View.new(title: @provider.provider_name) %>
+          <% end %>
         <% end %>
-      <% end %>
-    </div>
+      </div>
 
       <% if render_navigation_bar?(@provider) && @provider.accredited_body? %>
           <%= render partial: "publish/shared/navigation_bar_with_training_partners" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,7 +38,6 @@
       ) %>
     <% end %>
 
-    <div class="govuk-width-container">
       <div class="govuk-width-container">
         <% if display_phase_banner_border?(current_user) %>
           <%= render PhaseBanner::View.new(no_border: true) %>

--- a/app/views/publish/shared/_navigation_bar_with_training_partners.html.erb
+++ b/app/views/publish/shared/_navigation_bar_with_training_partners.html.erb
@@ -2,7 +2,7 @@
   items: [
     { name: t("navigation_bar.courses"), url: publish_provider_recruitment_cycle_courses_path(@provider.provider_code, @provider.recruitment_cycle_year) },
     { name: t("navigation_bar.locations"), url: publish_provider_recruitment_cycle_locations_path(@provider.provider_code, @provider.recruitment_cycle_year) },
-    { name: t("navigation_bar.users"), url: users_publish_provider_path(code: @provider.provider_code) },
+    { name: t("navigation_bar.users"), url: users_publish_provider_path(code: @provider.provider_code), additional_url: request_access_publish_provider_path(@provider.provider_code) },
     { name: t("navigation_bar.training_partners"), url: publish_provider_recruitment_cycle_training_providers_path(@provider.provider_code, @provider.recruitment_cycle_year) },
     { name: t("navigation_bar.organisation_details"), url: details_publish_provider_recruitment_cycle_path(@provider.provider_code, @provider.recruitment_cycle_year) },
   ],

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -28,3 +28,4 @@ basic_auth:
 
 features:
   send_request_data_to_bigquery: true
+  new_publish_navigation: true

--- a/spec/components/phase_banner/view_spec.rb
+++ b/spec/components/phase_banner/view_spec.rb
@@ -38,13 +38,6 @@ module PhaseBanner
       end
     end
 
-    context "when false is passed in to 'no_border'" do
-      it "renders a border" do
-        render_inline(described_class.new(no_border: false))
-        expect(page).not_to have_css(".app-phase-banner--no-border")
-      end
-    end
-
     context "when true is passed in to 'no_border'" do
       it "does not render a border" do
         render_inline(described_class.new(no_border: true))

--- a/spec/components/phase_banner/view_spec.rb
+++ b/spec/components/phase_banner/view_spec.rb
@@ -30,5 +30,26 @@ module PhaseBanner
       render_inline(described_class.new)
       expect(page).to have_text("This is a new service")
     end
+
+    context "when no value is passed in to 'no_border'" do
+      it "renders a border" do
+        render_inline(described_class.new)
+        expect(page).not_to have_css(".app-phase-banner--no-border")
+      end
+    end
+
+    context "when false is passed in to 'no_border'" do
+      it "renders a border" do
+        render_inline(described_class.new(no_border: false))
+        expect(page).not_to have_css(".app-phase-banner--no-border")
+      end
+    end
+
+    context "when true is passed in to 'no_border'" do
+      it "does not render a border" do
+        render_inline(described_class.new(no_border: true))
+        expect(page).to have_css(".app-phase-banner--no-border")
+      end
+    end
   end
 end


### PR DESCRIPTION
### Context

A few small tweaks in preparation for switching on the new navigation.

Note that when this is merged the app-header line will cover the full page width. This is not behind a feature flag. 

### Changes proposed in this pull request

- Extend app-header line to cover full page width
- Grey background spans full viewport width
- Reduce spacing between change org link and primary nav bar

Only display the phase banner border:
- If there is a current user
- if the current user is not an admin
- if the current user is associated with more than one provider

### Screenshots

## Before

<img width="1791" alt="image" src="https://user-images.githubusercontent.com/50492247/171177747-de567fa6-9210-4020-b397-4cbaf2bb5d38.png">


## After

<img width="1790" alt="image" src="https://user-images.githubusercontent.com/50492247/171177604-12fe3894-0cc4-415b-bba8-88c9aba5b16c.png">


### Guidance to review

- Recommend reviewing commit by commit 

- Take a look at the nav bar and change org link as a multi org user, single org user and accredited body 
- Do the same for the phase banner border
- Compare and contrast with the prototype
