### PR TITLE
Add SNYK scan to build workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -46,12 +46,33 @@ jobs:
         # This is the latest commit on the actual PR branch
         echo "DOCKER_IMAGE_TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
 
+    - name: Set KV environment variables
+      if: github.actor != 'dependabot[bot]'
+      run: |
+        # tag build to the review env for vars and secrets
+        tf_vars_file=terraform/workspace_variables/review.tfvars.json
+        echo "KEY_VAULT_NAME=$(jq -r '.key_vault_name' ${tf_vars_file})" >> $GITHUB_ENV
+        echo "KEY_VAULT_INFRA_SECRET_NAME=$(jq -r '.key_vault_infra_secret_name' ${tf_vars_file})" >> $GITHUB_ENV
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1.12.0
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: azure/login@v1
+      if: github.actor != 'dependabot[bot]'
+      with:
+        creds: ${{ secrets.AZURE_CREDENTIALS_REVIEW }}
+
+    - uses: DFE-Digital/keyvault-yaml-secret@v1
+      if: github.actor != 'dependabot[bot]'
+      id: get-secret
+      with:
+        keyvault: ${{ env.KEY_VAULT_NAME }}
+        secret: ${{ env.KEY_VAULT_INFRA_SECRET_NAME }}
+        key: SNYK_TOKEN
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -73,7 +94,8 @@ jobs:
         tags: |
           ${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
           ${{ env.DOCKER_IMAGE}}:${{ env.DOCKER_IMAGE_TAG }}
-        push: true
+        push: false
+        load: true
         cache-from: |
           type=registry,ref=${{ env.DOCKER_IMAGE}}:master
           type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
@@ -82,6 +104,23 @@ jobs:
         build-args: |
           BUILDKIT_INLINE_CACHE=1
           COMMIT_SHA=${{ env.DOCKER_IMAGE_TAG }}
+
+    - name: Push ${{ env.DOCKER_IMAGE }} images for review
+      if: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'deploy') }}
+      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
+
+    - name: Run Snyk to check Docker image for vulnerabilities
+      if: github.actor != 'dependabot[bot]'
+      uses: snyk/actions/docker@master
+      env:
+        SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
+      with:
+        image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
+        args: --file=Dockerfile --severity-threshold=high
+
+    - name: Push ${{ env.DOCKER_IMAGE }} images
+      if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}
+      run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
     - name: Alert Build Failures
       if: ${{ failure() && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
### Context

Add SNYK security scan of the docker image to the build workflow.
It will scan on PR (but not for dependabot) and merge to main.

Any High (or above) vulnerability will cause the build workflow to fail,
and will need to be fixed (or excluded) for the build to continue.

https://trello.com/c/aqX2HVlk/338-scan-docker-images

### Changes proposed in this pull request

Additions to the build-and-deploy workflow

### Guidance to review

Check workflow runs as expected

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased master
- [ ] Cleaned commit history
- [ ] Tested by running locally
