### PR TITLE
[0028] Api docs `text` is wrong

### DIFF
--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -128,7 +128,6 @@ module GovukTechDocs
         operations = get_operations(path)
         operations.compact.each do |key, operation|
           id = "#{path_id}-#{key.parameterize}"
-          text = :text
           parameters = parameters(operation, id)
           responses = responses(operation, id)
           curl_examples = curl_examples(operation, id)


### PR DESCRIPTION
### Context
Api docs `text` is wrong

### Changes proposed in this pull request
Removed unneeded assignment

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
