### PR TITLE
Change vacancy link text

### DIFF
--- a/app/decorators/course_decorator.rb
+++ b/app/decorators/course_decorator.rb
@@ -360,7 +360,7 @@ private
 
   def edit_vacancy_link
     h.govuk_link_to(h.vacancies_publish_provider_recruitment_cycle_course_path(object.provider_code, object.recruitment_cycle.year, object.course_code)) do
-      h.raw("Edit<span class=\"govuk-visually-hidden\"> vacancies for #{name_and_code}</span>")
+      h.raw("Change<span class=\"govuk-visually-hidden\"> vacancies for #{name_and_code}</span>")
     end
   end
 

--- a/spec/decorators/course_decorator_spec.rb
+++ b/spec/decorators/course_decorator_spec.rb
@@ -780,7 +780,7 @@ describe CourseDecorator do
 
     context "has no vacancies" do
       it "has link" do
-        expect(subject).to eq "No (<a class=\"govuk-link\" href=\"#{link}\">Edit<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
+        expect(subject).to eq "No (<a class=\"govuk-link\" href=\"#{link}\">Change<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
       end
 
       context "has been withdrawn" do
@@ -796,7 +796,7 @@ describe CourseDecorator do
       let(:has_vacancies) { true }
 
       it "has link" do
-        expect(subject).to eq "Yes (<a class=\"govuk-link\" href=\"#{link}\">Edit<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
+        expect(subject).to eq "Yes (<a class=\"govuk-link\" href=\"#{link}\">Change<span class=\"govuk-visually-hidden\"> vacancies for Mathematics (A1)</span></a>)"
       end
 
       context "has been withdrawn" do


### PR DESCRIPTION
### Context

The vacancies ‘Edit’ link should be called ‘Change’

### Changes proposed in this pull request

- Change link text from `Edit` to `Change`
- Fix tests

### Guidance to review

- Inspect the change links on the courses page. Ensure it still has the visually hidden text (course name and course code)
- 🚢 
