### PR TITLE
Remove pointless return nils

### DIFF
--- a/app/forms/publish/notification_form.rb
+++ b/app/forms/publish/notification_form.rb
@@ -29,7 +29,7 @@ module Publish
     end
 
     def preference_selected?
-      return nil if user_notification_preferences.updated_at.blank?
+      return if user_notification_preferences.updated_at.blank?
 
       user_notification_preferences.enabled?
     end

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -339,8 +339,8 @@ class Course < ApplicationRecord
   end
 
   def accrediting_provider_description
-    return nil if accrediting_provider.blank?
-    return nil if provider.accrediting_provider_enrichments.blank?
+    return if accrediting_provider.blank?
+    return if provider.accrediting_provider_enrichments.blank?
 
     accrediting_provider_enrichment = provider.accrediting_provider_enrichments
       .find do |provider|
@@ -440,7 +440,7 @@ class Course < ApplicationRecord
   end
 
   def funding_type
-    return nil if program_type.nil?
+    return if program_type.nil?
 
     if school_direct_salaried_training_programme?
       "salary"

--- a/app/models/user_notification_preferences.rb
+++ b/app/models/user_notification_preferences.rb
@@ -13,7 +13,7 @@ class UserNotificationPreferences
   end
 
   def updated_at
-    return nil if user_notifications.empty?
+    return if user_notifications.empty?
 
     user_notifications.maximum(:updated_at).iso8601
   end

--- a/app/services/courses/copy_to_provider_service.rb
+++ b/app/services/courses/copy_to_provider_service.rb
@@ -6,8 +6,8 @@ module Courses
     end
 
     def execute(course:, new_provider:, force: false)
-      return nil unless course.rollable? || force
-      return nil if course_code_already_exists_on_provider?(course: course, new_provider: new_provider)
+      return unless course.rollable? || force
+      return if course_code_already_exists_on_provider?(course: course, new_provider: new_provider)
 
       new_course = nil
 

--- a/app/services/sites/copy_to_provider_service.rb
+++ b/app/services/sites/copy_to_provider_service.rb
@@ -3,7 +3,7 @@ module Sites
     def execute(site:, new_provider:)
       new_site = new_provider.sites.find_by(code: site.code)
 
-      return nil if new_site.present?
+      return if new_site.present?
 
       new_site = site.dup
       new_site.provider_id = new_provider.id

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -286,7 +286,6 @@ module GovukTechDocs
 
       def get_schema_name(text)
         unless text.is_a?(String)
-          return nil
         end
 
         # Schema dictates that it's always components['schemas']

--- a/docs/lib/govuk_tech_docs/open_api/renderer.rb
+++ b/docs/lib/govuk_tech_docs/open_api/renderer.rb
@@ -285,8 +285,7 @@ module GovukTechDocs
       end
 
       def get_schema_name(text)
-        unless text.is_a?(String)
-        end
+        return unless text.is_a?(String)
 
         # Schema dictates that it's always components['schemas']
         text.gsub(/#\/components\/schemas\//, "")


### PR DESCRIPTION
### Context

We don't need to `return nil`, `return` implicitly returns nil.

### Changes proposed in this pull request

- Remove all instances of `return nil` in the codebase and replace with just `return`