### PR TITLE
120 fix start of rollover failing tests

### DIFF
--- a/spec/controllers/publish/courses_controller_spec.rb
+++ b/spec/controllers/publish/courses_controller_spec.rb
@@ -19,6 +19,7 @@ module Publish
       before do
         allow(controller).to receive(:authenticate).and_return(true)
         controller.instance_variable_set(:@current_user, user)
+        given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       end
 
       it "calls NotificationService::CoursePublished when successful" do

--- a/spec/controllers/publish/courses_controller_spec.rb
+++ b/spec/controllers/publish/courses_controller_spec.rb
@@ -15,11 +15,10 @@ module Publish
       )
     end
 
-    describe "#Publish" do
+    describe "#Publish", { can_edit_current_and_next_cycles: false } do
       before do
         allow(controller).to receive(:authenticate).and_return(true)
         controller.instance_variable_set(:@current_user, user)
-        given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       end
 
       it "calls NotificationService::CoursePublished when successful" do

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -578,6 +578,10 @@ describe CourseDecorator do
     context "when the course has no start date" do
       let(:start_date) { nil }
 
+      before do
+        given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+      end
+
       it "returns the September of the current cycle" do
         expect(decorated_course.return_start_date).to eq("September #{current_recruitment_cycle.year}")
       end

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -575,12 +575,8 @@ describe CourseDecorator do
       end
     end
 
-    context "when the course has no start date" do
+    context "when the course has no start date", { can_edit_current_and_next_cycles: false } do
       let(:start_date) { nil }
-
-      before do
-        given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-      end
 
       it "returns the September of the current cycle" do
         expect(decorated_course.return_start_date).to eq("September #{current_recruitment_cycle.year}")

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Authentication" do
   scenario "Provider user signs in" do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_a_provider_user
     when_i_visit_the_root_path
     then_i_am_expected_to_sign_in

--- a/spec/features/auth/provider_user_signs_in_spec.rb
+++ b/spec/features/auth/provider_user_signs_in_spec.rb
@@ -3,8 +3,7 @@
 require "rails_helper"
 
 feature "Authentication" do
-  scenario "Provider user signs in" do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  scenario "Provider user signs in", { can_edit_current_and_next_cycles: false } do
     given_i_am_a_provider_user
     when_i_visit_the_root_path
     then_i_am_expected_to_sign_in

--- a/spec/features/publish/accepting_terms_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/accepting_terms_without_new_publish_navigation_spec.rb
@@ -4,9 +4,8 @@
 
 require "rails_helper"
 
-feature "Accepting terms" do
+feature "Accepting terms", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_a_user_who_has_not_accepted_the_terms
     when_i_visit_the_publish_service
   end

--- a/spec/features/publish/accepting_terms_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/accepting_terms_without_new_publish_navigation_spec.rb
@@ -6,6 +6,7 @@ require "rails_helper"
 
 feature "Accepting terms" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_a_user_who_has_not_accepted_the_terms
     when_i_visit_the_publish_service
   end

