### PR TITLE
Remove provider personas when going to support

### DIFF
--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -14,7 +14,7 @@ module Authentication
   def authenticate
     if !authenticated?
       session["post_dfe_sign_in_path"] = request.fullpath
-      redirect_to sign_in_path
+      redirect_to sign_in_path({ support: params[:controller].start_with?("support") })
     end
   end
 end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -12,9 +12,13 @@ module Authentication
   end
 
   def authenticate
-    if !authenticated?
+    unless authenticated?
       session["post_dfe_sign_in_path"] = request.fullpath
-      redirect_to sign_in_path({ support: params[:controller].start_with?("support") })
+      if AuthenticationService.mode == :persona
+        redirect_to sign_in_path({ support: params[:controller].start_with?("support") })
+      else
+        redirect_to sign_in_path
+      end
     end
   end
 end

--- a/app/views/sign_in/_default_signin_content.html.erb
+++ b/app/views/sign_in/_default_signin_content.html.erb
@@ -7,8 +7,13 @@
   <%= govuk_button_to("Sign in using DfE Sign-in", "/auth/dfe", class: "qa-sign_in_button") %>
 
   <p class="govuk-body-m">If you do not have a DfE Sign-in account but need access to <%= I18n.t("service_name") %>, email <%= support_email %>.</p>
-<% else %>
-  <p class="govuk-body-m">Use Personas to access an account.</p>
-
-  <%= govuk_link_to "Sign in using a Persona", "/personas", class: "govuk-button", data: { qa: "sign-in-using-a-persona" } %>
+  <% elsif params[:support] == "true" %>
+    <%= render Persona::View.new(
+      email_address: "becomingateacher+admin-integration-tests@digital.education.gov.uk",
+      first_name: "Support agent",
+      last_name: "an Admin"
+    ) %>
+  <% else %>
+    <p class="govuk-body-m">Use Personas to access an account.</p>
+    <%= govuk_link_to "Sign in using a Persona", "/personas", class: "govuk-button", data: { qa: "sign-in-using-a-persona" } %>
 <% end %>

--- a/spec/features/auth/persona_spec.rb
+++ b/spec/features/auth/persona_spec.rb
@@ -3,22 +3,44 @@
 require "rails_helper"
 
 feature "Authentication with Personas" do
-  scenario "Sign in with a persona" do
+  before do
     given_persona_based_authentication_is_active
+  end
+
+  scenario "Sign in with a persona" do
     when_i_go_to_sign_in
     then_i_am_given_the_option_to_sign_in_with_a_persona
   end
 
+  scenario "Sign in to support" do
+    when_i_go_to_support
+    i_am_given_the_option_to_login_as_an_admin
+    and_i_do_not_see_persona_related_text
+  end
+
   def given_persona_based_authentication_is_active
-    allow(AuthenticationService).to receive(:mode).and_return("persona")
+    allow(AuthenticationService).to receive(:mode).and_return(:persona)
   end
 
   def when_i_go_to_sign_in
     sign_in_page.load
   end
 
+  def when_i_go_to_support
+    support_provider_index_page.load
+  end
+
   def then_i_am_given_the_option_to_sign_in_with_a_persona
     expect(sign_in_page).to have_text("Use Personas to access an account.")
     expect(sign_in_page).to have_link("Sign in using a Persona")
+  end
+
+  def i_am_given_the_option_to_login_as_an_admin
+    expect(sign_in_page).to have_button("Login as an Admin")
+  end
+
+  def and_i_do_not_see_persona_related_text
+    expect(sign_in_page).not_to have_text("Use Personas to access an account.")
+    expect(sign_in_page).not_to have_link("Sign in using a Persona")
   end
 end


### PR DESCRIPTION
### Context

`/support` leads us to support login. For personas (on qa and dev environments) we have 3 personas that are not eligible to login. These personas are for publish, not support. 

### Changes proposed in this pull request

- Render the button to Login as an Admin (Colin) if the user is going to `/support`
- Add support to params and dynamically render true or false, based on the path and use this as the check for which button to render.
- Keep the previous journey if the user is going to Publish
- This change will only be applied to persona login

### Guidance to review

- Login to support, and ensure that you don't see any non eligible personas to login with.
- Login to Publish and ensure that the original persona login journey remains the same.

### Checklist

- [x] Make sure all information from the Trello card is in here
- [x] Attach to Trello card
- [x] Rebased main
- [x] Cleaned commit history
- [x] Tested by running locally
