### PR TITLE
Remove duplicate add course button

### DIFF
--- a/app/views/publish/courses/index.html.erb
+++ b/app/views/publish/courses/index.html.erb
@@ -9,16 +9,14 @@
 </h1>
 
 
-<% if @provider.courses.count > 10 %>
   <%= govuk_button_link_to(
-    "Add a new course",
+    "Add course",
     new_publish_provider_recruitment_cycle_course_path(
       provider_code: @provider.provider_code,
       recruitment_cycle_year: @provider.recruitment_cycle_year,
     ),
     class: "govuk-!-margin-bottom-6",
   ) %>
-<% end %>
 
 <% if @self_accredited_courses %>
   <section data-qa="courses__table-section">
@@ -36,12 +34,3 @@
     <%= render partial: "course_table", locals: { courses: courses } %>
   </section>
 <% end %>
-
-<%= govuk_button_link_to(
-  "Add a new course",
-  new_publish_provider_recruitment_cycle_course_path(
-    provider_code: @provider.provider_code,
-    recruitment_cycle_year: @provider.recruitment_cycle_year,
-  ),
-  class: "govuk-!-margin-bottom-2",
-) %>

--- a/spec/support/page_objects/publish/provider_courses_index.rb
+++ b/spec/support/page_objects/publish/provider_courses_index.rb
@@ -20,7 +20,7 @@ module PageObjects
 
       element :success_summary, ".govuk-notification-banner--success"
 
-      element :add_course, ".govuk-button", text: "Add a new course"
+      element :add_course, ".govuk-button", text: "Add course"
     end
   end
 end


### PR DESCRIPTION
### Context

We have two `Add a new course` buttons by design if there are more than 10 courses, one at the top and one at the bottom. 

### Changes proposed in this pull request

- Remove the one at the bottom 
- Rename the one at the top to: `Add course` 
