### PR TITLE
117 replace master with main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@
 
 - [ ] Make sure all information from the Trello card is in here
 - [ ] Attach to Trello card
-- [ ] Rebased master
+- [ ] Rebased main
 - [ ] Cleaned commit history
 - [ ] Tested by running locally

--- a/.github/actions/deploy/action.yml
+++ b/.github/actions/deploy/action.yml
@@ -84,7 +84,7 @@ runs:
         slack-webhook: ${{ inputs.slack-webhook }}
 
     - name: Alert on Failure
-      if: ${{ failure() && github.ref == 'refs/heads/master' }}
+      if: ${{ failure() && github.ref == 'refs/heads/main' }}
       uses: rtCamp/action-slack-notify@master
       env:
         SLACK_CHANNEL: twd_findpub_tech

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -4,7 +4,7 @@ concurrency: build_and_deploy_${{ github.ref_name }}
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     types: [opened, reopened, synchronize, labeled]
 
@@ -84,7 +84,7 @@ jobs:
         push: true
         target: middleman
         cache-from: |
-          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:main
           type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
         build-args: BUILDKIT_INLINE_CACHE=1
 
@@ -97,9 +97,9 @@ jobs:
         push: false
         load: true
         cache-from: |
-          type=registry,ref=${{ env.DOCKER_IMAGE}}:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}:main
           type=registry,ref=${{ env.DOCKER_IMAGE}}:${{ env.BRANCH_TAG }}
-          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:master
+          type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:main
           type=registry,ref=${{ env.DOCKER_IMAGE}}-middleman:${{ env.BRANCH_TAG }}
         build-args: |
           BUILDKIT_INLINE_CACHE=1
@@ -123,7 +123,7 @@ jobs:
       run: docker image push --all-tags ${{ env.DOCKER_IMAGE }}
 
     - name: Alert Build Failures
-      if: ${{ failure() && github.ref == 'refs/heads/master' }}
+      if: ${{ failure() && github.ref == 'refs/heads/main' }}
       uses: rtCamp/action-slack-notify@master
       env:
         SLACK_CHANNEL: twd_findpub_tech
@@ -171,7 +171,7 @@ jobs:
         IMAGE_TAG: ${{ env.DOCKER_IMAGE_TAG }}
 
     - name: Alert Test Failures
-      if: ${{ failure() && github.ref == 'refs/heads/master' }}
+      if: ${{ failure() && github.ref == 'refs/heads/main' }}
       uses: rtCamp/action-slack-notify@master
       env:
         SLACK_CHANNEL: twd_findpub_tech
@@ -229,7 +229,7 @@ jobs:
     environment:
       name: ${{ matrix.environment }}
       url: ${{ steps.deploy_app.outputs.deploy-url }}
-    if: ${{ success() && github.ref == 'refs/heads/master' }}
+    if: ${{ success() && github.ref == 'refs/heads/main' }}
     needs: [test]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/delete-review-app.yml
+++ b/.github/workflows/delete-review-app.yml
@@ -3,7 +3,7 @@ name: Delete Review App
 on:
   pull_request:
     types: [closed]
-    branches: [master]
+    branches: [main]
 
 permissions:
   deployments: write

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ rollover: ## Set DEPLOY_ENV to rollover
 	$(eval paas_env=rollover)
 
 deploy-init:
-	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=master))
+	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
 	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
 	$(eval export TF_VAR_cf_sso_passcode=$(PASSCODE))
 	$(eval export TF_VAR_paas_docker_image=ghcr.io/dfe-digital/teacher-training-api:$(IMAGE_TAG))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build](https://github.com/DFE-Digital/teacher-training-api/workflows/Build/badge.svg?branch=master&event=push)
+![Build](https://github.com/DFE-Digital/teacher-training-api/workflows/Build/badge.svg)
 [![View performance data on Skylight](https://badges.skylight.io/status/NXAwzyZjkp2m.svg?token=JaYZey50Y8gfC00RvzkcrDz5OP-SwiBSTtbhkMw1KIs)](https://www.skylight.io/app/applications/NXAwzyZjkp2m)
 
 # Teacher Training API
@@ -32,7 +32,7 @@ asdf plugin add yarn
 asdf install
 ```
 
-When the versions are updated in master run `asdf install` again to update your
+When the versions are updated in main run `asdf install` again to update your
 installation.
 
 (We don't mandate asdf, you can use other tools if you prefer.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       context: .
       cache_from:
         - ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
-        - ghcr.io/dfe-digital/teacher-training-api-middleman:master
+        - ghcr.io/dfe-digital/teacher-training-api-middleman:main
     image: ghcr.io/dfe-digital/teacher-training-api:${IMAGE_TAG:-latest}
     command: ash -c "rm -f tmp/pids/server.pid && bundle exec rails server -p 3001 -b '0.0.0.0'"
     ports:

--- a/spec/README.md
+++ b/spec/README.md
@@ -81,8 +81,7 @@ The way we do it:
 4. Provide a way to specify exactly what associated object(s) override.
 5. When creating a memoized object that is included in the creation of another
    object, use `build` to prevent secondary objects from being created.
-6. Factories can be tested too, e.g.
-   <https://github.com/DFE-Digital/teacher-training-api/blob/master/spec/factory_specs/course_spec.rb>
+6. Factories can be tested too.
 7. Don't continue the `count` trait pattern you might find already in the code
    for creating many related objects, that turned out not to be such a great
    idea. Help eliminate them if you can.


### PR DESCRIPTION
### Context

We want to use `main` not `master`, this will bring us in line with the other BAT repos.

### Changes proposed in this pull request


Replace all incidences of `master` in actions and `Makefile` with `main`.

Once this is in, we'll need to tell GitHub `main` is the primary branch: https://github.com/github/renaming

Removing a non existent GitHub link while we are here. 


### Guidance to review

Have I missed anything?