### PR TITLE
Add review database backup content

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,12 @@ restore-data-from-nightly-backup: read-deployment-config read-keyvault-config # 
 	$(if $(CONFIRM_RESTORE), , $(error Restore can only run with CONFIRM_RESTORE))
 	bin/restore-nightly-backup ${space} ${postgres_database_name} ${paas_env}_backup- ${BACKUP_DATE}
 
+upload-review-backup: read-deployment-config read-keyvault-config # make review upload-review-backup BACKUP_DATE=2022-06-10 APP_NAME=1234
+	bin/upload-review-backup ${backup_storage_secret_name} ${key_vault_name} ${paas_env}-db-backup ${paas_env}_backup-${BACKUP_DATE}.sql.tar.gz
+
+backup-review-database: read-deployment-config # make review backup-review-database APP_NAME=1234
+	bin/backup-review-database ${postgres_database_name} ${paas_env}
+
 get-image-tag:
 	$(eval export TAG=$(shell cf target -s ${space} 1> /dev/null && cf app teacher-training-api-${paas_env} | grep -Po "docker image:\s+\S+:\K\w+"))
 	@echo ${TAG}

--- a/bin/backup-review-database
+++ b/bin/backup-review-database
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+DATABASE_TO_BACKUP=${1:-}
+REVIEW_ENV=${2:-}
+
+if [[ -z "${DATABASE_TO_BACKUP}" ]]; then
+  echo "DATABASE_TO_BACKUP environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${REVIEW_ENV}" ]]; then
+  echo "REVIEW_ENV environment variable not set"
+  exit 1
+fi
+
+echo "DATABASE_TO_BACKUP: ${DATABASE_TO_BACKUP}"
+echo "REVIEW_ENV: ${REVIEW_ENV}"
+
+now=$(date +"%F")
+REVIEW_BACKUP=${REVIEW_ENV}_backup-${now}.sql
+
+if [[ -e ${REVIEW_BACKUP} ]]; then
+  echo "File ${REVIEW_BACKUP} already exists"
+else
+  cf conduit ${DATABASE_TO_BACKUP} -- pg_dump --encoding utf8 --clean --no-owner --if-exists -f $REVIEW_BACKUP
+  tar -cvzf ${REVIEW_BACKUP}.tar.gz ${REVIEW_BACKUP}
+fi

--- a/bin/upload-review-backup
+++ b/bin/upload-review-backup
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -eu
+
+BACKUP_STORAGE_SECRET_NAME=${1:-}
+KEY_VAULT_NAME=${2:-}
+AZURE_BACKUP_STORAGE_CONTAINER_NAME=${3:-}
+BACKUP_ARCHIVE_FILENAME=${4:-}
+
+if [[ -z "${BACKUP_STORAGE_SECRET_NAME}" ]]; then
+  echo "BACKUP_STORAGE_SECRET_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${KEY_VAULT_NAME}" ]]; then
+  echo "KEY_VAULT_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${AZURE_BACKUP_STORAGE_CONTAINER_NAME}" ]]; then
+  echo "AZURE_BACKUP_STORAGE_CONTAINER_NAME environment variable not set"
+  exit 1
+fi
+
+if [[ -z "${BACKUP_ARCHIVE_FILENAME}" ]]; then
+  echo "BACKUP_ARCHIVE_FILENAME variable not set"
+  exit 1
+fi
+
+STORAGE_CONN_STR="$(az keyvault secret show --name ${BACKUP_STORAGE_SECRET_NAME} --vault-name ${KEY_VAULT_NAME} | jq -r .value)"
+
+if [[ ! -e ${BACKUP_ARCHIVE_FILENAME} ]]; then
+  echo "There are no files found matching ${BACKUP_ARCHIVE_FILENAME}"
+  exit 1
+else
+  echo "Checking if storage container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} exists"
+  STORAGE_CONTAINER_EXISTS=$(az storage container exists --connection-string ${STORAGE_CONN_STR} -n ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} | jq -r .exists)
+
+  if [[ ${STORAGE_CONTAINER_EXISTS} = "false" ]]; then
+    echo "Creating storage container ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} ..."
+    az storage container create --connection-string ${STORAGE_CONN_STR} -n ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} --output none
+  fi
+
+  echo "Storage container created. Uploading ${BACKUP_ARCHIVE_FILENAME} ..."
+  az storage blob upload --connection-string ${STORAGE_CONN_STR} -c ${AZURE_BACKUP_STORAGE_CONTAINER_NAME} -n ${BACKUP_ARCHIVE_FILENAME} -f ${BACKUP_ARCHIVE_FILENAME} --overwrite --output none
+fi

--- a/docs/disaster-recovery.md
+++ b/docs/disaster-recovery.md
@@ -86,6 +86,8 @@ Once the lost database instance has been recreated, the last nightly backup will
 
 The make recipe `restore-data-from-nightly-backup` executes 2 scripts, these should be committed with the execute permission (755) set but these may have been inadvertently altered.  If you get a permissions error executing them run `chmod +x <path/to/script>`.
 
+When testing this step against a review environment a manual backup will need to be created from the review postgres instance. Use the make receipe `backup-review-database` by executing `make review backup-review-database APP_NAME=1234`. This can then be uploaded to the backup Azure storage container by executing `make review upload-review-backup BACKUP_DATE="yyyy-mm-dd" APP_NAME=1234`.
+
 ```
 # space is the name of the environment in GOV.UK PaaS, eg 'bat-prod'
 # env is the target environment in the make file e.g. 'production'


### PR DESCRIPTION
Add content to document backup of review database when testing against a review environment.

### Context
Improve the testing process for a review environment by aligning it more closely with non-review environments. This includes creating a database backup and uploading it to a storage account so the same scripts can be used for review as with non-review environments.

### Changes proposed in this pull request

### Guidance to review

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
