### PR TITLE
Revert "Bump sidekiq-cron from 1.4.0 to 1.5.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,7 +548,7 @@ GEM
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
       redis (>= 4.2.0)
-    sidekiq-cron (1.5.0)
+    sidekiq-cron (1.4.0)
       fugit (~> 1)
       sidekiq (>= 4.2.1)
     signet (0.16.1)


### PR DESCRIPTION
Reverts DFE-Digital/teacher-training-api#2738