### PR TITLE
Add prune-repeated-subdependencies to SNYK scan

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -116,7 +116,7 @@ jobs:
         SNYK_TOKEN: ${{ steps.get-secret.outputs.snyk_token }}
       with:
         image: ${{ env.DOCKER_IMAGE }}:${{ env.DOCKER_IMAGE_TAG }}
-        args: --file=Dockerfile --severity-threshold=high
+        args: --file=Dockerfile --severity-threshold=high --prune-repeated-subdependencies
 
     - name: Push ${{ env.DOCKER_IMAGE }} images
       if: ${{ success() && !contains(github.event.pull_request.labels.*.name, 'deploy') }}


### PR DESCRIPTION
### Context

Improve SNYK performance for larger projects
and possibly stop 'Failed to get Vulns' errors
https://support.snyk.io/hc/en-us/articles/360002061438-CLI-returns-the-error-Failed-to-get-Vulns-

### Changes proposed in this pull request

Add --prune-repeated-subdependencies

### Guidance to review

Check scan runs ok in build step

### Checklist

- [ ] Make sure all information from the Trello card is in here
- [ ] Attach to Trello card
- [ ] Rebased main
- [ ] Cleaned commit history
- [ ] Tested by running locally
