### PR TITLE
99 pe courses for next cycle

### DIFF
--- a/app/helpers/provider_helper.rb
+++ b/app/helpers/provider_helper.rb
@@ -1,14 +1,4 @@
 module ProviderHelper
-  def add_course_url(email, provider)
-    cycle_key = is_current_cycle(provider.recruitment_cycle_year) ? "current_cycle" : "next_cycle"
-
-    if provider.accredited_body?
-      google_form_url_for(Settings.google_forms[cycle_key].new_pe_course_for_accredited_bodies, email, provider)
-    else
-      google_form_url_for(Settings.google_forms[cycle_key].new_pe_course_for_unaccredited_bodies, email, provider)
-    end
-  end
-
   def visa_sponsorship_status(provider)
     if !provider.declared_visa_sponsorship?
       visa_sponsorship_call_to_action(provider)

--- a/app/views/publish/courses/subjects/new.html.erb
+++ b/app/views/publish/courses/subjects/new.html.erb
@@ -15,15 +15,6 @@
                   method: :get do |form| %>
       <%= render "publish/courses/new_fields_holder", form: form, except_keys: [] do |fields| %>
         <%= render 'form_fields', form: fields %>
-
-        <div data-qa="course__google_form_link" >
-          <% if !current_user["admin"] && @course.level == "secondary" %>
-            <h2 class="govuk-heading-m"> Adding a Physical education course?</h2>
-            <p class="govuk-body">You’ll need to fill in a
-              <%= govuk_link_to "separate Google Form", add_course_url(current_user.email, @provider), rel: "noopener noreferrer", target: "_blank" %>,
-            as PE places are limited.</p>
-          <% end %>
-        </div>
       <% end %>
     <% end %>
   </div>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -82,27 +82,6 @@ google:
     api_json_key: ""
     table_name: events
 
-google_forms:
-  current_cycle:
-    new_pe_course_for_accredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSerPrTvuQNNkpMH_yfgJ8_o5ajthtq5XhOP9x-zG8JL4o5n-Q/viewform?usp=pp_url
-      email_entry: entry.957076544
-      provider_code_entry: entry.1735563938
-    new_pe_course_for_unaccredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSeZK6wGdvDy40QFiFcI8_JRgG-kPWUPBjLfY_EffebCkL0goQ/viewform?usp=pp_url
-      email_entry: entry.1033530353
-      provider_code_entry: entry.158771972
-  # NOTE: these forms are only in use / visible during Rollover i.e. when both cycles are visible.
-  next_cycle:
-    new_pe_course_for_accredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSerPrTvuQNNkpMH_yfgJ8_o5ajthtq5XhOP9x-zG8JL4o5n-Q/viewform?usp=pp_url
-      email_entry: entry.957076544
-      provider_code_entry: entry.1735563938
-    new_pe_course_for_unaccredited_bodies:
-      url: https://docs.google.com/forms/d/e/1FAIpQLSeZK6wGdvDy40QFiFcI8_JRgG-kPWUPBjLfY_EffebCkL0goQ/viewform?usp=pp_url
-      email_entry: entry.1033530353
-      provider_code_entry: entry.158771972
-
 feedback:
   link: https://docs.google.com/forms/d/e/1FAIpQLSfZNWa6zx30SkF_1EAwqNPZHOgK8qYcVQ7uDyhi0P6oPm71zg/viewform
 


### PR DESCRIPTION
### Context

We no longer require the google forms for PE as recruitment is now uncapped.

### Changes proposed in this pull request

- Remove PE google form links from yml
- Remove PE google form links from create course flow
- Remove PE course google form url helper method

### Guidance to review

- Create a PE course and ensure there is no sign of the google forms. 
- Have I missed anything?