--- a/spec/features/publish/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/publish/allocations/edit_initial_allocation_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
-RSpec.feature "PE allocations" do
+RSpec.feature "PE allocations", { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
     allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     and_there_is_a_previous_recruitment_cycle
   end
 

--- a/spec/features/publish/allocations/edit_initial_allocation_spec.rb
+++ b/spec/features/publish/allocations/edit_initial_allocation_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "PE allocations" do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
     allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     and_there_is_a_previous_recruitment_cycle
   end
 

--- a/spec/features/publish/allocations/initial_allocation_spec.rb
+++ b/spec/features/publish/allocations/initial_allocation_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.feature "PE allocations" do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     and_there_is_a_previous_recruitment_cycle
     and_there_is_a_training_provider
   end

--- a/spec/features/publish/allocations/initial_allocation_spec.rb
+++ b/spec/features/publish/allocations/initial_allocation_spec.rb
@@ -1,9 +1,8 @@
 require "rails_helper"
 
-RSpec.feature "PE allocations" do
+RSpec.feature "PE allocations", { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     and_there_is_a_previous_recruitment_cycle
     and_there_is_a_training_provider
   end

--- a/spec/features/publish/allocations/repeat_allocation_spec.rb
+++ b/spec/features/publish/allocations/repeat_allocation_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "PE allocations" do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
     allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
 
     and_there_is_a_previous_recruitment_cycle
     and_there_is_a_previous_training_provider

--- a/spec/features/publish/allocations/repeat_allocation_spec.rb
+++ b/spec/features/publish/allocations/repeat_allocation_spec.rb
@@ -1,10 +1,9 @@
 require "rails_helper"
 
-RSpec.feature "PE allocations" do
+RSpec.feature "PE allocations", { can_edit_current_and_next_cycles: false } do
   before do
     allow(Settings.features.allocations).to receive(:state).and_return("open")
     allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
 
     and_there_is_a_previous_recruitment_cycle
     and_there_is_a_previous_training_provider

--- a/spec/features/publish/allocations/view_closed_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_closed_state_allocation_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
-RSpec.feature "PE allocations" do
+RSpec.feature "PE allocations", { can_edit_current_and_next_cycles: false } do
   context "allocations state is closed" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("closed")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
     end

--- a/spec/features/publish/allocations/view_closed_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_closed_state_allocation_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "PE allocations" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("closed")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
     end

--- a/spec/features/publish/allocations/view_confirmed_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_confirmed_state_allocation_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "PE allocations" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("confirmed")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
     end

--- a/spec/features/publish/allocations/view_confirmed_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_confirmed_state_allocation_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "PE allocations" do
-  context "allocations state is confirmed" do
+  context "allocations state is confirmed", { can_edit_current_and_next_cycles: false } do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("confirmed")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
     end

--- a/spec/features/publish/allocations/view_open_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_open_state_allocation_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
-RSpec.feature "PE allocations" do
+RSpec.feature "PE allocations", { can_edit_current_and_next_cycles: false } do
   context "allocations state is open" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("open")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
       and_there_is_a_previous_repeat_training_provider

--- a/spec/features/publish/allocations/view_open_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_open_state_allocation_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "PE allocations" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("open")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
-      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
+      given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
       and_there_is_a_previous_repeat_training_provider

--- a/spec/features/publish/allocations/view_open_state_allocation_spec.rb
+++ b/spec/features/publish/allocations/view_open_state_allocation_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "PE allocations" do
     before do
       allow(Settings.features.allocations).to receive(:state).and_return("open")
       allow(Settings).to receive(:allocation_cycle_year).and_return(2022)
+      allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
       given_i_am_authenticated(user: user_with_accredited_bodies)
       and_there_is_a_previous_recruitment_cycle
       and_there_is_a_previous_repeat_training_provider

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "course confirmation" do
+feature "course confirmation", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_confirmation_page
   end

--- a/spec/features/publish/course_confirmation_spec.rb
+++ b/spec/features/publish/course_confirmation_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "course confirmation" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_confirmation_page
   end

--- a/spec/features/publish/courses/copy_from_list_spec.rb
+++ b/spec/features/publish/courses/copy_from_list_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-feature "Copying course information" do
+feature "Copying course information", { can_edit_current_and_next_cycles: false } do
   context "with accredited courses" do
     before do
       given_i_am_authenticated_as_an_accredited_provider_user

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Deleting courses" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/deleting_a_course_spec.rb
+++ b/spec/features/publish/courses/deleting_a_course_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Deleting courses" do
+feature "Deleting courses", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_age_range_spec.rb
+++ b/spec/features/publish/courses/editing_age_range_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting an age range" do
+feature "selecting an age range", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
   end

--- a/spec/features/publish/courses/editing_age_range_spec.rb
+++ b/spec/features/publish/courses/editing_age_range_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting an age range" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
   end

--- a/spec/features/publish/courses/editing_course_information_spec.rb
+++ b/spec/features/publish/courses/editing_course_information_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing course information" do
+feature "Editing course information", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_information_page

--- a/spec/features/publish/courses/editing_course_information_spec.rb
+++ b/spec/features/publish/courses/editing_course_information_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing course information" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_information_page

--- a/spec/features/publish/courses/editing_course_locations_spec.rb
+++ b/spec/features/publish/courses/editing_course_locations_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing course locations" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_locations_page

--- a/spec/features/publish/courses/editing_course_locations_spec.rb
+++ b/spec/features/publish/courses/editing_course_locations_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing course locations" do
+feature "Editing course locations", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_locations_page

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing course outcome" do
+feature "Editing course outcome", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_course_outcome_spec.rb
+++ b/spec/features/publish/courses/editing_course_outcome_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing course outcome" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_course_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing course requirements" do
+feature "Editing course requirements", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_requirements_page

--- a/spec/features/publish/courses/editing_course_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_course_requirements_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing course requirements" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_course_i_want_to_edit
     when_i_visit_the_course_requirements_page

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing course study mode" do
+feature "Editing course study mode", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_course_study_mode_spec.rb
+++ b/spec/features/publish/courses/editing_course_study_mode_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing course study mode" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_degree_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_degree_requirements_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing degree requirements" do
+feature "Editing degree requirements", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_degree_requirements_spec.rb
+++ b/spec/features/publish/courses/editing_degree_requirements_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing degree requirements" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a subject" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_secondary_course_i_want_to_edit
   end

--- a/spec/features/publish/courses/editing_modern_languages_spec.rb
+++ b/spec/features/publish/courses/editing_modern_languages_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a subject" do
+feature "selecting a subject", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_there_is_a_secondary_course_i_want_to_edit
   end

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "updating a subject" do
+feature "updating a subject", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/editing_subject_spec.rb
+++ b/spec/features/publish/courses/editing_subject_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "updating a subject" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
-feature "GCSE equivalency requirements", type: :feature do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "GCSE equivalency requirements", { can_edit_current_and_next_cycles: false } do
   scenario "a provider completes the gcse equivalency requirements section" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_gcse_requirements_page(course: course)

--- a/spec/features/publish/courses/gcse_equivalency_spec.rb
+++ b/spec/features/publish/courses/gcse_equivalency_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 feature "GCSE equivalency requirements", type: :feature do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "a provider completes the gcse equivalency requirements section" do
     given_i_am_authenticated(user: user_with_courses)
     when_i_visit_the_course_gcse_requirements_page(course: course)

--- a/spec/features/publish/courses/new_accredited_body_spec.rb
+++ b/spec/features/publish/courses/new_accredited_body_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selection accredited_bodies" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_accredited_bodies_page
   end

--- a/spec/features/publish/courses/new_accredited_body_spec.rb
+++ b/spec/features/publish/courses/new_accredited_body_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selection accredited_bodies" do
+feature "selection accredited_bodies", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_accredited_bodies_page
   end

--- a/spec/features/publish/courses/new_age_range_spec.rb
+++ b/spec/features/publish/courses/new_age_range_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting an age range" do
+feature "selecting an age range", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/new_age_range_spec.rb
+++ b/spec/features/publish/courses/new_age_range_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting an age range" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/new_applications_open_spec.rb
+++ b/spec/features/publish/courses/new_applications_open_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "choosing an application open from date" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_applications_open_from_page
   end

--- a/spec/features/publish/courses/new_applications_open_spec.rb
+++ b/spec/features/publish/courses/new_applications_open_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "choosing an application open from date" do
+feature "choosing an application open from date", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_applications_open_from_page
   end

--- a/spec/features/publish/courses/new_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/new_apprenticeship_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a teaching apprenticeship" do
+feature "selecting a teaching apprenticeship", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_an_accredited_body_provider_user
     when_i_visit_the_apprenticeship_page
   end

--- a/spec/features/publish/courses/new_apprenticeship_spec.rb
+++ b/spec/features/publish/courses/new_apprenticeship_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a teaching apprenticeship" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_an_accredited_body_provider_user
     when_i_visit_the_apprenticeship_page
   end

--- a/spec/features/publish/courses/new_course_outcome_spec.rb
+++ b/spec/features/publish/courses/new_course_outcome_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a course outcome" do
+feature "selecting a course outcome", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_outcome_page
   end

--- a/spec/features/publish/courses/new_course_outcome_spec.rb
+++ b/spec/features/publish/courses/new_course_outcome_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a course outcome" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_outcome_page
   end

--- a/spec/features/publish/courses/new_fee_or_salary_spec.rb
+++ b/spec/features/publish/courses/new_fee_or_salary_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a fee or salary" do
+feature "selecting a fee or salary", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_fee_or_salary_page
   end

--- a/spec/features/publish/courses/new_fee_or_salary_spec.rb
+++ b/spec/features/publish/courses/new_fee_or_salary_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a fee or salary" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_fee_or_salary_page
   end

--- a/spec/features/publish/courses/new_level_spec.rb
+++ b/spec/features/publish/courses/new_level_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a level" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_i_visit_the_new_course_level_page
   end

--- a/spec/features/publish/courses/new_level_spec.rb
+++ b/spec/features/publish/courses/new_level_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a level" do
+feature "selecting a level", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_i_visit_the_new_course_level_page
   end

--- a/spec/features/publish/courses/new_locations_spec.rb
+++ b/spec/features/publish/courses/new_locations_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selection locations" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_that_sites_exist
     when_i_visit_the_new_locations_page

--- a/spec/features/publish/courses/new_locations_spec.rb
+++ b/spec/features/publish/courses/new_locations_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selection locations" do
+feature "selection locations", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     and_that_sites_exist
     when_i_visit_the_new_locations_page

--- a/spec/features/publish/courses/new_mordern_languages_spec.rb
+++ b/spec/features/publish/courses/new_mordern_languages_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a subject" do
+feature "selecting a subject", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/new_mordern_languages_spec.rb
+++ b/spec/features/publish/courses/new_mordern_languages_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a subject" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "choosing a start date" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_start_date_page
   end

--- a/spec/features/publish/courses/new_start_date_spec.rb
+++ b/spec/features/publish/courses/new_start_date_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "choosing a start date" do
+feature "choosing a start date", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_start_date_page
   end

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting full time or part time or full or part time" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_study_mode_page
   end

--- a/spec/features/publish/courses/new_study_mode_spec.rb
+++ b/spec/features/publish/courses/new_study_mode_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting full time or part time or full or part time" do
+feature "selecting full time or part time or full or part time", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_new_study_mode_page
   end

--- a/spec/features/publish/courses/new_subject_spec.rb
+++ b/spec/features/publish/courses/new_subject_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
-feature "selecting a subject" do
+feature "selecting a subject", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/new_subject_spec.rb
+++ b/spec/features/publish/courses/new_subject_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 feature "selecting a subject" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Publishing courses" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/publishing_a_course_spec.rb
+++ b/spec/features/publish/courses/publishing_a_course_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Publishing courses" do
+feature "Publishing courses", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/withdrawing_a_course_spec.rb
+++ b/spec/features/publish/courses/withdrawing_a_course_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Withdrawing courses" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/courses/withdrawing_a_course_spec.rb
+++ b/spec/features/publish/courses/withdrawing_a_course_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Withdrawing courses" do
+feature "Withdrawing courses", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
-feature "new course" do
+feature "new course", { can_edit_current_and_next_cycles: false } do
   scenario "creates the correct course" do
     # This is intended to be a test which will go through the entire flow
     # and ensure that the correct page gets displayed at the end
     # with the correct course being created
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_courses_page
     and_i_click_on_add_course

--- a/spec/features/publish/e2e/new_course_spec.rb
+++ b/spec/features/publish/e2e/new_course_spec.rb
@@ -5,6 +5,7 @@ feature "new course" do
     # This is intended to be a test which will go through the entire flow
     # and ensure that the correct page gets displayed at the end
     # with the correct course being created
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_courses_page
     and_i_click_on_add_course

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "About Your Organisation section" do
   scenario "Provider user edits provider details" do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_a_provider_user
     and_my_provider_has_accrediting_providers
     when_i_visit_the_details_page

--- a/spec/features/publish/edit_provider_details_spec.rb
+++ b/spec/features/publish/edit_provider_details_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "About Your Organisation section" do
+feature "About Your Organisation section", { can_edit_current_and_next_cycles: false } do
   scenario "Provider user edits provider details" do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_a_provider_user
     and_my_provider_has_accrediting_providers
     when_i_visit_the_details_page

--- a/spec/features/publish/editing_contact_details_spec.rb
+++ b/spec/features/publish/editing_contact_details_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing contact details" do
+feature "Editing contact details", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_contact_details_page
   end

--- a/spec/features/publish/editing_contact_details_spec.rb
+++ b/spec/features/publish/editing_contact_details_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing contact details" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_contact_details_page
   end

--- a/spec/features/publish/editing_vacancies_spec.rb
+++ b/spec/features/publish/editing_vacancies_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing vacancies" do
+feature "Editing vacancies", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/editing_vacancies_spec.rb
+++ b/spec/features/publish/editing_vacancies_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing vacancies" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
   end
 

--- a/spec/features/publish/editing_visa_sponsorships_spec.rb
+++ b/spec/features/publish/editing_visa_sponsorships_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Editing visa sponsorships" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_visa_sponsorships_page
   end

--- a/spec/features/publish/editing_visa_sponsorships_spec.rb
+++ b/spec/features/publish/editing_visa_sponsorships_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Editing visa sponsorships" do
+feature "Editing visa sponsorships", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_visa_sponsorships_page
   end

--- a/spec/features/publish/managing_locations_spec.rb
+++ b/spec/features/publish/managing_locations_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Managing a provider's locations" do
+feature "Managing a provider's locations", { can_edit_current_and_next_cycles: false } do
   scenario "i can view and update a provider's locations" do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_locations_page
     then_i_should_see_a_list_of_locations

--- a/spec/features/publish/managing_locations_spec.rb
+++ b/spec/features/publish/managing_locations_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Managing a provider's locations" do
   scenario "i can view and update a provider's locations" do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_locations_page
     then_i_should_see_a_list_of_locations

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 feature "Providers index" do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "view page as Mary - multi provider user" do
     given_the_new_publish_flow_feature_flag_is_enabled
     and_i_am_authenticated_as_a_multi_provider_user

--- a/spec/features/publish/providers_index_spec.rb
+++ b/spec/features/publish/providers_index_spec.rb
@@ -1,10 +1,6 @@
 require "rails_helper"
 
-feature "Providers index" do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "Providers index", { can_edit_current_and_next_cycles: false } do
   scenario "view page as Mary - multi provider user" do
     given_the_new_publish_flow_feature_flag_is_enabled
     and_i_am_authenticated_as_a_multi_provider_user

--- a/spec/features/publish/providers_index_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/providers_index_without_new_publish_navigation_spec.rb
@@ -1,11 +1,7 @@
 # These tests can be deleted when the `publish_new_navigation` feature flag is removed. All these tests are covered in `provider_index_spec.rb`
 require "rails_helper"
 
-feature "Providers index" do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "Providers index", { can_edit_current_and_next_cycles: false } do
   scenario "view page as Mary - multi provider user" do
     given_i_am_authenticated_as_a_multi_provider_user
     when_i_visit_the_publish_providers_index_page

--- a/spec/features/publish/providers_index_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/providers_index_without_new_publish_navigation_spec.rb
@@ -2,6 +2,10 @@
 require "rails_helper"
 
 feature "Providers index" do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "view page as Mary - multi provider user" do
     given_i_am_authenticated_as_a_multi_provider_user
     when_i_visit_the_publish_providers_index_page

--- a/spec/features/publish/providers_show_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/providers_show_without_new_publish_navigation_spec.rb
@@ -4,11 +4,7 @@
 
 require "rails_helper"
 
-feature "Providers show" do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "Providers show", { can_edit_current_and_next_cycles: false } do
   scenario "view page as Anne - user with single provider" do
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_publish_providers_show_page

--- a/spec/features/publish/providers_show_without_new_publish_navigation_spec.rb
+++ b/spec/features/publish/providers_show_without_new_publish_navigation_spec.rb
@@ -5,6 +5,10 @@
 require "rails_helper"
 
 feature "Providers show" do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "view page as Anne - user with single provider" do
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_publish_providers_show_page

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Course show" do
+feature "Course show", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_course_details_page
   end

--- a/spec/features/publish/viewing_a_course_details_spec.rb
+++ b/spec/features/publish/viewing_a_course_details_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Course show" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_course_details_page
   end

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 feature "Course show" do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "i can view the course basic details" do
     given_i_am_authenticated(user: user_with_fee_based_course)
     when_i_visit_the_course_preview_page

--- a/spec/features/publish/viewing_a_course_preview_spec.rb
+++ b/spec/features/publish/viewing_a_course_preview_spec.rb
@@ -2,11 +2,7 @@
 
 require "rails_helper"
 
-feature "Course show" do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "Course show", { can_edit_current_and_next_cycles: false } do
   scenario "i can view the course basic details" do
     given_i_am_authenticated(user: user_with_fee_based_course)
     when_i_visit_the_course_preview_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 feature "Course show" do
+  before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  end
+
   scenario "i can view the course basic details" do
     given_i_am_authenticated_as_a_provider_user(course: build(:course))
     when_i_visit_the_course_page

--- a/spec/features/publish/viewing_a_course_spec.rb
+++ b/spec/features/publish/viewing_a_course_spec.rb
@@ -2,11 +2,7 @@
 
 require "rails_helper"
 
-feature "Course show" do
-  before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  end
-
+feature "Course show", { can_edit_current_and_next_cycles: false } do
   scenario "i can view the course basic details" do
     given_i_am_authenticated_as_a_provider_user(course: build(:course))
     when_i_visit_the_course_page

--- a/spec/features/publish/viewing_courses_spec.rb
+++ b/spec/features/publish/viewing_courses_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Managing a provider's courses" do
+feature "Managing a provider's courses", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_courses_page
   end

--- a/spec/features/publish/viewing_courses_spec.rb
+++ b/spec/features/publish/viewing_courses_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Managing a provider's courses" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_a_provider_user
     when_i_visit_the_courses_page
   end

--- a/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
+++ b/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Viewing courses as an accredited body" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_an_accredited_body_user
     and_some_courses_exist_with_one_i_accredit
     when_i_visit_the_training_providers_page

--- a/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
+++ b/spec/features/publish/viewing_training_providers_and_their_courses_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Viewing courses as an accredited body" do
+feature "Viewing courses as an accredited body", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated_as_an_accredited_body_user
     and_some_courses_exist_with_one_i_accredit
     when_i_visit_the_training_providers_page

--- a/spec/features/support/access_requests/managing_requests_spec.rb
+++ b/spec/features/support/access_requests/managing_requests_spec.rb
@@ -4,6 +4,7 @@ require "rails_helper"
 
 feature "Viewing and approving requests" do
   before do
+    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated(user: admin)
     and_there_are_access_requests
   end

--- a/spec/features/support/access_requests/managing_requests_spec.rb
+++ b/spec/features/support/access_requests/managing_requests_spec.rb
@@ -2,9 +2,8 @@
 
 require "rails_helper"
 
-feature "Viewing and approving requests" do
+feature "Viewing and approving requests", { can_edit_current_and_next_cycles: false } do
   before do
-    given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
     given_i_am_authenticated(user: admin)
     and_there_are_access_requests
   end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -12,7 +12,3 @@ def disable_features(*feature_keys)
     allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(false)
   end
 end
-
-def given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
-  allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
-end

--- a/spec/support/feature_flags.rb
+++ b/spec/support/feature_flags.rb
@@ -12,3 +12,7 @@ def disable_features(*feature_keys)
     allow(FeatureService).to receive(:enabled?).with(feature_key).and_return(false)
   end
 end
+
+def given_the_can_edit_current_and_next_cycles_feature_flag_is_disabled
+  allow(Settings.features.rollover).to receive(:can_edit_current_and_next_cycles).and_return(false)
+end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -14,4 +14,22 @@ RSpec.configure do |config|
   config.include FeatureHelpers::PublishPages, type: :feature
   config.include FeatureHelpers::CourseSteps, type: :feature
   config.include DfESignInUserHelper, type: :feature
+
+  # This is required as a workaround for failing tests when the `can_edit_current_and_next_cycles` feature flag is active
+  config.around do |example|
+    can_edit_current_and_next_cycles = example.metadata[:can_edit_current_and_next_cycles]
+
+    if can_edit_current_and_next_cycles == false
+      old_value = Settings.features.rollover.can_edit_current_and_next_cycles
+      Settings.features.rollover.can_edit_current_and_next_cycles = false
+      Rails.application.reload_routes!
+
+      example.run
+
+      Settings.features.rollover.can_edit_current_and_next_cycles = old_value
+      Rails.application.reload_routes!
+    else
+      example.run
+    end
+  end
 end

--- a/spec/support/features.rb
+++ b/spec/support/features.rb
@@ -14,22 +14,4 @@ RSpec.configure do |config|
   config.include FeatureHelpers::PublishPages, type: :feature
   config.include FeatureHelpers::CourseSteps, type: :feature
   config.include DfESignInUserHelper, type: :feature
-
-  # This is required as a workaround for failing tests when the `can_edit_current_and_next_cycles` feature flag is active
-  config.around do |example|
-    can_edit_current_and_next_cycles = example.metadata[:can_edit_current_and_next_cycles]
-
-    if can_edit_current_and_next_cycles == false
-      old_value = Settings.features.rollover.can_edit_current_and_next_cycles
-      Settings.features.rollover.can_edit_current_and_next_cycles = false
-      Rails.application.reload_routes!
-
-      example.run
-
-      Settings.features.rollover.can_edit_current_and_next_cycles = old_value
-      Rails.application.reload_routes!
-    else
-      example.run
-    end
-  end
 end

--- a/spec/support/features/rollover/can_edit_current_and_next_cycle.rb
+++ b/spec/support/features/rollover/can_edit_current_and_next_cycle.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+# This is required as a workaround for failing tests when the `can_edit_current_and_next_cycles` feature flag is active
+
+RSpec.configure do |config|
+  config.around do |example|
+    can_edit_current_and_next_cycles = example.metadata[:can_edit_current_and_next_cycles]
+
+    if can_edit_current_and_next_cycles == false
+      old_value = Settings.features.rollover.can_edit_current_and_next_cycles
+      Settings.features.rollover.can_edit_current_and_next_cycles = false
+      Rails.application.reload_routes!
+
+      example.run
+
+      Settings.features.rollover.can_edit_current_and_next_cycles = old_value
+      Rails.application.reload_routes!
+    else
+      example.run
+    end
+  end
+end


### PR DESCRIPTION
### Context

We have 171 failing tests when `can_edit_current_and_next_cycles` is set to true in `Settings.yml`. 

### Changes proposed in this pull request

- Deactivate the `can_edit_current_and_next_cycles` feature flag in these tests.
- Add a helper method to `features.rb` encompassing this 

### Guidance to review

- Activate `can_edit_current_and_next_cycles` in `Settings.yml`
- Run the tests and ensure they all pass