### PR TITLE
[xxx] Fix zeitwerk error

### DIFF
--- a/app/controllers/personas_controller.rb
+++ b/app/controllers/personas_controller.rb
@@ -1,9 +1,7 @@
-if AuthenticationService.persona?
-  class PersonasController < ApplicationController
-    layout "application"
+class PersonasController < ApplicationController
+  layout "application"
 
-    skip_before_action :authenticate
+  skip_before_action :authenticate
 
-    def index; end
-  end
+  def index; end
 end


### PR DESCRIPTION
### Context

These are already conditionally handled in the routes, i don't think we should be wrapping the controller behind similar logic as it causes an issue with Zeitwerk

```
/usr/local/bundle/gems/zeitwerk-2.5.4/lib/zeitwerk/loader/callbacks.rb:25:in `on_file_autoloaded': expected file /app/app/controllers/personas_controller.rb to define constant PersonasController, but didn't (Zeitwerk::NameError)
```